### PR TITLE
K8SPXC-471 - Fix for running security-context test in EKS

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -240,6 +240,7 @@ compare_kubectl() {
         | yq d - 'metadata.selfLink' \
         | yq d - 'metadata.deletionTimestamp' \
         | yq d - 'metadata.annotations."k8s.v1.cni.cncf.io*"' \
+        | yq d - 'metadata.annotations."kubernetes.io/psp"' \
         | yq d - '**.(name==percona-xtradb-cluster-operator-workload-token*)' \
         | yq d - '**.creationTimestamp' \
         | yq d - '**.image' \


### PR DESCRIPTION
[![K8SPXC-471](https://badgen.net/badge/JIRA/K8SPXC-471/green)](https://jira.percona.com/browse/K8SPXC-471)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

It had additional field on EKS so diff was failing:
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    kubernetes.io/psp: eks.privileged
    openshift.io/scc: privileged
```
