### PR TITLE
K8SPXC-366 Add possibility to clean up unused ns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,6 +102,7 @@ if ( env.CHANGE_URL ) {
 pipeline {
     environment {
         CLOUDSDK_CORE_DISABLE_PROMPTS = 1
+        CLEAN_NAMESPACE = 1
         GIT_SHORT_COMMIT = sh(script: 'git describe --always --dirty', , returnStdout: true).trim()
         VERSION = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}"
         CLUSTER_NAME = sh(script: "echo jenkins-pxc-${GIT_SHORT_COMMIT} | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -47,6 +47,10 @@ wait_cluster_consistency() {
 }
 
 create_namespace() {
+    if [ "${CLEAN_NAMESPACE}" == 1 ]; then
+        kubectl get ns | egrep -v "^kube-|^default|Terminating|^NAME" | awk '{print$1}' | xargs kubectl delete ns
+    fi
+
     local namespace="$1"
     if [ "$OPENSHIFT" == 1 ]; then
         oc delete project "$namespace" && sleep 40 || :


### PR DESCRIPTION
[![K8SPXC-366](https://badgen.net/badge/JIRA/K8SPXC-366/green)](https://jira.percona.com/browse/K8SPXC-366)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* if test fails then ns is not deleted automatically that is why
      we have the situation that gke cluster has a lot of old pods
      in namespaces which were used for failed tests