### PR TITLE
[BugFix] Modified base64 option(decode data)

### DIFF
--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -37,8 +37,8 @@ get_backup_dest() {
     if $ctrl get "pxc-backup/$backup" 1>/dev/null 2>/dev/null; then
         local secret=$( $ctrl get "pxc-backup/$backup" -o "jsonpath={.status.s3.credentialsSecret}" 2>/dev/null)
         export AWS_ENDPOINT_URL=$(  $ctrl get "pxc-backup/$backup" -o "jsonpath={.status.s3.endpointUrl}" 2>/dev/null)
-        export AWS_ACCESS_KEY_ID=$( $ctrl get "secret/$secret"     -o 'jsonpath={.data.AWS_ACCESS_KEY_ID}'     2>/dev/null | base64 -D)
-        export AWS_SECRET_ACCESS_KEY=$($ctrl get "secret/$secret"  -o 'jsonpath={.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -D)
+        export AWS_ACCESS_KEY_ID=$( $ctrl get "secret/$secret"     -o 'jsonpath={.data.AWS_ACCESS_KEY_ID}'     2>/dev/null | base64 -d)
+        export AWS_SECRET_ACCESS_KEY=$($ctrl get "secret/$secret"  -o 'jsonpath={.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -d)
 
         $ctrl get "pxc-backup/$backup" -o jsonpath='{.status.destination}'
     else

--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -35,10 +35,25 @@ get_backup_dest() {
     local backup=$1
 
     if $ctrl get "pxc-backup/$backup" 1>/dev/null 2>/dev/null; then
+        BASE64_DECODE_CMD=""
+        echo $(echo 'abc'|base64) | base64 -d 1>/dev/null 2>/dev/null
+        res1=$?
+        echo $(echo 'abc'|base64) | base64 -D 1>/dev/null 2>/dev/null
+        res2=$?
+
+        if [[ ${res1} == 0 ]]; then
+            BASE64_DECODE_CMD="base64 -d"
+        elif [[ ${res2} == 0 ]]; then
+            BASE64_DECODE_CMD="base64 -D"
+        else
+             echo "base64 decode error."
+             exit 1
+        fi
+
         local secret=$( $ctrl get "pxc-backup/$backup" -o "jsonpath={.status.s3.credentialsSecret}" 2>/dev/null)
         export AWS_ENDPOINT_URL=$(  $ctrl get "pxc-backup/$backup" -o "jsonpath={.status.s3.endpointUrl}" 2>/dev/null)
-        export AWS_ACCESS_KEY_ID=$( $ctrl get "secret/$secret"     -o 'jsonpath={.data.AWS_ACCESS_KEY_ID}'     2>/dev/null | base64 -d)
-        export AWS_SECRET_ACCESS_KEY=$($ctrl get "secret/$secret"  -o 'jsonpath={.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -d)
+        export AWS_ACCESS_KEY_ID=$( $ctrl get "secret/$secret"     -o 'jsonpath={.data.AWS_ACCESS_KEY_ID}'     2>/dev/null | eval ${BASE64_DECODE_CMD})
+        export AWS_SECRET_ACCESS_KEY=$($ctrl get "secret/$secret"  -o 'jsonpath={.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | eval ${BASE64_DECODE_CMD})
 
         $ctrl get "pxc-backup/$backup" -o jsonpath='{.status.destination}'
     else

--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -36,18 +36,13 @@ get_backup_dest() {
 
     if $ctrl get "pxc-backup/$backup" 1>/dev/null 2>/dev/null; then
         BASE64_DECODE_CMD=""
-        echo $(echo 'abc'|base64) | base64 -d 1>/dev/null 2>/dev/null
-        res1=$?
-        echo $(echo 'abc'|base64) | base64 -D 1>/dev/null 2>/dev/null
-        res2=$?
-
-        if [[ ${res1} == 0 ]]; then
+        if echo eWVz | base64 -d 1>/dev/null 2>/dev/null; then
             BASE64_DECODE_CMD="base64 -d"
-        elif [[ ${res2} == 0 ]]; then
+        elif echo eWVz | base64 -D 1>/dev/null 2>/dev/null; then
             BASE64_DECODE_CMD="base64 -D"
         else
-             echo "base64 decode error."
-             exit 1
+            echo "base64 decode error."
+            exit 1
         fi
 
         local secret=$( $ctrl get "pxc-backup/$backup" -o "jsonpath={.status.s3.credentialsSecret}" 2>/dev/null)

--- a/deploy/backup/restore-backup.sh
+++ b/deploy/backup/restore-backup.sh
@@ -38,8 +38,8 @@ get_backup_dest() {
     if $ctrl get "pxc-backup/$backup" 1>/dev/null 2>/dev/null; then
         local secret=$( $ctrl get "pxc-backup/$backup" -o "jsonpath={.status.s3.credentialsSecret}" 2>/dev/null)
         export AWS_ENDPOINT_URL=$(  $ctrl get "pxc-backup/$backup" -o "jsonpath={.status.s3.endpointUrl}" 2>/dev/null)
-        export AWS_ACCESS_KEY_ID=$( $ctrl get "secret/$secret"     -o 'jsonpath={.data.AWS_ACCESS_KEY_ID}'     2>/dev/null | base64 -D)
-        export AWS_SECRET_ACCESS_KEY=$($ctrl get "secret/$secret"  -o 'jsonpath={.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -D)
+        export AWS_ACCESS_KEY_ID=$( $ctrl get "secret/$secret"     -o 'jsonpath={.data.AWS_ACCESS_KEY_ID}'     2>/dev/null | base64 -d)
+        export AWS_SECRET_ACCESS_KEY=$($ctrl get "secret/$secret"  -o 'jsonpath={.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -d)
 
         $ctrl get "pxc-backup/$backup" -o jsonpath='{.status.destination}'
     else

--- a/deploy/backup/restore-backup.sh
+++ b/deploy/backup/restore-backup.sh
@@ -37,18 +37,13 @@ get_backup_dest() {
 
     if $ctrl get "pxc-backup/$backup" 1>/dev/null 2>/dev/null; then
         BASE64_DECODE_CMD=""
-        echo $(echo 'abc'|base64) | base64 -d 1>/dev/null 2>/dev/null
-        res1=$?
-        echo $(echo 'abc'|base64) | base64 -D 1>/dev/null 2>/dev/null
-        res2=$?
-
-        if [[ ${res1} == 0 ]]; then
+        if echo eWVz | base64 -d 1>/dev/null 2>/dev/null; then
             BASE64_DECODE_CMD="base64 -d"
-        elif [[ ${res2} == 0 ]]; then
+        elif echo eWVz | base64 -D 1>/dev/null 2>/dev/null; then
             BASE64_DECODE_CMD="base64 -D"
         else
-             echo "base64 decode error."
-             exit 1
+            echo "base64 decode error."
+            exit 1
         fi
 
         local secret=$( $ctrl get "pxc-backup/$backup" -o "jsonpath={.status.s3.credentialsSecret}" 2>/dev/null)


### PR DESCRIPTION
When I use `deploy/backup/restore-backup.sh` to restore data, I got the following error:
```
[root@iZuf60l6m7p7elsxtxv2yuZ ~]# ./restore-backup.sh cron-cluster1-20190424052506-uumyj cluster1
Log: /tmp/tmp.Xk5K8y67Ev/log
base64: invalid option -- 'D'
Try 'base64 --help' for more information.
base64: invalid option -- 'D'
Try 'base64 --help' for more information.
pvc/cluster1-xb-cron-cluster1-20190424052506-uumyjbase64: invalid option -- 'D'
Try 'base64 --help' for more information.
base64: invalid option -- 'D'
Try 'base64 --help' for more information.


All data in 'cluster1' Percona XtraDB Cluster will be deleted during the backup restoration.
Are you sure? [y/N] y
perconaxtradbcluster.pxc.percona.com "cluster1" deleted
Deleting cluster1-pxc-2.[done]
Deleting cluster1-pxc-1.[done]
Deleting cluster1-pxc-0.................[done]
persistentvolumeclaim "datadir-cluster1-pxc-2" deleted
persistentvolumeclaim "datadir-cluster1-pxc-1" deleted
service/restore-src-cluster1 created
pod/restore-src-cluster1 created
job.batch/restore-job-cluster1 created
Recovering.....................[done]
service "restore-src-cluster1" deleted
pod "restore-src-cluster1" deleted
perconaxtradbcluster.pxc.percona.com/cluster1 created

You can view xtrabackup log:
    $ kubectl logs job/restore-job-cluster1
If everything is fine, you can cleanup the job:
    $ kubectl delete job/restore-job-cluster1
```
system version:
```
[root@iZuf60l6m7p7elsxtxv2yuZ ~]# cat /etc/os-release
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"
```
and i executed `base64 --help` on my centos7.4, i got the following tips:
```
[root@iZuf60l6m7p7elsxtxv2yuZ ~]# base64 --help
Usage: base64 [OPTION]... [FILE]
Base64 encode or decode FILE, or standard input, to standard output.

Mandatory arguments to long options are mandatory for short options too.
  -d, --decode          decode data
  -i, --ignore-garbage  when decoding, ignore non-alphabet characters
  -w, --wrap=COLS       wrap encoded lines after COLS character (default 76).
                          Use 0 to disable line wrapping

      --help     display this help and exit
      --version  output version information and exit

With no FILE, or when FILE is -, read standard input.

The data are encoded as described for the base64 alphabet in RFC 3548.
When decoding, the input may contain newlines in addition to the bytes of
the formal base64 alphabet.  Use --ignore-garbage to attempt to recover
from any other non-alphabet bytes in the encoded stream.

GNU coreutils online help: <http://www.gnu.org/software/coreutils/>
For complete documentation, run: info coreutils 'base64 invocation'
```
on my mac book, I got the same result:
```
$ base64 --help
Usage: base64 [OPTION]... [FILE]
Base64 encode or decode FILE, or standard input, to standard output.

With no FILE, or when FILE is -, read standard input.

Mandatory arguments to long options are mandatory for short options too.
  -d, --decode          decode data
  -i, --ignore-garbage  when decoding, ignore non-alphabet characters
  -w, --wrap=COLS       wrap encoded lines after COLS character (default 76).
                          Use 0 to disable line wrapping

      --help     display this help and exit
      --version  output version information and exit

The data are encoded as described for the base64 alphabet in RFC 4648.
When decoding, the input may contain newlines in addition to the bytes of
the formal base64 alphabet.  Use --ignore-garbage to attempt to recover
from any other non-alphabet bytes in the encoded stream.

GNU coreutils online help: <https://www.gnu.org/software/coreutils/>
Full documentation at: <https://www.gnu.org/software/coreutils/base64>
or available locally via: info '(coreutils) base64 invocation'
```
I don't know why `-D` is written in uppercase, but I think it might be more common to write lowercase in this place.