### PR TITLE
K8SPXC-512 feature Add support for comma separated namespaces in WATCH_NAMESPACE

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	_ "github.com/Percona-Lab/percona-version-service/api"
 	certmgrscheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
@@ -16,6 +17,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
@@ -61,6 +63,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Add support for MultiNamespace set in WATCH_NAMESPACE
+	options := manager.Options{
+		Namespace: namespace,
+	}
+
+	if strings.Contains(namespace, ",") {
+		options.Namespace = ""
+		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
+	}
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -80,7 +92,7 @@ func main() {
 	defer r.Unset()
 
 	// Create a new Cmd to provide shared dependencies and start components
-	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})
+	mgr, err := manager.New(cfg, options)
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)


### PR DESCRIPTION
[![K8SPXC-512](https://badgen.net/badge/JIRA/K8SPXC-512/green)](https://jira.percona.com/browse/K8SPXC-512)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

JIRA issue reference: https://jira.percona.com/browse/K8SPXC-512

example code can be found here - https://sdk.operatorframework.io/docs/building-operators/golang/operator-scope/#configuring-cluster-scoped-operators-with-multinamespacedcachebuilder