### PR TITLE
K8SPXC-40 Handle missing proxysql spec section

### DIFF
--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -60,7 +60,7 @@ type PerconaXtraDBClusterStatus struct {
 	Messages           []string           `json:"message,omitempty"`
 	Status             AppState           `json:"state,omitempty"`
 	Conditions         []ClusterCondition `json:"conditions,omitempty"`
-	ObservedGeneration int64              `json:"observedGeneration, omitepty"`
+	ObservedGeneration int64              `json:"observedGeneration,omitepty"`
 }
 
 type ConditionStatus string
@@ -91,7 +91,7 @@ type ClusterCondition struct {
 
 type AppStatus struct {
 	Size    int32    `json:"size,omitempty"`
-	Ready   int32    `json:"ready"`
+	Ready   int32    `json:"ready,omitempty"`
 	Status  AppState `json:"status,omitempty"`
 	Message string   `json:"message,omitempty"`
 }

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -111,6 +111,8 @@ func (r *ReconcilePerconaXtraDBCluster) updateStatus(cr *api.PerconaXtraDBCluste
 		if err != nil {
 			return fmt.Errorf("check proxysql upgrade progress: %v", err)
 		}
+	} else {
+		cr.Status.ProxySQL = api.AppStatus{}
 	}
 
 	if !inProgres {
@@ -128,6 +130,13 @@ func (r *ReconcilePerconaXtraDBCluster) updateStatus(cr *api.PerconaXtraDBCluste
 				Type:               api.ClusterReady,
 				LastTransitionTime: metav1.NewTime(time.Now()),
 			}
+		}
+		cr.Status.Status = cr.Status.PXC.Status
+	case cr.Spec.ProxySQL == nil && cr.Status.PXC.Status == api.AppStateReady:
+		clusterCondition = api.ClusterCondition{
+			Status:             api.ConditionTrue,
+			Type:               api.ClusterReady,
+			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
 		cr.Status.Status = cr.Status.PXC.Status
 	case cr.Status.PXC.Status == api.AppStateError || cr.Status.ProxySQL.Status == api.AppStateError:

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -132,14 +132,7 @@ func (r *ReconcilePerconaXtraDBCluster) updateStatus(cr *api.PerconaXtraDBCluste
 			}
 		}
 		cr.Status.Status = cr.Status.PXC.Status
-	case cr.Spec.ProxySQL == nil && cr.Status.PXC.Status == api.AppStateReady:
-		clusterCondition = api.ClusterCondition{
-			Status:             api.ConditionTrue,
-			Type:               api.ClusterReady,
-			LastTransitionTime: metav1.NewTime(time.Now()),
-		}
-		cr.Status.Status = cr.Status.PXC.Status
-	case cr.Spec.ProxySQL != nil && cr.Spec.ProxySQL.Enabled == false && cr.Status.PXC.Status == api.AppStateReady:
+	case (cr.Spec.ProxySQL == nil || cr.Spec.ProxySQL.Enabled == false) && cr.Status.PXC.Status == api.AppStateReady:
 		clusterCondition = api.ClusterCondition{
 			Status:             api.ConditionTrue,
 			Type:               api.ClusterReady,
@@ -153,7 +146,7 @@ func (r *ReconcilePerconaXtraDBCluster) updateStatus(cr *api.PerconaXtraDBCluste
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
 		cr.Status.Status = api.AppStateError
-	case cr.Status.PXC.Status == api.AppStateInit || cr.Status.ProxySQL.Status == api.AppStateInit:
+	case cr.Status.PXC.Status == api.AppStateInit || cr.Spec.ProxySQL == nil || cr.Status.ProxySQL.Status == api.AppStateInit:
 		clusterCondition = api.ClusterCondition{
 			Status:             api.ConditionTrue,
 			Type:               api.ClusterInit,

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -146,7 +146,7 @@ func (r *ReconcilePerconaXtraDBCluster) updateStatus(cr *api.PerconaXtraDBCluste
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
 		cr.Status.Status = api.AppStateError
-	case cr.Status.PXC.Status == api.AppStateInit || cr.Spec.ProxySQL == nil || cr.Status.ProxySQL.Status == api.AppStateInit:
+	case cr.Status.PXC.Status == api.AppStateInit || (cr.Spec.ProxySQL != nil && cr.Status.ProxySQL.Status == api.AppStateInit):
 		clusterCondition = api.ClusterCondition{
 			Status:             api.ConditionTrue,
 			Type:               api.ClusterInit,

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -132,7 +132,7 @@ func (r *ReconcilePerconaXtraDBCluster) updateStatus(cr *api.PerconaXtraDBCluste
 			}
 		}
 		cr.Status.Status = cr.Status.PXC.Status
-	case (cr.Spec.ProxySQL == nil || cr.Spec.ProxySQL.Enabled == false) && cr.Status.PXC.Status == api.AppStateReady:
+	case (cr.Spec.ProxySQL == nil || !cr.Spec.ProxySQL.Enabled) && cr.Status.PXC.Status == api.AppStateReady:
 		clusterCondition = api.ClusterCondition{
 			Status:             api.ConditionTrue,
 			Type:               api.ClusterReady,

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -139,6 +139,13 @@ func (r *ReconcilePerconaXtraDBCluster) updateStatus(cr *api.PerconaXtraDBCluste
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
 		cr.Status.Status = cr.Status.PXC.Status
+	case cr.Spec.ProxySQL != nil && cr.Spec.ProxySQL.Enabled == false && cr.Status.PXC.Status == api.AppStateReady:
+		clusterCondition = api.ClusterCondition{
+			Status:             api.ConditionTrue,
+			Type:               api.ClusterReady,
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		}
+		cr.Status.Status = cr.Status.PXC.Status
 	case cr.Status.PXC.Status == api.AppStateError || cr.Status.ProxySQL.Status == api.AppStateError:
 		clusterCondition = api.ClusterCondition{
 			Status:             api.ConditionTrue,


### PR DESCRIPTION
Status would be look like 

`status:
  conditions:
  - lastTransitionTime: "2020-01-30T17:09:23Z"
    status: "True"
    type: Initializing
  - lastTransitionTime: "2020-01-30T17:11:55Z"
    status: "True"
    type: Ready
  host: cluster1-pxc
  observedGeneration: 1
  proxysql: {}
  pxc:
    ready: 3
    size: 3
    status: ready
  state: ready`