### PR TITLE
K8SPXC-353 haproxy-replicas service should forward from 3306 to 3307

### DIFF
--- a/pkg/pxc/service.go
+++ b/pkg/pxc/service.go
@@ -227,7 +227,7 @@ func NewServiceHAProxyReplicas(cr *api.PerconaXtraDBCluster) *corev1.Service {
 			Type: svcType,
 			Ports: []corev1.ServicePort{
 				{
-					Port:       3307,
+					Port:       3306,
 					TargetPort: intstr.FromInt(3307),
 					Name:       "mysql-replicas",
 				},


### PR DESCRIPTION
[![K8SPXC-353](https://badgen.net/badge/JIRA/K8SPXC-353/green)](https://jira.percona.com/browse/K8SPXC-353)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We have separate service for reading traffic which is automatically distributed between all PXC members.
it also should use default MySQL port for incoming traffic.