### PR TITLE
K8SPXC-352 dont recreate cronjob on each reconcile loop

### DIFF
--- a/pkg/pxc/backup/names.go
+++ b/pkg/pxc/backup/names.go
@@ -1,27 +1,10 @@
 package backup
 
 import (
-	"math/rand"
 	"strings"
-	"time"
 
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
-const genSymbols = "abcdefghijklmnopqrstuvwxyz1234567890"
-
-func genRandString(ln int) string {
-	b := make([]byte, ln)
-	for i := range b {
-		b[i] = genSymbols[rand.Intn(len(genSymbols))]
-	}
-
-	return string(b)
-}
 
 func genScheduleLabel(sched string) string {
 	r := strings.NewReplacer("*", "N", "/", "E", " ", "_", ",", ".")

--- a/pkg/pxc/backup/scheduled.go
+++ b/pkg/pxc/backup/scheduled.go
@@ -2,6 +2,8 @@ package backup
 
 import (
 	"fmt"
+	"hash/crc32"
+	"strconv"
 
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -89,7 +91,7 @@ func (bcp *Backup) scheduledJob(spec *api.PXCScheduledBackupSchedule, strg *api.
 							},
 							{
 								Name:  "suffix",
-								Value: genRandString(5),
+								Value: strconv.FormatUint(uint64(crc32.ChecksumIEEE([]byte(spec.Schedule))), 32)[:5],
 							},
 						},
 						Args: []string{


### PR DESCRIPTION
[![K8SPXC-352](https://badgen.net/badge/JIRA/K8SPXC-352/green)](https://jira.percona.com/browse/K8SPXC-352)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

unique backup "suffix" is needed for reduce chance of
conflict between different backup CR names which can
be produced in the same second by two backup cronjobs.
unfortunately, "suffix" regenerated on each reconcile loop.