### PR TITLE
Fix install of peer-list

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -34,7 +34,7 @@ LABEL name="Percona XtraDB Cluster Operator" \
 
 COPY LICENSE /licenses/
 COPY --from=go_builder /usr/local/bin/percona-xtradb-cluster-operator /usr/local/bin/percona-xtradb-cluster-operator
-COPY --from=go_builder /usr/local/bin/peer-list /usr/local/bin/peer-list
+COPY --from=go_builder /usr/local/bin/peer-list /peer-list
 COPY build/pxc-entrypoint.sh /pxc-entrypoint.sh
 COPY build/pxc-init-entrypoint.sh /pxc-init-entrypoint.sh
 COPY build/unsafe-bootstrap.sh /unsafe-bootstrap.sh

--- a/build/pxc-init-entrypoint.sh
+++ b/build/pxc-init-entrypoint.sh
@@ -8,4 +8,4 @@ install -o "$(id -u)" -g "$(id -g)" -m 0755 -D /unsafe-bootstrap.sh /var/lib/mys
 install -o "$(id -u)" -g "$(id -g)" -m 0755 -D /pxc-configure-pxc.sh /var/lib/mysql/pxc-configure-pxc.sh
 install -o "$(id -u)" -g "$(id -g)" -m 0755 -D /liveness-check.sh /var/lib/mysql/liveness-check.sh
 install -o "$(id -u)" -g "$(id -g)" -m 0755 -D /readiness-check.sh /var/lib/mysql/readiness-check.sh
-install -o "$(id -u)" -g "$(id -g)" -m 0755 -D /usr/local/bin/peer-list /usr/local/bin/peer-list
+install -o "$(id -u)" -g "$(id -g)" -m 0755 -D /peer-list /usr/local/bin/peer-list


### PR DESCRIPTION
PXC pods container pxc-init is failing like below, but it is already added in the Dockerfile into the same location:
```
++ id -u
++ id -g
+ install -o 99 -g 99 -m 0755 -D /pxc-entrypoint.sh /var/lib/mysql/pxc-entrypoint.sh
++ id -u
++ id -g
+ install -o 99 -g 99 -m 0755 -D /unsafe-bootstrap.sh /var/lib/mysql/unsafe-bootstrap.sh
++ id -u
++ id -g
+ install -o 99 -g 99 -m 0755 -D /pxc-configure-pxc.sh /var/lib/mysql/pxc-configure-pxc.sh
++ id -u
++ id -g
+ install -o 99 -g 99 -m 0755 -D /liveness-check.sh /var/lib/mysql/liveness-check.sh
++ id -u
++ id -g
+ install -o 99 -g 99 -m 0755 -D /readiness-check.sh /var/lib/mysql/readiness-check.sh
++ id -u
++ id -g
+ install -o 99 -g 99 -m 0755 -D /usr/local/bin/peer-list /usr/local/bin/peer-list
install: '/usr/local/bin/peer-list' and '/usr/local/bin/peer-list' are the same file
```