### PR TITLE
K8SPXC-356 Fix security-context test on EKS

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -207,6 +207,7 @@ compare_kubectl() {
         | $sed -e '/name: suffix/,+1d' \
         | $sed -e '/name: S3_BUCKET_PATH/,+1d' \
         | $sed -e '/name: S3_BUCKET_URL/,+1d' \
+        | $sed -e '/annotations:$/{N;N;s/annotations:\n    kubernetes.io.*\n    \(openshift.io.*\)/annotations:\n    \1/}' \
         | $sed -e '/annotations:$/{$!{N;s/annotations:\n    kubernetes.io.*//;ty;P;D;:y;d}}' \
         | $sed -e '/annotations:$/{$!{N;s/annotations:\n    cni.projectcalico.org.*//;ty;P;D;:y;d}}' \
         | $sed -e '/volumeClaimTemplates:$/{N;/  \- apiVersion.*$/ {N;/  kind.*$/ {N;/    metadata:$/{s/volumeClaimTemplates.*metadata:$/volumeClaimTemplates:\n  \- metadata:/}}}}' \


### PR DESCRIPTION
[![K8SPXC-356](https://badgen.net/badge/JIRA/K8SPXC-356/green)](https://jira.percona.com/browse/K8SPXC-356)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

In EKS restore pod could have definition like this:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubernetes.io/psp: eks.privileged
    openshift.io/scc: privileged
```
and it was failing like this:
```
+ diff -u /vagrant/production/percona-xtradb-cluster-operator/e2e-tests/security-context/compare/job.batch_sec-context-xb-on-demand-backup-pvc.yml /tmp/tmp.eXeMfonXII/job.batch_sec-context-xb-on-demand-backup-pvc.yml
--- /vagrant/production/percona-xtradb-cluster-operator/e2e-tests/security-context/compare/job.batch_sec-context-xb-on-demand-backup-pvc.yml  2020-06-23 07:27:54.000000000 +0000
+++ /tmp/tmp.eXeMfonXII/job.batch_sec-context-xb-on-demand-backup-pvc.yml 2020-07-20 08:30:25.966218104 +0000
@@ -1,8 +1,6 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    openshift.io/scc: privileged
   labels:
     cluster: sec-context
     job-name: sec-context-xb-on-demand-backup-pvc
```
so we need to remove the kubernetes.io row and leave the openshift.io one untouched together with annotations.
This was noticed during the release so using the release ticket.
Here's the run on EKS: https://cloud.cd.percona.com/job/pxc-operator-eks/68/