### PR TITLE
K8SPXC-365 run version detection on image change if SmartUpdate disabled

### DIFF
--- a/pkg/controller/pxc/version.go
+++ b/pkg/controller/pxc/version.go
@@ -123,7 +123,6 @@ func (r *ReconcilePerconaXtraDBCluster) ensurePXCVersion(cr *api.PerconaXtraDBCl
 	}
 
 	if cr.Spec.Backup.Image != newVersion.BackupImage {
-		log.Info(fmt.Sprintf("update Backup image from '%s' to '%s'", cr.Status.Backup.Image, newVersion.BackupImage))
 		log.Info(fmt.Sprintf("update Backup version from %s to %s", cr.Status.Backup.Version, newVersion.BackupVersion))
 		cr.Spec.Backup.Image = newVersion.BackupImage
 	}
@@ -134,7 +133,6 @@ func (r *ReconcilePerconaXtraDBCluster) ensurePXCVersion(cr *api.PerconaXtraDBCl
 	}
 
 	if cr.Spec.ProxySQL != nil && cr.Spec.ProxySQL.Enabled && cr.Spec.ProxySQL.Image != newVersion.ProxySqlImage {
-		log.Info(fmt.Sprintf("update ProxySQL image from '%s' to '%s'", cr.Status.ProxySQL.Image, newVersion.ProxySqlImage))
 		log.Info(fmt.Sprintf("update ProxySQL version from %s to %s", cr.Status.ProxySQL.Version, newVersion.ProxySqlVersion))
 		cr.Spec.ProxySQL.Image = newVersion.ProxySqlImage
 	}


### PR DESCRIPTION
[![K8SPXC-365](https://badgen.net/badge/JIRA/K8SPXC-365/green)](https://jira.percona.com/browse/K8SPXC-365)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

we should refetch version information from PXC if the user manually changed the PXC image.
we should take the version from Version Service if SmartUpdate enabled