### PR TITLE
K8SPSMDB-234 GKE version upgrade

### DIFF
--- a/source/System-Requirements.rst
+++ b/source/System-Requirements.rst
@@ -15,8 +15,8 @@ The following platforms are supported:
 
 * OpenShift 3.11
 * OpenShift 4.2
-* Google Kubernetes Engine (GKE) 1.13
-* GKE 1.15
+* Google Kubernetes Engine (GKE) 1.15
+* GKE 1.17
 * Amazon Elastic Kubernetes Service (EKS) 1.15
 * Minikube 1.16
 


### PR DESCRIPTION
[![K8SPSMDB-234](https://badgen.net/badge/JIRA/K8SPSMDB-234/green)](https://jira.percona.com/browse/K8SPSMDB-234)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Since 1.14 is no longer available in stable channel
versions have to be updated