### PR TITLE
K8SPXC-326 fix empty hash if AllowUnsafeConfig enabled

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -379,7 +379,7 @@ func (r *ReconcilePerconaXtraDBCluster) deploy(cr *api.PerconaXtraDBCluster) err
 	if err != nil {
 		return fmt.Errorf("get secret hash error: %v", err)
 	}
-	if cr.CompareVersionWith("1.1.0") >= 0 {
+	if sslHash != "" && cr.CompareVersionWith("1.1.0") >= 0 {
 		nodeSet.Spec.Template.Annotations["percona.com/ssl-hash"] = sslHash
 	}
 
@@ -387,7 +387,7 @@ func (r *ReconcilePerconaXtraDBCluster) deploy(cr *api.PerconaXtraDBCluster) err
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("get secret hash error: %v", err)
 	}
-	if !k8serrors.IsNotFound(err) && cr.CompareVersionWith("1.1.0") >= 0 {
+	if sslInternalHash != "" && cr.CompareVersionWith("1.1.0") >= 0 {
 		nodeSet.Spec.Template.Annotations["percona.com/ssl-internal-hash"] = sslInternalHash
 	}
 

--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -55,7 +55,7 @@ func (r *ReconcilePerconaXtraDBCluster) updatePod(sfs api.StatefulApp, podSpec *
 	if err != nil {
 		return fmt.Errorf("upgradePod/updateApp error: update secret error: %v", err)
 	}
-	if cr.CompareVersionWith("1.1.0") >= 0 {
+	if sslHash != "" && cr.CompareVersionWith("1.1.0") >= 0 {
 		currentSet.Spec.Template.Annotations["percona.com/ssl-hash"] = sslHash
 	}
 
@@ -63,7 +63,7 @@ func (r *ReconcilePerconaXtraDBCluster) updatePod(sfs api.StatefulApp, podSpec *
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("upgradePod/updateApp error: update secret error: %v", err)
 	}
-	if !errors.IsNotFound(err) && cr.CompareVersionWith("1.1.0") >= 0 {
+	if sslInternalHash != "" && cr.CompareVersionWith("1.1.0") >= 0 {
 		currentSet.Spec.Template.Annotations["percona.com/ssl-internal-hash"] = sslInternalHash
 	}
 
@@ -323,10 +323,6 @@ func (r *ReconcilePerconaXtraDBCluster) getConfigHash(cr *api.PerconaXtraDBClust
 }
 
 func (r *ReconcilePerconaXtraDBCluster) getTLSHash(cr *api.PerconaXtraDBCluster, secretName string) (string, error) {
-	if cr.Spec.AllowUnsafeConfig {
-		return "", nil
-	}
-
 	secretObj := corev1.Secret{}
 	if err := r.client.Get(context.TODO(),
 		types.NamespacedName{
@@ -334,7 +330,9 @@ func (r *ReconcilePerconaXtraDBCluster) getTLSHash(cr *api.PerconaXtraDBCluster,
 			Name:      secretName,
 		},
 		&secretObj,
-	); err != nil {
+	); err != nil && errors.IsNotFound(err) && cr.Spec.AllowUnsafeConfig {
+		return "", nil
+	} else if err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
[![K8SPXC-326](https://badgen.net/badge/JIRA/K8SPXC-326/green)](https://jira.percona.com/browse/K8SPXC-326)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

changes in TLS secrets should trigger PXC restart
(trigger changing annotation with a new hash)
even if AllowUnsafeConfig is enabled