### PR TITLE
K8SPXC-487 Improve haproxy reload

### DIFF
--- a/pkg/pxc/statefulset.go
+++ b/pkg/pxc/statefulset.go
@@ -34,7 +34,7 @@ func StatefulSet(sfs api.StatefulApp, podSpec *api.PodSpec, cr *api.PerconaXtraD
 	}
 	pod.Affinity = PodAffinity(podSpec.Affinity, sfs)
 
-	if sfs.Labels()["app.kubernetes.io/component"] == "haproxy" {
+	if sfs.Labels()["app.kubernetes.io/component"] == "haproxy" && cr.CompareVersionWith("1.7.0") == -1 {
 		t := true
 		pod.ShareProcessNamespace = &t
 	}


### PR DESCRIPTION
[![K8SPXC-487](https://badgen.net/badge/JIRA/K8SPXC-487/green)](https://jira.percona.com/browse/K8SPXC-487)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* stop using 'shareProcessNamespace' because it is not
      supported by openshift 3.11