### PR TITLE
K8SPXC-327 crash after interrupted SST

### DIFF
--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -318,8 +318,11 @@ if [ -z "$CLUSTER_JOIN" ] && [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 fi
 
 if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
+	DATADIR=$(_get_config 'datadir' "$@")
+	SST_DIR=$(_get_cnf_config sst tmpdir "${DATADIR}/sst-xb-tmpdir")
+	rm -rvf "${SST_DIR}"
+
 	"$@" --version | tee /tmp/version_info
-	DATADIR="$(_get_config 'datadir' "$@")"
 	if [ -f "$DATADIR/version_info" ] && ! diff /tmp/version_info "$DATADIR/version_info"; then
 		SOCKET="$(_get_config 'socket' "$@")"
 		"$@" --skip-networking --socket="${SOCKET}" --wsrep-provider='none' &


### PR DESCRIPTION
[![K8SPXC-327](https://badgen.net/badge/JIRA/K8SPXC-327/green)](https://jira.percona.com/browse/K8SPXC-327)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

can be merged only after https://github.com/percona/percona-xtradb-cluster-operator/pull/449

if PXC Pod was restarted during SST the /var/lib/mysql/sst-xb-tmpdir
directory become preserved. Every new SST failed if directory exists.
```
2020-06-23T20:05:34.526984Z 0 [ERROR] [MY-000000] [WSREP-SST] FATAL: Found existing /var/lib/mysql//sst-xb-tmpdir
2020-06-23T20:05:34.527007Z 0 [ERROR] [MY-000000] [WSREP-SST] Please remove it or specify alternative temporary directory location by setting [sst]/tmpdir
```

SST code - https://github.com/percona/percona-xtradb-cluster/blob/8.0/scripts/wsrep_sst_xtrabackup-v2.sh#L2040