### PR TITLE
K8SPXC-331 REVOKE SYSTEM_USER only on 8.0

### DIFF
--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -136,7 +136,7 @@ fi
 
 # add sst.cpat to exclude pxc-entrypoint and unsafe-bootstrap from SST cleanup
 grep -q "^[sst]" "$CFG" || printf '[sst]\n' >> "$CFG"
-grep -q "^cpat=" "$CFG" || sed '/^\[sst\]/a cpat=.*\\.pem$\\|.*init\\.ok$\\|.*galera\\.cache$\\|.*sst_in_progress$\\|.*sst-xb-tmpdir$\\|.*gvwstate\\.dat$\\|.*grastate\\.dat$\\|.*\\.err$\\|.*\\.log$\\|.*RPM_UPGRADE_MARKER$\\|.*RPM_UPGRADE_HISTORY$\\|.*pxc-entrypoint\\.sh$\\|.*unsafe-bootstrap\\.sh$' "$CFG" 1<> "$CFG"
+grep -q "^cpat=" "$CFG" || sed '/^\[sst\]/a cpat=.*\\.pem$\\|.*init\\.ok$\\|.*galera\\.cache$\\|.*sst_in_progress$\\|.*sst-xb-tmpdir$\\|.*\\.sst$\\|.*gvwstate\\.dat$\\|.*grastate\\.dat$\\|.*\\.err$\\|.*\\.log$\\|.*RPM_UPGRADE_MARKER$\\|.*RPM_UPGRADE_HISTORY$\\|.*pxc-entrypoint\\.sh$\\|.*unsafe-bootstrap\\.sh$' "$CFG" 1<> "$CFG"
 
 file_env 'XTRABACKUP_PASSWORD' 'xtrabackup'
 file_env 'CLUSTERCHECK_PASSWORD' 'clustercheck'

--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -278,7 +278,7 @@ if [ -z "$CLUSTER_JOIN" ] && [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
 			GRANT ALL ON *.* TO 'root'@'localhost' WITH GRANT OPTION ;
 			${rootCreate}
-			REVOKE SYSTEM_USER ON *.* FROM root ;
+			/*!80016 REVOKE SYSTEM_USER ON *.* FROM root */;
 
 			CREATE USER 'operator'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '${OPERATOR_ADMIN_PASSWORD}' ;
 			GRANT ALL ON *.* TO 'operator'@'${MYSQL_ROOT_HOST}' WITH GRANT OPTION ;

--- a/e2e-tests/affinity/compare/statefulset_custom-pxc-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-pxc-oc.yml
@@ -164,7 +164,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/affinity/compare/statefulset_custom-pxc.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-pxc.yml
@@ -164,7 +164,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/affinity/compare/statefulset_hostname-pxc-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-pxc-oc.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/affinity/compare/statefulset_hostname-pxc.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-pxc.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/affinity/compare/statefulset_region-pxc-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-pxc-oc.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/affinity/compare/statefulset_region-pxc.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-pxc.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/affinity/compare/statefulset_zone-pxc-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-pxc-oc.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/affinity/compare/statefulset_zone-pxc.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-pxc.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/init-deploy/compare/statefulset_no-proxysql-pxc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_no-proxysql-pxc.yml
@@ -123,7 +123,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-pxc-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-pxc-oc.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-pxc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-pxc.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-oc.yml
@@ -123,7 +123,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased.yml
@@ -123,7 +123,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-oc.yml
@@ -123,7 +123,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc.yml
@@ -123,7 +123,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-pxc-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-pxc-increased-oc.yml
@@ -120,7 +120,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-pxc-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-pxc-increased.yml
@@ -120,7 +120,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-pxc-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-pxc-oc.yml
@@ -120,7 +120,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-pxc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-pxc.yml
@@ -120,7 +120,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-requests-pxc-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-pxc-increased-oc.yml
@@ -123,7 +123,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-requests-pxc-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-pxc-increased.yml
@@ -123,7 +123,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-requests-pxc-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-pxc-oc.yml
@@ -123,7 +123,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/limits/compare/statefulset_no-requests-pxc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-pxc.yml
@@ -123,7 +123,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-oc.yml
@@ -182,7 +182,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc.yml
@@ -182,7 +182,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/monitoring/compare/statefulset_monitoring-pxc-oc.yml
+++ b/e2e-tests/monitoring/compare/statefulset_monitoring-pxc-oc.yml
@@ -175,7 +175,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/monitoring/compare/statefulset_monitoring-pxc.yml
+++ b/e2e-tests/monitoring/compare/statefulset_monitoring-pxc.yml
@@ -175,7 +175,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/security-context/compare/statefulset_sec-context-pxc-changes.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-pxc-changes.yml
@@ -140,7 +140,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         securityContext:

--- a/e2e-tests/security-context/compare/statefulset_sec-context-pxc.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-pxc.yml
@@ -140,7 +140,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         securityContext:

--- a/e2e-tests/storage/compare/statefulset_emptydir-pxc-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-pxc-oc.yml
@@ -133,7 +133,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/storage/compare/statefulset_emptydir-pxc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-pxc.yml
@@ -133,7 +133,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/storage/compare/statefulset_hostpath-pxc-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-pxc-oc.yml
@@ -129,7 +129,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/storage/compare/statefulset_hostpath-pxc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-pxc.yml
@@ -133,7 +133,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         securityContext:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-150-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-150-oc.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-150.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-150.yml
@@ -137,7 +137,7 @@ spec:
       initContainers:
       - command:
         - /pxc-init-entrypoint.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: pxc-init
         resources: {}
         terminationMessagePath: /dev/termination-log

--- a/pkg/pxc/app/statefulset/init.go
+++ b/pkg/pxc/app/statefulset/init.go
@@ -11,6 +11,7 @@ func EntrypointInitContainer(initImageName string, securityContext *corev1.Secur
 			},
 		},
 		Image:           initImageName,
+		ImagePullPolicy: corev1.PullAlways,
 		Name:            "pxc-init",
 		Command:         []string{"/pxc-init-entrypoint.sh"},
 		SecurityContext: securityContext,


### PR DESCRIPTION
[![K8SPXC-331](https://badgen.net/badge/JIRA/K8SPXC-331/green)](https://jira.percona.com/browse/K8SPXC-331)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

SYSTEM_USER privilegie was added in 8.0.16.
running "REVOKE SYSTEM_USER" on versions less than 8.0.16 produces
the issue
```
+ mysql --protocol=socket -uroot -hlocalhost --socket=/tmp/mysql.sock --password=
ERROR 1064 (42000) at line 10: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SYSTEM_USER ON *.* FROM root'
```