### PR TITLE
Improve smart-update limit logic

### DIFF
--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -444,6 +444,10 @@ func (r *ReconcilePerconaXtraDBCluster) waitPodRestart(updateRevision string, po
 				}
 			}
 
+			if pod.Status.Phase == corev1.PodFailed {
+				return errors.Errorf("pod %s is in failed phase", pod.Name)
+			}
+
 			if pod.Status.Phase == corev1.PodRunning && pod.ObjectMeta.Labels["controller-revision-hash"] == updateRevision && ready {
 				log.Info(fmt.Sprintf("pod %s is running", pod.Name))
 				return true, nil


### PR DESCRIPTION
This PR fixes limit logic.
Previous implementation count timeout as 
```pseudocode
for i from 0 to waitLimit {
    sleep 1 second
    ok = doSomeWork...
    if ok {
       break
    }
}
```
There a 2 problems I see:
1. doSomeWork takes some time, but it does not counted as a time. So if time limit is 5 min this function will take `5 min` + `time to doSomeWork`*`count of iterations`
2. sleep 1 second. It's not proper to send request to PXC every second if previous call was unsuccessful.

In current implementation timeout is fair. In worst case it will take `waitLimit` + 10 sec