### PR TITLE
Revert "K8SPXC-438 add possibility to use 32 symbols for cluster name"

### DIFF
--- a/build/pxc-configure-pxc.sh
+++ b/build/pxc-configure-pxc.sh
@@ -78,7 +78,7 @@ egrep -q "^[#]?wsrep_sst_donor" "$CFG" || sed '/^\[mysqld\]/a wsrep_sst_donor=\n
 egrep -q "^[#]?wsrep_node_incoming_address" "$CFG" || sed '/^\[mysqld\]/a wsrep_node_incoming_address=\n' ${CFG} 1<> ${CFG}
 sed -r "s|^[#]?server_id=.*$|server_id=1${SERVER_ID}|" ${CFG} 1<> ${CFG}
 sed -r "s|^[#]?wsrep_node_address=.*$|wsrep_node_address=${NODE_IP}|" ${CFG} 1<> ${CFG}
-sed -r "s|^[#]?wsrep_cluster_name=.*$|wsrep_cluster_name=${CLUSTER_NAME%'-pxc'}|" ${CFG} 1<> ${CFG}
+sed -r "s|^[#]?wsrep_cluster_name=.*$|wsrep_cluster_name=${CLUSTER_NAME}|" ${CFG} 1<> ${CFG}
 sed -r "s|^[#]?wsrep_sst_donor=.*$|wsrep_sst_donor=${DONOR_ADDRESS}|" ${CFG} 1<> ${CFG}
 sed -r "s|^[#]?wsrep_cluster_address=.*$|wsrep_cluster_address=gcomm://${WSREP_CLUSTER_ADDRESS}|" ${CFG} 1<> ${CFG}
 sed -r "s|^[#]?wsrep_node_incoming_address=.*$|wsrep_node_incoming_address=${NODE_NAME}:${NODE_PORT}|" ${CFG} 1<> ${CFG}

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -283,7 +283,7 @@ type StatefulApp interface {
 	UpdateStrategy(cr *PerconaXtraDBCluster) appsv1.StatefulSetUpdateStrategy
 }
 
-const clusterNameMaxLen = 32
+const clusterNameMaxLen = 22
 
 var defaultPXCGracePeriodSec int64 = 600
 var livenessInitialDelaySeconds int32 = 300

--- a/pkg/pxc/backup/restore.go
+++ b/pkg/pxc/backup/restore.go
@@ -25,12 +25,12 @@ func PVCRestoreService(cr *api.PerconaXtraDBClusterRestore) *corev1.Service {
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "restore-src-" + cr.Name + "-" + trimNameRight(cr.Spec.PXCCluster, 16),
+			Name:      "restore-src-" + cr.Name + "-" + cr.Spec.PXCCluster,
 			Namespace: cr.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"name": "restore-src-" + cr.Name + "-" + trimNameRight(cr.Spec.PXCCluster, 16),
+				"name": "restore-src-" + cr.Name + "-" + cr.Spec.PXCCluster,
 			},
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
@@ -62,7 +62,7 @@ func PVCRestorePod(cr *api.PerconaXtraDBClusterRestore, bcpStorageName, pvcName 
 	for key, value := range cluster.Backup.Storages[bcpStorageName].Labels {
 		labels[key] = value
 	}
-	labels["name"] = "restore-src-" + cr.Name + "-" + trimNameRight(cr.Spec.PXCCluster, 16)
+	labels["name"] = "restore-src-" + cr.Name + "-" + cr.Spec.PXCCluster
 
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -70,7 +70,7 @@ func PVCRestorePod(cr *api.PerconaXtraDBClusterRestore, bcpStorageName, pvcName 
 			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "restore-src-" + cr.Name + "-" + trimNameRight(cr.Spec.PXCCluster, 16),
+			Name:        "restore-src-" + cr.Name + "-" + cr.Spec.PXCCluster,
 			Namespace:   cr.Namespace,
 			Annotations: cluster.Backup.Storages[bcpStorageName].Annotations,
 			Labels:      labels,
@@ -158,7 +158,7 @@ func PVCRestoreJob(cr *api.PerconaXtraDBClusterRestore, cluster api.PerconaXtraD
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "restore-job-" + cr.Name + "-" + trimNameRight(cr.Spec.PXCCluster, 16),
+			Name:      "restore-job-" + cr.Name + "-" + cr.Spec.PXCCluster,
 			Namespace: cr.Namespace,
 		},
 		Spec: batchv1.JobSpec{
@@ -198,7 +198,7 @@ func PVCRestoreJob(cr *api.PerconaXtraDBClusterRestore, cluster api.PerconaXtraD
 							Env: []corev1.EnvVar{
 								{
 									Name:  "RESTORE_SRC_SERVICE",
-									Value: "restore-src-" + cr.Name + "-" + trimNameRight(cr.Spec.PXCCluster, 16),
+									Value: "restore-src-" + cr.Name + "-" + cr.Spec.PXCCluster,
 								},
 							},
 							Resources: resources,
@@ -267,7 +267,7 @@ func S3RestoreJob(cr *api.PerconaXtraDBClusterRestore, bcp *api.PerconaXtraDBClu
 			Kind:       "Job",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "restore-job-" + cr.Name + "-" + trimNameRight(cr.Spec.PXCCluster, 16),
+			Name:      "restore-job-" + cr.Name + "-" + cr.Spec.PXCCluster,
 			Namespace: cr.Namespace,
 		},
 		Spec: batchv1.JobSpec{


### PR DESCRIPTION
[![K8SPXC-438](https://badgen.net/badge/JIRA/K8SPXC-438/green)](https://jira.percona.com/browse/K8SPXC-438)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Reverts percona/percona-xtradb-cluster-operator#560