### PR TITLE
CLOUD-556 Remove extra fields

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -205,7 +205,7 @@ compare_kubectl() {
         | $sed -e '/name: S3_BUCKET_URL/,+1d' \
         | $sed -e '/annotations:$/{$!{N;s/annotations:\n    kubernetes.io.*//;ty;P;D;:y;d}}' \
         | $sed -e '/annotations:$/{$!{N;s/annotations:\n    cni.projectcalico.org.*//;ty;P;D;:y;d}}' \
-        | $sed -e '/volumeClaimTemplates/{N;/  \- apiVersion.*$/ {N;/  kind.*$/ {N;/    metadata:$/{s/volumeClaimTemplates.*metadata:$/volumeClaimTemplates:\n  \- metadata:/}}}}'
+        | $sed -e '/volumeClaimTemplates:$/{N;/  \- apiVersion.*$/ {N;/  kind.*$/ {N;/    metadata:$/{s/volumeClaimTemplates.*metadata:$/volumeClaimTemplates:\n  \- metadata:/}}}}' \
         > ${new_result}
 
     diff -u ${expected_result} ${new_result}

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -205,6 +205,7 @@ compare_kubectl() {
         | $sed -e '/name: S3_BUCKET_URL/,+1d' \
         | $sed -e '/annotations:$/{$!{N;s/annotations:\n    kubernetes.io.*//;ty;P;D;:y;d}}' \
         | $sed -e '/annotations:$/{$!{N;s/annotations:\n    cni.projectcalico.org.*//;ty;P;D;:y;d}}' \
+        | $sed -e '/volumeClaimTemplates/{N;/  \- apiVersion.*$/ {N;/  kind.*$/ {N;/    metadata:$/{s/volumeClaimTemplates.*metadata:$/volumeClaimTemplates:\n  \- metadata:/}}}}'
         > ${new_result}
 
     diff -u ${expected_result} ${new_result}


### PR DESCRIPTION
[![CLOUD-556](https://badgen.net/badge/JIRA/CLOUD-556/green)](https://jira.percona.com/browse/CLOUD-556)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Kubernets 1.17 puts some extra fields into Statefulset about
pod volume claim. We do not expect them, thus need to get rid
of them

```
+ diff -u /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/init-deploy/compare/statefulset_some-name-pxc.yml /tmp/tmp.YUAO2Wdrs9/statefulset_some-name-pxc.yml
--- /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/init-deploy/compare/statefulset_some-name-pxc.yml	2020-07-02 06:19:52.000000000 +0000
+++ /tmp/tmp.YUAO2Wdrs9/statefulset_some-name-pxc.yml	2020-07-02 06:29:10.855373281 +0000
@@ -187,7 +187,9 @@
       partition: 0
     type: RollingUpdate
   volumeClaimTemplates:
-  - metadata:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
       name: datadir
     spec:
       accessModes:
```