### PR TITLE
K8SPXC-274 force mysql_upgrade if version upgrade is detected

### DIFF
--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -401,7 +401,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			exit 1
 		fi
 
-		mysql_upgrade "${mysql[@]:1}"
+		mysql_upgrade --force "${mysql[@]:1}"
 		if ! kill -s TERM "$pid" || ! wait "$pid"; then
 			echo >&2 'MySQL init process failed.'
 			exit 1


### PR DESCRIPTION
[![K8SPXC-274](https://badgen.net/badge/JIRA/K8SPXC-274/green)](https://jira.percona.com/browse/K8SPXC-274)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

during each Pod start, we store MySQL version into version_info file
after that during the next Pod started we able to compare the current
MySQL version with the version stored in version_info
if version changed we run mysql_upgrade tool, it works fine if any
changes needed. but fails if MySQL changes not needed.