### PR TITLE
Bug fix VolumeSpec.reconcileOpts Not correctly ininited 

### DIFF
--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 
 	"github.com/go-ini/ini"
+	v "github.com/hashicorp/go-version"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/percona/percona-xtradb-cluster-operator/version"
-
-	v "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	. "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -637,6 +637,11 @@ func (p *PodSpec) reconcileAffinityOpts() {
 func (v *VolumeSpec) reconcileOpts() (changed bool, err error) {
 	if v.EmptyDir == nil && v.HostPath == nil && v.PersistentVolumeClaim == nil {
 		v.PersistentVolumeClaim = &corev1.PersistentVolumeClaimSpec{}
+		storageList:=make(corev1.ResourceList)
+		storageList[corev1.ResourceStorage], _ = ParseQuantity("1Mb")
+		v.PersistentVolumeClaim.Resources.Requests=storageList
+		storageCls:="perona-storage-class"
+		v.PersistentVolumeClaim.StorageClassName=&storageCls
 	}
 
 	if v.PersistentVolumeClaim != nil {


### PR DESCRIPTION
reconcile bug fix ,pvc set volume and storageclass

unc (v *VolumeSpec) reconcileOpts() (changed bool, err error) {
	if v.EmptyDir == nil && v.HostPath == nil && v.PersistentVolumeClaim == nil {
		v.PersistentVolumeClaim = &corev1.PersistentVolumeClaimSpec{}
		**storageList:=make(corev1.ResourceList)
		storageList[corev1.ResourceStorage], _ = ParseQuantity("1Mb")
		v.PersistentVolumeClaim.Resources.Requests=storageList
		storageCls:="perona-storage-class"
		v.PersistentVolumeClaim.StorageClassName=&storageCls**
	}