### PR TITLE
K8SPXC-360: keep HAProxy version during status update

### DIFF
--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -86,6 +86,7 @@ func (r *ReconcilePerconaXtraDBCluster) updateStatus(cr *api.PerconaXtraDBCluste
 		if err != nil {
 			return fmt.Errorf("get haproxy status: %v", err)
 		}
+		haProxyStatus.Version = cr.Status.HAProxy.Version
 
 		if haProxyStatus.Status != cr.Status.HAProxy.Status {
 			if haProxyStatus.Status == api.AppStateReady {


### PR DESCRIPTION
[![K8SPXC-360](https://badgen.net/badge/JIRA/K8SPXC-360/green)](https://jira.percona.com/browse/K8SPXC-360)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

HAProxy version received from version service and set only once, we should intentionally save it during status updates later