### PR TITLE
K8SPXC-461 rework the doc about certified images

### DIFF
--- a/source/custom-registry.rst
+++ b/source/custom-registry.rst
@@ -61,6 +61,9 @@ in the OpenShift environment.
       Digest: sha256:841c07eef30605080bfe80e549f9332ab6b9755fcbc42aacbf86e4ac9ef0e444
       Status: Image is up to date for docker.io/perconalab/percona-xtradb-cluster-operator@sha256:841c07eef30605080bfe80e549f9332ab6b9755fcbc42aacbf86e4ac9ef0e444
 
+   You can find correct names and SHA digests in the
+   :ref:`current list of the Operator-related images officially certified by Percona<custom-registry-images>`.
+
 5. The following way is used to push an image to the custom registry
    (into the OpenShift pxc project):
 
@@ -93,99 +96,3 @@ in the OpenShift environment.
 
 9. Now follow the standard `Percona XtraDB Cluster Operator installation
    instruction <./openshift>`__.
-
-.. _custom-registry-images:
-
-Percona certified images
-------------------------
-
-Following table presents Percona’s certified images to be used with the
-Percona XtraDB Cluster Operator:
-
-
-      .. list-table::
-         :widths: 15 50
-         :header-rows: 1
-
-         * - Image
-           - Digest
-         * - percona/percona-xtradb-cluster-operator:1.5.0
-           - 99c551f5437ed5f2fe004877c15a4665260969d0923f7c95fbf7a4c9e7305bb1
-         * - percona/percona-xtradb-cluster-operator:1.5.0-haproxy
-           - 6978a9a4a49515fd8be713312221ab72729a220c180663c5bfdd5bd6d3317504
-         * - percona/percona-xtradb-cluster-operator:1.5.0-proxysql
-           - 629f344e6d6b4e2cec95a461cfcba7f48759bb742182c4ebff453707aba77b6b
-         * - percona/percona-xtradb-cluster-operator:1.5.0-pxc8.0-backup
-           - 7cddeedaa90ec9ba529340e34ee5662c9485139b2b197fc0abdbb6c261a14f62
-         * - percona/percona-xtradb-cluster-operator:1.5.0-pxc5.7-backup
-           - 6191dd4f7b8678d69dea9a87e083becfbba1a633ef725a0513babd55e5ac76f3
-         * - percona/percona-xtradb-cluster-operator:1.5.0-pmm
-           - 28bbb6693689a15c407c85053755334cd25d864e632ef7fed890bc85726cfb68
-         * - percona/percona-xtradb-cluster:8.0.19-10.1-debug
-           - de50c66ac39186b24048823aac59a1684b72e0199e3e6dccc4b6e4ce27a4a123
-         * - percona/percona-xtradb-cluster:8.0.19-10.1
-           - 1058ae8eded735ebdf664807aad7187942fc9a1170b3fd0369574cb61206b63a
-         * - percona/percona-xtradb-cluster:5.7.30-31.43-debug
-           - de784e3442b0ad8ca1fbcf5b031180a76e25d77bc52d9456effc8cf2873c32b4
-         * - percona/percona-xtradb-cluster:5.7.30-31.43
-           - b03a060e9261b37288a2153c78f86dcfc53367c36e1bcdcae046dd2d0b0721af
-         * - percona/percona-xtradb-cluster:5.7.29-31.43
-           - 85fb479de073770280ae601cf3ec22dc5c8cca4c8b0dc893b09503767338e6f9
-         * - percona/percona-xtradb-cluster:5.7.28-31.41.2
-           - fccd6525aaeedb5e436e9534e2a63aebcf743c043526dd05dba8519ebddc8b30
-         * - percona/percona-xtradb-cluster:5.7.27-31.39
-           - 7d8eb4d2031c32c6e96451655f359d8e5e8e047dc95bada9a28c41c158876c26
-         * - percona/percona-xtradb-cluster:5.7.26-31.37
-           - 9d43d8e435e4aca5c694f726cc736667cb938158635c5f01a0e9412905f1327f
-         * - percona/percona-xtradb-cluster-operator:1.4.0
-           - 277d62967e94dc4e7d0569656413967e6a8597842753da05f083543e68c9b719
-         * - percona/percona-xtradb-cluster-operator:1.4.0-proxysql
-           - 1ee8b9c291dac955dd98441187476fe8c3b5a4930e9e4dc39b9534376d0cc4f2
-         * - percona/percona-xtradb-cluster-operator:1.4.0-pxc8.0
-           - 58296417cc97378b906e12855cb1f4f2420f06168d2096acc08a93c8afa793f6
-         * - percona/percona-xtradb-cluster-operator:1.4.0-pxc8.0-backup
-           - 566ea1f6cf9387a06898d5f7af15189ed577d3af771d5954b2e869593b80cb6b
-         * - percona/percona-xtradb-cluster-operator:1.4.0-pxc5.7
-           - 4ff39dab7872a4b45250ca170604f6bce1fcc52510407f6cbd93cd81f5a32d8f
-         * - percona/percona-xtradb-cluster-operator:1.4.0-pxc5.7-backup
-           - ca8e3fd49d3a2ac15c0b9c44f8ea4e0f8240789de274859a91ec9cd8d8e80763
-         * - percona/percona-xtradb-cluster-operator:1.4.0-pmm
-           - 28bbb6693689a15c407c85053755334cd25d864e632ef7fed890bc85726cfb68
-         * - percona/percona-xtradb-cluster-operator:1.3.0
-           - 85cfaf78394e21b722be92015912c39e483f7ae5de1aab114293520a3825eb99
-         * - percona/percona-xtradb-cluster-operator:1.3.0-proxysql
-           - 8e40dec83008894aaa438f31233acb90f29969ad660cce26b700075eeaf9d34b
-         * - percona/percona-xtradb-cluster-operator:1.3.0-pxc
-           - a7d04c0a343fd0b7f08a306bb9f00b6df2f398bb7163990ba787f037c294853e
-         * - percona/percona-xtradb-cluster-operator:1.3.0-backup
-           - f786d92d96c5036df1785647d323081235c06fad56653ca93ae44af85c2d19e8
-         * - percona/percona-xtradb-cluster-operator:1.3.0-pmm
-           - 28bbb6693689a15c407c85053755334cd25d864e632ef7fed890bc85726cfb68
-         * - percona/percona-xtradb-cluster-operator:1.2.0
-           - 841c07eef30605080bfe80e549f9332ab6b9755fcbc42aacbf86e4ac9ef0e444
-         * - percona/percona-xtradb-cluster-operator:1.2.0-pxc
-           - d38482fcbe0d0f169e41eefd889404e967e8abc65a6890cbab4dd1f3ea2229df
-         * - percona/percona-xtradb-cluster-operator:1.2.0-proxysql
-           - 1385b77d3498cebc201426821fda620e0884e8fdaba6756240c9821948864af3
-         * - percona/percona-xtradb-cluster-operator:1.2.0-backup
-           - bd45486507321de67ff8ad2fa40c4f55fc20bd15db6369b61c73a5db11bb57cd
-         * - percona/percona-xtradb-cluster-operator:1.2.0-broker
-           - c0903f41539767fcfe49da815e1c3bfefe4e48a36912b64fb5350b09b51cab32
-         * - percona/percona-xtradb-cluster-operator:1.2.0-pmm
-           - 28bbb6693689a15c407c85053755334cd25d864e632ef7fed890bc85726cfb68
-         * - percona/percona-xtradb-cluster-operator:1.1.0
-           - fbfc2fc5c3afc80f18dddc5a1c3439fab89950081cf86c3439a226d4c97198eb
-         * - percona/percona-xtradb-cluster-operator:1.1.0-pxc
-           - a66a9212760e823af3c666a78e4b480cc7cc0d8be5cfa29c8141319c0036706e
-         * - percona/percona-xtradb-cluster-operator:1.1.0-proxysql
-           - ac952afb3721eafe86431155da7c3f7f90c4e800491c400a4222b650fd393357
-         * - percona/percona-xtradb-cluster-operator:1.1.0-backup
-           - 4852da039dd2a1d3ae9243ec634c14fd9f9e5af18a1fc6c7c9d25d4287dd6941
-         * - percona/percona-xtradb-cluster-operator:1.0.0
-           - b9e97c66a69f448898f8d43b92dd0314aaf53997b70824056dd3d0aec62488eb
-         * - percona/percona-xtradb-cluster-operator:1.0.0-pxc
-           - 6797c8492cff8092b39cdce75d7d85b9c2d4d08c4f6e0ba7b05c21562a54f168
-         * - percona/percona-xtradb-cluster-operator:1.0.0-proxysql
-           - b9360f1a8dc1e57e5ae7442373df02869ddc4da69ef9190190edde70b465235e
-         * - percona/percona-xtradb-cluster-operator:1.0.0-backup
-           - 652be455c8faf2d610de15e3568ff57fe8630fa353b6d97ff1c6b91d44741f8b

--- a/source/debug.rst
+++ b/source/debug.rst
@@ -3,25 +3,29 @@
 Debug
 =================
 
-For the cases when Pods are failing for some reason or just show abnormal behavior, 
-the Operator can be used with a special *debug image* of the Percona XtraDB Cluster,
-which has the following specifics:
+For the cases when Pods are failing for some reason or just show abnormal
+behavior, the Operator can be used with a special *debug images*. Percona XtraDB
+Cluster debug image has the following specifics:
 
 * it avoids restarting on fail,
 * it contains additional tools useful for debugging (sudo, telnet, gdb, etc.),
 * it has debug mode enabled for the logs.
 
-Particularly, using this image is useful if the container entry point fails
-(``mysqld`` crashes). In such a situation, Pod is continuously restarting.
+There are debug versions for all :ref:`Percona certified images<custom-registry-images>`: they have same names as normal images with a special ``-debug`` suffix in their version tag: for example, ``percona-xtradb-cluster-operator:{{{release}}}-debug``.
+
+Particularly, using such image is useful if the container entry point fails
+(e.g. ``mysqld`` crashes). In such a situation, Pod is continuously restarting.
 Continuous restarts prevent to get console access to the container,
 and so a special approach is needed to make fixes.
 
-To use the *debug* image instead of the normal one, find the needed image name
+To use the debug image instead of the normal one, find the needed image name
 :ref:`in the list of certified images<custom-registry-images>` and set it
-for the ``pxc.image`` key in the ``deploy/cr.yaml`` configuration file, e.g.:
+for the proper key in the ``deploy/cr.yaml`` configuration file. For example,
+set the following value of the ``pxc.image`` key to use the Percona XtraDB
+Cluster debug image:
 
-* ``percona/percona-xtradb-cluster:{{{pxc80recommended}}}-debug`` for PXC 8.0,
-* ``percona/percona-xtradb-cluster:{{{pxc57recommended}}}-debug`` for PXC 5.7.
+* ``percona/percona-xtradb-cluster:{{{pxc80recommended}}}-debug`` for Percona XtraDB Cluster 8.0,
+* ``percona/percona-xtradb-cluster:{{{pxc57recommended}}}-debug`` for Percona XtraDB Cluster 5.7.
 
 The Pod should be restarted to get the new image.
 

--- a/source/images.rst
+++ b/source/images.rst
@@ -1,0 +1,40 @@
+.. _custom-registry-images:
+
+Percona certified images
+------------------------
+
+Following table presents Percona’s certified docker images to be used with the
+Percona XtraDB Cluster Operator:
+
+
+      .. list-table::
+         :widths: 15 50
+         :header-rows: 1
+
+         * - Image
+           - Digest
+         * - percona/percona-xtradb-cluster-operator:1.5.0
+           - 99c551f5437ed5f2fe004877c15a4665260969d0923f7c95fbf7a4c9e7305bb1
+         * - percona/percona-xtradb-cluster-operator:1.5.0-haproxy
+           - 6978a9a4a49515fd8be713312221ab72729a220c180663c5bfdd5bd6d3317504
+         * - percona/percona-xtradb-cluster-operator:1.5.0-proxysql
+           - 629f344e6d6b4e2cec95a461cfcba7f48759bb742182c4ebff453707aba77b6b
+         * - percona/percona-xtradb-cluster-operator:1.5.0-pxc8.0-backup
+           - 7cddeedaa90ec9ba529340e34ee5662c9485139b2b197fc0abdbb6c261a14f62
+         * - percona/percona-xtradb-cluster-operator:1.5.0-pxc5.7-backup
+           - 6191dd4f7b8678d69dea9a87e083becfbba1a633ef725a0513babd55e5ac76f3
+         * - percona/percona-xtradb-cluster-operator:1.5.0-pmm
+           - 28bbb6693689a15c407c85053755334cd25d864e632ef7fed890bc85726cfb68
+         * - percona/percona-xtradb-cluster:8.0.19-10.1
+           - 1058ae8eded735ebdf664807aad7187942fc9a1170b3fd0369574cb61206b63a
+         * - percona/percona-xtradb-cluster:5.7.30-31.43
+           - b03a060e9261b37288a2153c78f86dcfc53367c36e1bcdcae046dd2d0b0721af
+         * - percona/percona-xtradb-cluster:5.7.29-31.43
+           - 85fb479de073770280ae601cf3ec22dc5c8cca4c8b0dc893b09503767338e6f9
+         * - percona/percona-xtradb-cluster:5.7.28-31.41.2
+           - fccd6525aaeedb5e436e9534e2a63aebcf743c043526dd05dba8519ebddc8b30
+         * - percona/percona-xtradb-cluster:5.7.27-31.39
+           - 7d8eb4d2031c32c6e96451655f359d8e5e8e047dc95bada9a28c41c158876c26
+         * - percona/percona-xtradb-cluster:5.7.26-31.37
+           - 9d43d8e435e4aca5c694f726cc736667cb938158635c5f01a0e9412905f1327f
+

--- a/source/index.rst
+++ b/source/index.rst
@@ -81,5 +81,6 @@ Reference
    :maxdepth: 1
 
    operator
+   images
    api
    Release Notes <ReleaseNotes/index>


### PR DESCRIPTION
[![K8SPXC-461](https://badgen.net/badge/JIRA/K8SPXC-461/green)](https://jira.percona.com/browse/K8SPXC-461)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Images and digests moved to a separate doc; debug doc now mentions there are debug versions for all images and not only for pxc ones. Also, only current images are listed.