### PR TITLE
add schedulerName

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -16,6 +16,7 @@ spec:
   pxc:
     size: 3
     image: percona/percona-xtradb-cluster-operator:1.1.0-pxc
+#    schedulerName: mycustom-scheduler
 #    readinessDelaySec: 15
 #    livenessDelaySec: 300
 #    forceUnsafeBootstrap: false
@@ -75,6 +76,7 @@ spec:
     enabled: true
     size: 3
     image: percona/percona-xtradb-cluster-operator:1.1.0-proxysql
+#    schedulerName: mycustom-scheduler
 #    imagePullSecrets:
 #      - name: private-registry-credentials
 #    annotations:

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -133,6 +133,7 @@ type PodSpec struct {
 	TerminationGracePeriodSeconds *int64                        `json:"gracePeriod,omitempty"`
 	ForceUnsafeBootstrap          bool                          `json:"forceUnsafeBootstrap,omitempty"`
 	ServiceType                   *corev1.ServiceType           `json:"serviceType,omitempty"`
+	SchedulerName                 string                        `json:"schedulerName,omitempty"`
 	ReadinessInitialDelaySeconds  *int32                        `json:"readinessDelaySec,omitempty"`
 	LivenessInitialDelaySeconds   *int32                        `json:"livenessDelaySec,omitempty"`
 }

--- a/pkg/pxc/app/statefulset/node.go
+++ b/pkg/pxc/app/statefulset/node.go
@@ -29,6 +29,13 @@ func NewNode(cr *api.PerconaXtraDBCluster) *Node {
 			Name:      cr.Name + "-" + app.Name,
 			Namespace: cr.Namespace,
 		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					SchedulerName: cr.Spec.PXC.SchedulerName,
+				},
+			},
+		},
 	}
 
 	labels := map[string]string{

--- a/pkg/pxc/statefulset.go
+++ b/pkg/pxc/statefulset.go
@@ -25,6 +25,7 @@ func StatefulSet(sfs api.StatefulApp, podSpec *api.PodSpec, cr *api.PerconaXtraD
 		},
 		NodeSelector:                  podSpec.NodeSelector,
 		Tolerations:                   podSpec.Tolerations,
+		SchedulerName:                 podSpec.SchedulerName,
 		PriorityClassName:             podSpec.PriorityClassName,
 		ImagePullSecrets:              podSpec.ImagePullSecrets,
 		TerminationGracePeriodSeconds: podSpec.TerminationGracePeriodSeconds,


### PR DESCRIPTION
This a pretty simple change in order to be able to define a scheduler.
For instance, we have storage nodes and all the others are standard worker nodes and we use a custom scheduler named Stork.

Related issue : https://jira.percona.com/browse/CLOUD-378