### PR TITLE
CLOUD-544 it is needed to disable version service in tests

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -505,7 +505,8 @@ cat_config() {
         | $sed -e "s#image:.*\/percona-xtradb-cluster:.*\$#image: $IMAGE_PXC#" \
         | $sed -e "s#image:.*-pmm\$#image: $IMAGE_PMM#" \
         | $sed -e "s#image:.*-backup\$#image: $IMAGE_BACKUP#" \
-        | $sed -e "s#image:.*-proxysql\$#image: $IMAGE_PROXY#"
+        | $sed -e "s#image:.*-proxysql\$#image: $IMAGE_PROXY#" \
+        | $sed -e "s#apply:.*#apply: Never#"
 }
 
 apply_config() {


### PR DESCRIPTION
[![CLOUD-544](https://badgen.net/badge/JIRA/CLOUD-544/green)](https://jira.percona.com/browse/CLOUD-544)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

reason: we should test images which are specified in tests,
not images which are fetched from version service.