### PR TITLE
K8SPXC-406 - fix wsrep_sst_donor option

### DIFF
--- a/build/pxc-configure-pxc.sh
+++ b/build/pxc-configure-pxc.sh
@@ -56,7 +56,7 @@ while read -ra LINE; do
 done
 
 if [ "${#PEERS[@]}" != 0 ]; then
-    DONOR_ADDRESS="$(printf '%s\n' "${PEERS[@]}" "${HOSTNAME}" | sort --version-sort | uniq | grep -v -- '-0$' | sed '$d' | tr '\n' ',' | sed 's/,$//')"
+    DONOR_ADDRESS="$(printf '%s\n' "${PEERS[@]}" "${HOSTNAME}" | sort --version-sort | uniq | grep -v -- '-0$' | sed '$d' | tr '\n' ',' | sed 's/^,$//')"
 fi
 if [ "${#PEERS_FULL[@]}" != 0 ]; then
     WSREP_CLUSTER_ADDRESS="$(printf '%s\n' "${PEERS_FULL[@]}" | sort --version-sort | tr '\n' ',' | sed 's/,$//')"


### PR DESCRIPTION
[![K8SPXC-406](https://badgen.net/badge/JIRA/K8SPXC-406/green)](https://jira.percona.com/browse/K8SPXC-406)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This fixes K8SPXC-406 by not deleting the final comma in the line (which is important because if our recommendations for donors fails then we let galera choose any donor). The comma will be removed only in case if it's the only thing in the line for some reason.

Didn't delete adding the HOSTNAME variable in the end because in 3 node cluster on node-2 (highest) the variable would end up empty since it would delete node-0 and node-1.

In current state for K8SPXC-406 node-1 would end up like wsrep_sst_donor=cluster1-pxc-1, (the comma will not be deleted) - which means the node will not be able to do SST to itself so it will try any other node - since in this case we are not sure which one is writer we will just leave it to galera to pick some.
And node-0 and node-2 will always try to pick node-1 as donor and if it fails galera will pick any other in the cluster.

Here's how it looks in different node sizes:
**1 node cluster**
```
$ kubectl exec -ti cluster1-pxc-0 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=
```
this variable is always empty in one node cluster and is not important since one node cannot give sst to itself anyway.

**3 node cluster**
```
# initial rollout
$ kubectl exec -ti cluster1-pxc-0 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=
$ kubectl exec -ti cluster1-pxc-1 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=
$ kubectl exec -ti cluster1-pxc-2 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=cluster1-pxc-1,

# add data and delete one by one node
# node 1 data deleted and pod deleted, status after re-init and SST done
$ kubectl exec -ti cluster1-pxc-0 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=cluster1-pxc-1,

$ kubectl logs cluster1-pxc-0 | grep "transfer from"
2020-09-12T16:56:39.921409Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-0) requested state transfer from 'cluster1-pxc-1,'. Selected 1.0 (cluster1-pxc-1)(SYNCED) as donor.
2020-09-12T16:57:14.150067Z 0 [Note] [MY-000000] [Galera] 2.0 (cluster1-pxc-0): State transfer from 1.0 (cluster1-pxc-1) complete.

# node 2 data deleted and pod deleted, status after re-init and SST done
$ kubectl exec -ti cluster1-pxc-1 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=cluster1-pxc-1,

$ kubectl logs cluster1-pxc-1 | grep "transfer from"
2020-09-12T16:59:02.743935Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-1) requested state transfer from 'cluster1-pxc-1,'. Selected 0.0 (cluster1-pxc-2)(SYNCED) as donor.
2020-09-12T16:59:37.182536Z 0 [Note] [MY-000000] [Galera] 1.0 (cluster1-pxc-1): State transfer from 0.0 (cluster1-pxc-2) complete.

# node 3 data deleted and pod deleted, status after re-init and SST done
$ kubectl exec -ti cluster1-pxc-2 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=cluster1-pxc-1,

$ kubectl logs cluster1-pxc-2 | grep "transfer from"
2020-09-12T17:01:43.015937Z 0 [Note] [MY-000000] [Galera] Member 1.0 (cluster1-pxc-2) requested state transfer from 'cluster1-pxc-1,'. Selected 0.0 (cluster1-pxc-1)(SYNCED) as donor.
2020-09-12T17:02:15.799350Z 0 [Note] [MY-000000] [Galera] 1.0 (cluster1-pxc-2): State transfer from 0.0 (cluster1-pxc-1) complete.
```

**5 node cluster**
```
# initial rollout
$ kubectl exec -ti cluster1-pxc-0 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=
$ kubectl exec -ti cluster1-pxc-1 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=
$ kubectl exec -ti cluster1-pxc-2 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=cluster1-pxc-1,
$ kubectl exec -ti cluster1-pxc-3 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=cluster1-pxc-1,cluster1-pxc-2,
$ kubectl exec -ti cluster1-pxc-4 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=cluster1-pxc-1,cluster1-pxc-2,cluster1-pxc-3,

# node 1 delete and rebuild
$ kubectl exec -ti cluster1-pxc-0 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=cluster1-pxc-1,cluster1-pxc-2,cluster1-pxc-3,

$ kubectl logs cluster1-pxc-0 | grep "transfer from"
2020-09-12T17:21:31.756200Z 0 [Note] [MY-000000] [Galera] Member 2.0 (cluster1-pxc-0) requested state transfer from 'cluster1-pxc-1,cluster1-pxc-2,cluster1-pxc-3,'. Selected 0.0 (cluster1-pxc-1)(SYNCED) as donor.
2020-09-12T17:22:04.794947Z 0 [Note] [MY-000000] [Galera] 2.0 (cluster1-pxc-0): State transfer from 0.0 (cluster1-pxc-1) complete.

# node 2 delete and rebuild
$ kubectl exec -ti cluster1-pxc-1 -- cat /etc/mysql/node.cnf | grep "wsrep_sst_donor"
wsrep_sst_donor=cluster1-pxc-1,cluster1-pxc-2,cluster1-pxc-3,

$ kubectl logs cluster1-pxc-1 | grep "transfer from"
2020-09-12T17:25:25.230345Z 0 [Note] [MY-000000] [Galera] Member 4.0 (cluster1-pxc-1) requested state transfer from 'cluster1-pxc-1,cluster1-pxc-2,cluster1-pxc-3,'. Selected 0.0 (cluster1-pxc-2)(SYNCED) as donor.
2020-09-12T17:25:59.155035Z 0 [Note] [MY-000000] [Galera] 4.0 (cluster1-pxc-1): State transfer from 0.0 (cluster1-pxc-2) complete.
```