### PR TITLE
Fix updating mysql hosts in proxysql for one node cluster

### DIFF
--- a/cmd/peer-list/main.go
+++ b/cmd/peer-list/main.go
@@ -134,7 +134,12 @@ func main() {
 		newPeers, err = lookup(*svc)
 		if err != nil {
 			log.Printf("%v", err)
-			continue
+
+			if lerr, ok := err.(*net.DNSError); ok && lerr.IsNotFound {
+				// Service not resolved - no endpoints, so reset peers list
+				peers = sets.NewString()
+				continue
+			}
 		}
 		peerList := newPeers.List()
 		sort.Strings(peerList)


### PR DESCRIPTION
When single pod in cluster restarted, list of peers is not changed
so peer-list not calling onchange script and not updating list of servers in proxysql

during update kubernetes service without endpoints is not resolved, so we have this behaviour:

["cluster1-pxc-0"]
...
resolv error
...
["cluster1-pxc-0"]

We can fix ochange by resetting list when service not resolving.

see https://github.com/Percona-Lab/percona-openshift/pull/68 for more info.