### PR TITLE
K8SPXC-471 Fix security-context test for openshift

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -22,7 +22,11 @@ conf_dir=$(realpath $test_dir/../conf || :)
 src_dir=$(realpath $test_dir/../..)
 
 if oc get projects ; then
-    OPENSHIFT=1
+    # Guessing Openshift version from master node API version
+    case "$(oc get nodes --no-headers=true | grep master | head -n1 | grep -Eo 'v[0-9]+\.[0-9]+')" in
+        "v1.11") OPENSHIFT=3.11 ;;
+              *) OPENSHIFT=4    ;;
+    esac
 fi
 HELM_VERSION=$(helm version -c | $sed -re 's/.*SemVer:"([^"]+)".*/\1/; s/.*\bVersion:"([^"]+)".*/\1/')
 if [ "${HELM_VERSION:0:2}" == "v2" ]; then
@@ -55,7 +59,7 @@ create_namespace() {
         kubectl get ns | egrep -v "^kube-|^default|Terminating|pxc-operator|openshift|^NAME" | awk '{print$1}' | xargs kubectl delete ns &
     fi
 
-    if [ "$OPENSHIFT" == 1 ]; then
+    if [ ! -z "$OPENSHIFT" ]; then
         oc delete project "$namespace" && sleep 40 || :
         oc new-project "$namespace"
         oc project "$namespace"
@@ -223,8 +227,11 @@ compare_kubectl() {
     local expected_result=${test_dir}/compare/${resource//\//_}${postfix}.yml
     local new_result="${tmp_dir}/${resource//\//_}.yml"
 
-    if [ "$OPENSHIFT" = 1 -a -f ${expected_result//.yml/-oc.yml} ]; then
+    if [ ! -z "$OPENSHIFT" -a -f ${expected_result//.yml/-oc.yml} ]; then
         expected_result=${expected_result//.yml/-oc.yml}
+        if [ "$OPENSHIFT" = 4 -a -f ${expected_result//-oc.yml/-4-oc.yml} ]; then
+            expected_result=${expected_result//-oc.yml/-4-oc.yml}
+        fi
     fi
 
     if [[ "$IMAGE_PXC" =~ 8\.0 ]] && [ -f ${expected_result//.yml/-80.yml} ]; then
@@ -451,7 +458,7 @@ destroy() {
     kubectl_bin delete pxc-restore --all || :
 
     kubectl_bin delete -f https://github.com/jetstack/cert-manager/releases/download/v0.15.1/cert-manager.yaml 2>/dev/null || :
-    if [ "$OPENSHIFT" == 1 ]; then
+    if [ ! -z "$OPENSHIFT" ]; then
         oc delete --grace-period=0 --force=true project "$namespace" &
     else
         kubectl_bin delete --grace-period=0 --force=true namespace "$namespace" &
@@ -819,7 +826,7 @@ EOF
     kubectl_bin get csr ${CSR_NAME} -o jsonpath='{.status.certificate}' > ${tmp_dir}/serverCert
     openssl base64 -in ${tmp_dir}/serverCert -d -A -out ${tmp_dir}/vault.crt
     kubectl_bin config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' | base64 -d > ${tmp_dir}/vault.ca
-    if [[ ${OPENSHIFT} == 1 ]]; then
+    if [[ ! -z ${OPENSHIFT} ]]; then
         if [[ "x$(kubectl_bin get namespaces | awk '{print $1}' | grep openshift-kube-controller-manager-operator)" != "x" ]]; then
             #Detecting openshift 4+
             kubectl_bin -n openshift-kube-controller-manager-operator get secret csr-signer -o jsonpath='{.data.tls\.crt}' \
@@ -847,7 +854,7 @@ start_vault() {
 
     local platform=kubernetes
 
-    if [[ ${OPENSHIFT} == 1 ]]; then
+    if [[ ! -z ${OPENSHIFT} ]]; then
         platform=openshift
         oc patch clusterrole system:auth-delegator --type='json' -p '[{"op":"add","path":"/rules/-", "value":{"apiGroups":["security.openshift.io"], "attributeRestrictions":null, "resourceNames": ["privileged"], "resources":["securitycontextconstraints"],"verbs":["use"]}}]'
     fi
@@ -891,7 +898,7 @@ storage \"file\" {
             --set global.platform="${platform}"
     fi
 
-    if [[ "${OPENSHIFT}" == 1 ]]; then
+    if [[ ! -z "${OPENSHIFT}" ]]; then
         oc patch clusterrole $name-agent-injector-clusterrole --type='json' -p '[{"op":"add","path":"/rules/-", "value":{"apiGroups":["security.openshift.io"], "attributeRestrictions":null, "resourceNames": ["privileged"], "resources":["securitycontextconstraints"],"verbs":["use"]}}]'
         oc adm policy add-scc-to-user privileged $name-agent-injector
     fi

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -13,7 +13,7 @@ deploy_helm $namespace
 
 desc 'install PMM Server'
 platform=kubernetes
-if [ "$OPENSHIFT" == 1 ]; then
+if [ ! -z "$OPENSHIFT" ]; then
     platform=openshift
 fi
 helm del monitoring || :

--- a/e2e-tests/monitoring/run
+++ b/e2e-tests/monitoring/run
@@ -12,7 +12,7 @@ deploy_helm $namespace
 
 desc 'install PMM Server'
 platform=kubernetes
-if [ "$OPENSHIFT" == 1 ]; then
+if [ ! -z "$OPENSHIFT" ]; then
     platform=openshift
 fi
 helm del monitoring || :

--- a/e2e-tests/scheduled-backup/run
+++ b/e2e-tests/scheduled-backup/run
@@ -94,7 +94,7 @@ compare_extrafields() {
     local expected_result=${test_dir}/compare/extra-fields.json
     local new_result="${tmp_dir}/${resource//\//_}.json"
 
-    if [ "$OPENSHIFT" = 1 -a -f ${expected_result//.json/-oc.json} ]; then
+    if [ ! -z "$OPENSHIFT" -a -f ${expected_result//.json/-oc.json} ]; then
         expected_result=${expected_result//.json/-oc.json}
     fi
 

--- a/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes-4-oc.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes-4-oc.yml
@@ -136,6 +136,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
+        runAsGroup: 1001
         runAsUser: 1001
         supplementalGroups:
           - 1001

--- a/e2e-tests/security-context/run
+++ b/e2e-tests/security-context/run
@@ -10,7 +10,7 @@ create_infra $namespace
 deploy_cert_manager
 
 kubectl_bin apply -f "$test_dir/conf/service-account.yml"
-if [[ "${OPENSHIFT}" == 1 ]]; then
+if [[ ! -z "${OPENSHIFT}" ]]; then
     oc adm policy add-scc-to-user privileged -z percona-xtradb-cluster-operator-workload
 
     if [ -n "$OPERATOR_NS" ]; then
@@ -76,7 +76,7 @@ kubectl_bin apply -f "$test_dir/conf/$cluster-$restore.yml"
 wait_backup_restore $restore
 compare_kubectl job.batch/restore-job-$restore-$cluster
 
-if [[ "${OPENSHIFT}" == 1 ]]; then
+if [[ ! -z "${OPENSHIFT}" ]]; then
     oc adm policy remove-scc-from-user privileged -z percona-xtradb-cluster-operator-workload
 fi
 destroy $namespace


### PR DESCRIPTION
[![K8SPXC-471](https://badgen.net/badge/JIRA/K8SPXC-471/green)](https://jira.percona.com/browse/K8SPXC-471)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Since the security-context test has processing diffence for
    openshift 3.11 and 4.x we need to know what platform version is
    used for test execution.