### PR TITLE
K8SPXC-503 - remove check for v1.7.0 when applying init image

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -273,7 +273,7 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(request reconcile.Request) (re
 		if o.CompareVersionWith("1.6.0") >= 0 {
 			initResources = o.Spec.PXC.Resources
 		}
-		if o.CompareVersionWith("1.7.0") >= 0 && len(o.Spec.InitImage) > 0 {
+		if len(o.Spec.InitImage) > 0 {
 			imageName = o.Spec.InitImage
 		}
 		initC, err := statefulset.EntrypointInitContainer(imageName, initResources, o.Spec.PXC.ContainerSecurityContext)


### PR DESCRIPTION
[![K8SPXC-503](https://badgen.net/badge/JIRA/K8SPXC-503/green)](https://jira.percona.com/browse/K8SPXC-503)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This should allow us to use initImage option in upgrade testing even before v1.7.0 is released.