### PR TITLE
K8SPXC-390 - Fix PXC-Operator pod crashing on missing HAProxy PodDisruptionBudget

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -581,7 +581,7 @@ func (r *ReconcilePerconaXtraDBCluster) deploy(cr *api.PerconaXtraDBCluster) err
 		// PodDisruptionBudget object for HAProxy
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: haProxySet.Name, Namespace: haProxySet.Namespace}, haProxySet)
 		if err == nil {
-			err := r.reconcilePDB(cr.Spec.ProxySQL.PodDisruptionBudget, sfsHAProxy, cr.Namespace, haProxySet)
+			err := r.reconcilePDB(cr.Spec.HAProxy.PodDisruptionBudget, sfsHAProxy, cr.Namespace, haProxySet)
 			if err != nil {
 				return fmt.Errorf("PodDisruptionBudget for %s: %v", haProxySet.Name, err)
 			}


### PR DESCRIPTION
[![K8SPXC-390](https://badgen.net/badge/JIRA/K8SPXC-390/green)](https://jira.percona.com/browse/K8SPXC-390)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

On Percona's recommendation we're switching our PXC-Operator managed
clusters from proxysql to HAProxy to front our clusters. For the
record we're using version 1.5.0 of the Percoan XtraDB Cluster
Operator.

With an HAProxy spec that matches the example here:

https://github.com/percona/percona-xtradb-cluster-operator/blob/1cc77802b559a4baa947bfa0b377a4d2a0858b31/deploy/cr.yaml#L93-L174

the percona-xtradb-cluster-operator pod fails to start indicating that
the pxc controller can't parse the HAProxy spec

```
...
{"level":"info","ts":1596064927.2384582,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"perconaxtradbclusterrestore-controller","worker count":1}
E0729 23:22:07.952718       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 613 [running:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x147a140, 0x2300e70)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x147a140, 0x2300e70)
    /usr/local/go/src/runtime/panic.go:969 +0x166
github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc.(*ReconcilePerconaXtraDBCluster).deploy(0xc0007b8be0, 0xc000426c00, 0x0, 0x0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:584 +0x3266
github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc.(*ReconcilePerconaXtraDBCluster).Reconcile(0xc0007b8be0, 0xc000882610, 0xc, 0xc000882600, 0x6, 0x0, 0x0, 0x0, 0x0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:242 +0x15e3
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002500c0, 0x14cd480, 0xc000ba0420, 0x0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256 +0x161
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0002500c0, 0xc000636700)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232 +0xae
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0002500c0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc00067e900)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5f
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00067e900, 0x3b9aca00, 0x0, 0x1, 0xc0001d0120)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc00067e900, 0x3b9aca00, 0xc0001d0120)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:193 +0x305
panic: runtime error: invalid memory address or nil pointer dereference [recovered
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xa0 pc=0x13265a6]
goroutine 613 [running:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x105
panic(0x147a140, 0x2300e70)
    /usr/local/go/src/runtime/panic.go:969 +0x166
github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc.(*ReconcilePerconaXtraDBCluster).deploy(0xc0007b8be0, 0xc000426c00, 0x0, 0x0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:584 +0x3266
github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc.(*ReconcilePerconaXtraDBCluster).Reconcile(0xc0007b8be0, 0xc000882610, 0xc, 0xc000882600, 0x6, 0x0, 0x0, 0x0, 0x0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:242 +0x15e3
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0002500c0, 0x14cd480, 0xc000ba0420, 0x0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256 +0x161
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0002500c0, 0xc000636700)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232 +0xae
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0002500c0)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc00067e900)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5f
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00067e900, 0x3b9aca00, 0x0, 0x1, 0xc0001d0120)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc00067e900, 0x3b9aca00, 0xc0001d0120)
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
    /go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:193 +0x305
stream closed
```

I believe the interesting bit of this stack is:

```
/go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:584
```

On this line it appears the controller is trying to load the pod
disruption budget for the HAProxy resource:

https://github.com/percona/percona-xtradb-cluster-operator/blob/v1.5.0/pkg/controller/pxc/controller.go#L584

```go
err := r.reconcilePDB(cr.Spec.ProxySQL.PodDisruptionBudget, sfsHAProxy, cr.Namespace, haProxySet)
```

However if you look closely, the controller is actually looking for
the HAProxy pod disruption budget in the ProxySQL struct.

As a temporary workaround we've modified our custom resource so that
we provide the HAProxy pod disruption budget under a ProxySQL spec as
the controller implementation expects. It looks something like the
following:

```yaml
spec:
  ...
  pxc:
    size: 3
    image: percona/percona-xtradb-cluster:5.7.30-31.43
    ...
    podDisruptionBudget:
      maxUnavailable: 1
    volumeSpec:
      emptyDir: {}
    gracePeriod: 600
  haproxy:
    enabled: true
    size: 3
    image: percona/percona-xtradb-cluster-operator:1.5.0-haproxy
    ....
  proxysql:
    podDisruptionBudget:
      maxUnavailable: 1
    gracePeriod: 30
```

This state of the spec satisfies the pxc controller and stops the
crash-looping, however the REAL fix seems to be to alter the PXC
controller to lookup the pod disruption budget in the correct struct.

References
----------

- https://percona.service-now.com/percona?id=percona_ticket&table=sn_customerservice_case&sys_id=b29103eb1bd11050ff8499b4bd4bcb33