### PR TITLE
Fix checks for PXC images in e2e functions and tests

### DIFF
--- a/e2e-tests/big-data/run
+++ b/e2e-tests/big-data/run
@@ -20,7 +20,7 @@ main() {
 
     kubectl_bin apply -f "${test_dir}/conf/crd_backup.yml"
 
-    if [[ "$IMAGE_PXC" =~ 8\.0$ ]]; then
+    if [[ "$IMAGE_PXC" =~ 8\.0 ]]; then
         desc 'Switch to 8.0 backup'
         kubectl_bin apply -f "${test_dir}/conf/backup.yml"
     else

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -216,7 +216,7 @@ compare_kubectl() {
         expected_result=${expected_result//.yml/-oc.yml}
     fi
 
-    if [[ "$IMAGE_PXC" =~ 8\.0$ ]] && [ -f ${expected_result//.yml/-80.yml} ]; then
+    if [[ "$IMAGE_PXC" =~ 8\.0 ]] && [ -f ${expected_result//.yml/-80.yml} ]; then
         expected_result=${expected_result//.yml/-80.yml}
     fi
 
@@ -282,7 +282,7 @@ compare_mysql_cmd() {
     local postfix="$4"
     local expected_result=${test_dir}/compare/${command_id}${postfix}.sql
 
-    if [[ "$IMAGE_PXC" =~ 8\.0$ ]] && [ -f ${test_dir}/compare/${command_id}${postfix}-80.sql ]; then
+    if [[ "$IMAGE_PXC" =~ 8\.0 ]] && [ -f ${test_dir}/compare/${command_id}${postfix}-80.sql ]; then
         expected_result=${test_dir}/compare/${command_id}${postfix}-80.sql
     fi
 
@@ -325,7 +325,7 @@ compare_mysql_user() {
     local user=$(echo $uri | sed -e 's/.*-u//; s/ .*//')
     local expected_result=${test_dir}/compare/$user$postfix.sql
 
-    if [[ "$IMAGE_PXC" =~ 8\.0$ ]] && [ -f ${test_dir}/compare/$user$postfix-80.sql ]; then
+    if [[ "$IMAGE_PXC" =~ 8\.0 ]] && [ -f ${test_dir}/compare/$user$postfix-80.sql ]; then
         expected_result=${test_dir}/compare/$user$postfix-80.sql
     fi
 
@@ -342,7 +342,7 @@ compare_mysql_user_local() {
     local user=$(echo $uri | sed -e 's/.*-u//; s/ .*//')
     local expected_result=$test_dir/compare/$user$postfix.sql
 
-    if [[ "$IMAGE_PXC" =~ 8\.0$ ]] && [ -f ${test_dir}/compare/$user$postfix-80.sql ]; then
+    if [[ "$IMAGE_PXC" =~ 8\.0 ]] && [ -f ${test_dir}/compare/$user$postfix-80.sql ]; then
         expected_result=${test_dir}/compare/$user$postfix-80.sql
     fi
 
@@ -532,7 +532,7 @@ spinup_pxc() {
     sleep $sleep
 
     desc 'write data'
-    if [[ "$IMAGE_PXC" =~ 5\.7$ ]] && [[ "$(is_keyring_plugin_in_use "$cluster")" ]]; then
+    if [[ "$IMAGE_PXC" =~ 5\.7 ]] && [[ "$(is_keyring_plugin_in_use "$cluster")" ]]; then
         encrypt='ENCRYPTION=\"Y\"'
     fi
     run_mysql \

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -501,7 +501,8 @@ EOF
 cat_config() {
     cat "$1" \
         | $sed -e "s#apiVersion: pxc.percona.com/v.*\$#apiVersion: $API#" \
-        | $sed -e "s#image:.*-pxc\$#image: $IMAGE_PXC#" \
+        | $sed -e "s#image:.*-pxc\([0-9]*.[0-9]*\)\{0,1\}\$#image: $IMAGE_PXC#" \
+        | $sed -e "s#image:.*\/percona-xtradb-cluster:.*\$#image: $IMAGE_PXC#" \
         | $sed -e "s#image:.*-pmm\$#image: $IMAGE_PMM#" \
         | $sed -e "s#image:.*-backup\$#image: $IMAGE_BACKUP#" \
         | $sed -e "s#image:.*-proxysql\$#image: $IMAGE_PROXY#"

--- a/e2e-tests/self-healing-advanced/run
+++ b/e2e-tests/self-healing-advanced/run
@@ -71,7 +71,7 @@ main() {
     desc 'start cluster'
     spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml"
 
-    if [[ "$IMAGE_PXC" =~ 8\.0$ ]]; then
+    if [[ "$IMAGE_PXC" =~ 8\.0 ]]; then
         desc 'kill all PXC pods'
         pumba_all_pods kill
     fi

--- a/e2e-tests/self-healing/run
+++ b/e2e-tests/self-healing/run
@@ -104,7 +104,7 @@ recreate() {
         >$tmp_dir/proxy-vars1.sql
 
     local expected_result=$test_dir/compare/proxy-vars.sql
-    if [[ "$IMAGE_PXC" =~ 8\.0$ ]] && [ -f $test_dir/compare/proxy-vars-80.sql ]; then
+    if [[ "$IMAGE_PXC" =~ 8\.0 ]] && [ -f $test_dir/compare/proxy-vars-80.sql ]; then
         expected_result=$test_dir/compare/proxy-vars-80.sql
     fi
     diff -u $expected_result $tmp_dir/proxy-vars1.sql
@@ -131,7 +131,7 @@ recreate() {
         >$tmp_dir/proxy-vars2.sql
 
     local expected_result=$test_dir/compare/proxy-vars.sql
-    if [[ "$IMAGE_PXC" =~ 8\.0$ ]] && [ -f $test_dir/compare/proxy-vars-80.sql ]; then
+    if [[ "$IMAGE_PXC" =~ 8\.0 ]] && [ -f $test_dir/compare/proxy-vars-80.sql ]; then
         expected_result=$test_dir/compare/proxy-vars-80.sql
     fi
     diff -u $expected_result $tmp_dir/proxy-vars2.sql


### PR DESCRIPTION
I have split it into two because some versions of sed don't support "|" operator.
First one works on images from operator dockergub and second one works on images from PXC dockerhub.
Here's a quick test:
```
$ cat test.txt
    image: percona/percona-xtradb-cluster-operator:1.4.0-pxc8.0
    image: percona/percona-xtradb-cluster-operator:1.4.0-pxc
    image: percona/percona-xtradb-cluster:8.0.18-9.3
    image: percona/percona-xtradb-cluster:5.7.28-31.41.2

$ cat test.txt | sed -e "s#image:.*-pxc\([0-9]*.[0-9]*\)\{0,1\}\$#image: aaa#"
    image: aaa
    image: aaa
    image: percona/percona-xtradb-cluster:8.0.18-9.3
    image: percona/percona-xtradb-cluster:5.7.28-31.41.2

$ cat test.txt | sed -e "s#image:.*\/percona-xtradb-cluster:.*\$#image: aaa#"
    image: percona/percona-xtradb-cluster-operator:1.4.0-pxc8.0
    image: percona/percona-xtradb-cluster-operator:1.4.0-pxc
    image: aaa
    image: aaa
```

Also fixed check for PXC image where version was expected as last string before the end of string and in new images we don't have that eg. `percona/percona-xtradb-cluster:5.7.29-31.43` or `percona/percona-xtradb-cluster:8.0.19-10.1`.