### PR TITLE
K8SPXC-257 add service account only in 1.5.0

### DIFF
--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-100-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-100-oc.yml
@@ -150,8 +150,6 @@ spec:
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-100.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-100.yml
@@ -151,8 +151,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-110-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-110-oc.yml
@@ -151,8 +151,6 @@ spec:
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-110.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-110.yml
@@ -152,8 +152,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-120-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-120-oc.yml
@@ -151,8 +151,6 @@ spec:
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-120.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-120.yml
@@ -152,8 +152,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-130-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-130-oc.yml
@@ -151,8 +151,6 @@ spec:
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-130.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-130.yml
@@ -152,8 +152,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-140-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-140-oc.yml
@@ -151,8 +151,6 @@ spec:
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-140.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-140.yml
@@ -152,8 +152,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-internal

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-150.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-150.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 2
+  generation: 3
   name: some-name-proxysql
   ownerReferences:
   - apiVersion: pxc.percona.com/v1

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-100-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-100-oc.yml
@@ -41,11 +41,7 @@ spec:
                 app.kubernetes.io/part-of: percona-xtradb-cluster
             topologyKey: kubernetes.io/hostname
       containers:
-      - args:
-        - mysqld
-        command:
-        - /var/lib/mysql/pxc-entrypoint.sh
-        env:
+      - env:
         - name: PXC_SERVICE
           value: some-name-pxc-unready
         - name: MYSQL_ROOT_PASSWORD
@@ -122,24 +118,11 @@ spec:
         - mountPath: /etc/mysql/ssl-internal
           name: ssl-internal
       dnsPolicy: ClusterFirst
-      initContainers:
-      - command:
-        - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
-        name: pxc-init
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /var/lib/mysql
-          name: datadir
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-100.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-100.yml
@@ -124,8 +124,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-110-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-110-oc.yml
@@ -42,11 +42,7 @@ spec:
                 app.kubernetes.io/part-of: percona-xtradb-cluster
             topologyKey: kubernetes.io/hostname
       containers:
-      - args:
-        - mysqld
-        command:
-        - /var/lib/mysql/pxc-entrypoint.sh
-        env:
+      - env:
         - name: PXC_SERVICE
           value: some-name-pxc-unready
         - name: MONITOR_HOST
@@ -125,24 +121,11 @@ spec:
         - mountPath: /etc/mysql/ssl-internal
           name: ssl-internal
       dnsPolicy: ClusterFirst
-      initContainers:
-      - command:
-        - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
-        name: pxc-init
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /var/lib/mysql
-          name: datadir
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-110.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-110.yml
@@ -127,8 +127,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-120-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-120-oc.yml
@@ -42,11 +42,7 @@ spec:
                 app.kubernetes.io/part-of: percona-xtradb-cluster
             topologyKey: kubernetes.io/hostname
       containers:
-      - args:
-        - mysqld
-        command:
-        - /var/lib/mysql/pxc-entrypoint.sh
-        env:
+      - env:
         - name: PXC_SERVICE
           value: some-name-pxc-unready
         - name: MONITOR_HOST
@@ -125,24 +121,11 @@ spec:
         - mountPath: /etc/mysql/ssl-internal
           name: ssl-internal
       dnsPolicy: ClusterFirst
-      initContainers:
-      - command:
-        - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
-        name: pxc-init
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /var/lib/mysql
-          name: datadir
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-120.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-120.yml
@@ -127,8 +127,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-130-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-130-oc.yml
@@ -42,11 +42,7 @@ spec:
                 app.kubernetes.io/part-of: percona-xtradb-cluster
             topologyKey: kubernetes.io/hostname
       containers:
-      - args:
-        - mysqld
-        command:
-        - /var/lib/mysql/pxc-entrypoint.sh
-        env:
+      - env:
         - name: PXC_SERVICE
           value: some-name-pxc-unready
         - name: MONITOR_HOST
@@ -127,24 +123,11 @@ spec:
         - mountPath: /etc/my.cnf.d
           name: auto-config
       dnsPolicy: ClusterFirst
-      initContainers:
-      - command:
-        - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
-        name: pxc-init
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /var/lib/mysql
-          name: datadir
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-130.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-130.yml
@@ -129,8 +129,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-140-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-140-oc.yml
@@ -42,11 +42,7 @@ spec:
                 app.kubernetes.io/part-of: percona-xtradb-cluster
             topologyKey: kubernetes.io/hostname
       containers:
-      - args:
-        - mysqld
-        command:
-        - /var/lib/mysql/pxc-entrypoint.sh
-        env:
+      - env:
         - name: PXC_SERVICE
           value: some-name-pxc-unready
         - name: MONITOR_HOST
@@ -129,24 +125,11 @@ spec:
         - mountPath: /etc/mysql/vault-keyring-secret
           name: vault-keyring-secret
       dnsPolicy: ClusterFirst
-      initContainers:
-      - command:
-        - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
-        name: pxc-init
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /var/lib/mysql
-          name: datadir
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-140.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-140.yml
@@ -131,8 +131,6 @@ spec:
         fsGroup: 1001
         supplementalGroups:
         - 1001
-      serviceAccount: percona-xtradb-cluster-operator-workload
-      serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 600
       volumes:
       - emptyDir: {}

--- a/e2e-tests/upgrade-consistency/run
+++ b/e2e-tests/upgrade-consistency/run
@@ -101,7 +101,7 @@ main() {
     kubectl_bin patch pxc "$cluster" --type=merge --patch '{
         "metadata": {"annotations":{ "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"'"$API"'\"}" }}
     }'
-    wait_for_running "$cluster-pxc" "1"
+    wait_for_sts_generation "$cluster-pxc" "5" "1"
 
     compare_kubectl service/$cluster-pxc "-150"
     compare_kubectl service/$cluster-proxysql "-150"

--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -41,6 +41,9 @@ func (r *ReconcilePerconaXtraDBCluster) updatePod(sfs api.StatefulApp, podSpec *
 	if cr.CompareVersionWith("1.1.0") >= 0 {
 		currentSet.Spec.Template.Annotations["percona.com/configuration-hash"] = configHash
 	}
+	if cr.CompareVersionWith("1.5.0") >= 0 {
+		currentSet.Spec.Template.Spec.ServiceAccountName = podSpec.ServiceAccountName
+	}
 
 	err = r.reconcileConfigMap(cr)
 	if err != nil {

--- a/pkg/pxc/statefulset.go
+++ b/pkg/pxc/statefulset.go
@@ -23,7 +23,9 @@ func StatefulSet(sfs api.StatefulApp, podSpec *api.PodSpec, cr *api.PerconaXtraD
 		ImagePullSecrets:              podSpec.ImagePullSecrets,
 		TerminationGracePeriodSeconds: podSpec.TerminationGracePeriodSeconds,
 	}
-	pod.ServiceAccountName = podSpec.ServiceAccountName
+	if cr.CompareVersionWith("1.5.0") >= 0 {
+		pod.ServiceAccountName = podSpec.ServiceAccountName
+	}
 	pod.Affinity = PodAffinity(podSpec.Affinity, sfs)
 
 	sfsVolume, err := sfs.Volumes(podSpec, cr)


### PR DESCRIPTION
[![K8SPXC-257](https://badgen.net/badge/JIRA/K8SPXC-257/green)](https://jira.percona.com/browse/K8SPXC-257)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

CR has operator version. Operator should be able to act as old version.
Operator should not trigger PXC restart if we update only Operator Pod
without updating operator version in CR.