### PR TITLE
Update after PXC 1.6.0 release and prepare for 1.7.0

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -33,6 +33,9 @@ spec:
       storage: false
       served: true
     - name: v1-6-0
+      storage: false
+      served: true
+    - name: v1-7-0
       storage: true
       served: true
     - name: v1alpha1

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -5,7 +5,7 @@ BASH_XTRACEFD="5"
 
 GIT_COMMIT=$(git rev-parse HEAD)
 GIT_BRANCH=${VERSION:-$(git rev-parse --abbrev-ref HEAD | sed -e 's^/^-^g; s^[.]^-^g;' | tr '[:upper:]' '[:lower:]')}
-API="pxc.percona.com/v1-6-0"
+API="pxc.percona.com/v1-7-0"
 IMAGE=${IMAGE:-"perconalab/percona-xtradb-cluster-operator:${GIT_BRANCH}"}
 IMAGE_PXC=${IMAGE_PXC:-"perconalab/percona-xtradb-cluster-operator:master-pxc8.0"}
 IMAGE_PMM=${IMAGE_PMM:-"perconalab/percona-xtradb-cluster-operator:master-pmm"}

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy.yml
@@ -109,7 +109,6 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      shareProcessNamespace: true
       terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoExecute

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
@@ -101,7 +101,6 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      shareProcessNamespace: true
       terminationGracePeriodSeconds: 30
       volumes:
         - configMap:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-170-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-170-oc.yml
@@ -1,0 +1,206 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  generation: 7
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pxc
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+      app.kubernetes.io/name: percona-xtradb-cluster
+      app.kubernetes.io/part-of: percona-xtradb-cluster
+  serviceName: some-name-pxc
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: pxc
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+        app.kubernetes.io/name: percona-xtradb-cluster
+        app.kubernetes.io/part-of: percona-xtradb-cluster
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: pxc
+                  app.kubernetes.io/instance: some-name
+                  app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+                  app.kubernetes.io/name: percona-xtradb-cluster
+                  app.kubernetes.io/part-of: percona-xtradb-cluster
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - mysqld
+          command:
+            - /var/lib/mysql/pxc-entrypoint.sh
+          env:
+            - name: PXC_SERVICE
+              value: some-name-pxc-unready
+            - name: MONITOR_HOST
+              value: '%'
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: root
+                  name: internal-some-name
+            - name: XTRABACKUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: internal-some-name
+            - name: MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: monitor
+                  name: internal-some-name
+            - name: CLUSTERCHECK_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: clustercheck
+                  name: internal-some-name
+            - name: OPERATOR_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: operator
+                  name: internal-some-name
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /var/lib/mysql/liveness-check.sh
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: pxc
+          ports:
+            - containerPort: 3306
+              name: mysql
+              protocol: TCP
+            - containerPort: 4444
+              name: sst
+              protocol: TCP
+            - containerPort: 4567
+              name: write-set
+              protocol: TCP
+            - containerPort: 4568
+              name: ist
+              protocol: TCP
+            - containerPort: 33062
+              name: mysql-admin
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /var/lib/mysql/readiness-check.sh
+            failureThreshold: 5
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 15
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: datadir
+            - mountPath: /etc/percona-xtradb-cluster.conf.d
+              name: config
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/my.cnf.d
+              name: auto-config
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /pxc-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: pxc-init
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: datadir
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        supplementalGroups:
+          - 1001
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 600
+      volumes:
+        - emptyDir: {}
+          name: tmp
+        - configMap:
+            defaultMode: 420
+            name: some-name-pxc
+            optional: true
+          name: config
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: false
+            secretName: some-name-ssl
+        - configMap:
+            defaultMode: 420
+            name: auto-some-name-pxc
+            optional: true
+          name: auto-config
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-vault
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+      status:
+        phase: Pending

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-170.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-170.yml
@@ -1,0 +1,207 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  generation: 7
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pxc
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+      app.kubernetes.io/name: percona-xtradb-cluster
+      app.kubernetes.io/part-of: percona-xtradb-cluster
+  serviceName: some-name-pxc
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: pxc
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+        app.kubernetes.io/name: percona-xtradb-cluster
+        app.kubernetes.io/part-of: percona-xtradb-cluster
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: pxc
+                  app.kubernetes.io/instance: some-name
+                  app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+                  app.kubernetes.io/name: percona-xtradb-cluster
+                  app.kubernetes.io/part-of: percona-xtradb-cluster
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - mysqld
+          command:
+            - /var/lib/mysql/pxc-entrypoint.sh
+          env:
+            - name: PXC_SERVICE
+              value: some-name-pxc-unready
+            - name: MONITOR_HOST
+              value: '%'
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: root
+                  name: internal-some-name
+            - name: XTRABACKUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: internal-some-name
+            - name: MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: monitor
+                  name: internal-some-name
+            - name: CLUSTERCHECK_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: clustercheck
+                  name: internal-some-name
+            - name: OPERATOR_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: operator
+                  name: internal-some-name
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /var/lib/mysql/liveness-check.sh
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: pxc
+          ports:
+            - containerPort: 3306
+              name: mysql
+              protocol: TCP
+            - containerPort: 4444
+              name: sst
+              protocol: TCP
+            - containerPort: 4567
+              name: write-set
+              protocol: TCP
+            - containerPort: 4568
+              name: ist
+              protocol: TCP
+            - containerPort: 33062
+              name: mysql-admin
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /var/lib/mysql/readiness-check.sh
+            failureThreshold: 5
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 15
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: datadir
+            - mountPath: /etc/percona-xtradb-cluster.conf.d
+              name: config
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/my.cnf.d
+              name: auto-config
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /pxc-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: pxc-init
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: datadir
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 600
+      volumes:
+        - emptyDir: {}
+          name: tmp
+        - configMap:
+            defaultMode: 420
+            name: some-name-pxc
+            optional: true
+          name: config
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: false
+            secretName: some-name-ssl
+        - configMap:
+            defaultMode: 420
+            name: auto-some-name-pxc
+            optional: true
+          name: auto-config
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-vault
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi
+      status:
+        phase: Pending

--- a/e2e-tests/upgrade-consistency/run
+++ b/e2e-tests/upgrade-consistency/run
@@ -125,6 +125,20 @@ main() {
     compare_kubectl statefulset/$cluster-pxc "-160"
     compare_kubectl statefulset/$cluster-proxysql "-160"
 
+    # test 1.7.0
+    API="pxc.percona.com/v1-7-0"
+    kubectl_bin apply -f https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/master/deploy/rbac.yaml
+    kubectl_bin patch pxc "$cluster" --type=merge --patch '{
+        "spec": {"crVersion":"1.7.0"}
+    }'
+    wait_cluster_consistency "$cluster" 3 1
+    wait_for_sts_generation "$cluster-pxc" "7" "1"
+
+    compare_kubectl service/$cluster-pxc "-170"
+    compare_kubectl service/$cluster-proxysql "-170"
+    compare_kubectl statefulset/$cluster-pxc "-170"
+    compare_kubectl statefulset/$cluster-proxysql "-170"
+
     destroy "${namespace}"
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.6.0"
+	Version = "1.7.0"
 )


### PR DESCRIPTION
haproxy and monitoring-2.0 are failing with diff issue because of this fix: https://github.com/percona/percona-xtradb-cluster-operator/commit/32e6fa19ded2f2c148cc19a043f3d2e787ecd323
```
+ diff -u /mnt/jenkins/workspace/cloud-pxc-operator_PR-637/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy.yml /tmp/tmp.lQln2oT2QJ/statefulset_haproxy-haproxy.yml
--- /mnt/jenkins/workspace/cloud-pxc-operator_PR-637/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy.yml	2020-10-13 05:27:25.805522784 +0000
+++ /tmp/tmp.lQln2oT2QJ/statefulset_haproxy-haproxy.yml	2020-10-13 05:44:54.405369014 +0000
@@ -109,7 +109,6 @@
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      shareProcessNamespace: true
       terminationGracePeriodSeconds: 30
       tolerations:
         - effect: NoExecute
```