### PR TITLE
K8SPXC-464 add 'pc.weight' option

### DIFF
--- a/build/pxc-configure-pxc.sh
+++ b/build/pxc-configure-pxc.sh
@@ -75,6 +75,7 @@ fi
 
 egrep -q "^[#]?wsrep_sst_donor" "$CFG" || sed '/^\[mysqld\]/a wsrep_sst_donor=\n' ${CFG} 1<> ${CFG}
 egrep -q "^[#]?wsrep_node_incoming_address" "$CFG" || sed '/^\[mysqld\]/a wsrep_node_incoming_address=\n' ${CFG} 1<> ${CFG}
+egrep -q "^[#]?wsrep_provider_options" "$CFG" || sed '/^\[mysqld\]/a wsrep_provider_options="pc.weight=10"\n' ${CFG} 1<> ${CFG}
 sed -r "s|^[#]?server_id=.*$|server_id=1${SERVER_ID}|" ${CFG} 1<> ${CFG}
 sed -r "s|^[#]?wsrep_node_address=.*$|wsrep_node_address=${NODE_IP}|" ${CFG} 1<> ${CFG}
 sed -r "s|^[#]?wsrep_cluster_name=.*$|wsrep_cluster_name=${CLUSTER_NAME%'-pxc'}|" ${CFG} 1<> ${CFG}

--- a/e2e-tests/one-pod/conf/one-pod.yml
+++ b/e2e-tests/one-pod/conf/one-pod.yml
@@ -19,7 +19,7 @@ spec:
       log-slave-updates
 
       wsrep_debug=1
-      wsrep_provider_options="gcache.size=1G; gcache.recover=yes"
+      wsrep_provider_options="pc.weight=10; gcache.size=1G; gcache.recover=yes"
     volumeSpec:
       persistentVolumeClaim:
         resources:


### PR DESCRIPTION
[![K8SPXC-464](https://badgen.net/badge/JIRA/K8SPXC-464/green)](https://jira.percona.com/browse/K8SPXC-464)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* add usage of 'pc.weight' option to avoid situation
      when pxc node becomes non-primary when backup via garbd
      fails for one pod installation