### PR TITLE
CLOUD-531 Fix wrong usage of strings.TrimLeft, cutset contains duplicate characters.

### DIFF
--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -454,7 +454,7 @@ func (cr *PerconaXtraDBCluster) setVersion() error {
 		}
 		apiVersion = newCR.APIVersion
 	}
-	crVersion := strings.Replace(strings.TrimLeft(apiVersion, "pxc.percona.com/v"), "-", ".", -1)
+	crVersion := strings.Replace(strings.TrimPrefix(apiVersion, "pxc.percona.com/v"), "-", ".", -1)
 	if len(crVersion) == 0 {
 		crVersion = "v1"
 	}


### PR DESCRIPTION
 strings.TrimLeft changed to strings.TrimPrefix. 

Please take a look at the strings.TrimLeft documentation.


> // TrimLeft returns a slice of the string s with all leading
> // Unicode code points contained in cutset removed.
> //
> // To remove a prefix, use TrimPrefix instead.


Signed-off-by: heartwilltell <heartwilltell@gmail.com>