### PR TITLE
dns lookup should use the headless svc  to get the pod behind the sts

### DIFF
--- a/pkg/pxc/app/statefulset/haproxy.go
+++ b/pkg/pxc/app/statefulset/haproxy.go
@@ -144,7 +144,7 @@ func (c *HAProxy) SidecarContainers(spec *api.PodSpec, secrets string, cr *api.P
 		Env: []corev1.EnvVar{
 			{
 				Name:  "PXC_SERVICE",
-				Value: c.labels["app.kubernetes.io/instance"] + "-" + "pxc",
+				Value: c.labels["app.kubernetes.io/instance"] + "-" + "pxc-unready",
 			},
 			{
 				Name: "MONITOR_PASSWORD",

--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -148,7 +148,7 @@ func (c *Proxy) SidecarContainers(spec *api.PodSpec, secrets string, cr *api.Per
 		Env: []corev1.EnvVar{
 			{
 				Name:  "PXC_SERVICE",
-				Value: c.labels["app.kubernetes.io/instance"] + "-pxc",
+				Value: c.labels["app.kubernetes.io/instance"] + "-pxc-unready",
 			},
 			{
 				Name: "MYSQL_ROOT_PASSWORD",


### PR DESCRIPTION
[![K8SPXC-433](https://badgen.net/badge/JIRA/K8SPXC-433/green)](https://jira.percona.com/browse/K8SPXC-433)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now, the svc use the clusterip service.
In the proxysql mode, the dns in the peerlist for the script is cluserter-pxc.{namespace}.svc.cluster.local, and the script cut the first word with spliter '.'， so the dns is cut as  {namespace}.svc.cluster.local, which is not valid in the k8s. And the same problem in haproxy mode.  
In this pr, use headless service. the peerlist dns is like '10-199-0-159.cluster2-pxc-unready.zlc.svc.cluster.local'

[K8SPXC-433](https://jira.percona.com/browse/K8SPXC-433?filter=-2)