### PR TITLE
K8SPXC-355 Swap day/month in S3 backup date format

### DIFF
--- a/pkg/controller/pxcbackup/controller.go
+++ b/pkg/controller/pxcbackup/controller.go
@@ -174,7 +174,7 @@ func (r *ReconcilePerconaXtraDBClusterBackup) Reconcile(request reconcile.Reques
 			return reconcile.Result{}, fmt.Errorf("set storage FS: %v", err)
 		}
 	case api.BackupStorageS3:
-		destination = bcpStorage.S3.Bucket + "/" + instance.Spec.PXCCluster + "-" + instance.CreationTimestamp.Time.Format("2006-02-01-15:04:05") + "-full"
+		destination = bcpStorage.S3.Bucket + "/" + instance.Spec.PXCCluster + "-" + instance.CreationTimestamp.Time.Format("2006-01-02-15:04:05") + "-full"
 		if !strings.HasPrefix(bcpStorage.S3.Bucket, "s3://") {
 			destination = "s3://" + destination
 		}


### PR DESCRIPTION
[![K8SPXC-355](https://badgen.net/badge/JIRA/K8SPXC-355/green)](https://jira.percona.com/browse/K8SPXC-355)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

S3 backup folder names were getting generated with YYYY-DD-MM date format. Change to use conventional YYYY-MM-DD order.