### PR TITLE
K8SPXC-290 - Extend usable backup schedule syntax

### DIFF
--- a/pkg/pxc/backup/names.go
+++ b/pkg/pxc/backup/names.go
@@ -24,7 +24,7 @@ func genRandString(ln int) string {
 }
 
 func genScheduleLabel(sched string) string {
-	r := strings.NewReplacer("*", "N", "/", "E", " ", "_")
+	r := strings.NewReplacer("*", "N", "/", "E", " ", "_", ",", ".")
 	return r.Replace(sched)
 }
 


### PR DESCRIPTION
Replace commas with periods when generating the "schedule" label for CronJobs.
This extends the usable syntax of backups to include lists of
values like: "0 0 * * 0,1,2,3,4,5" = daily, except saturday.