### PR TITLE
Fix operator pod selector in e2e-tests functions

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -74,7 +74,7 @@ create_namespace() {
 
 get_operator_pod() {
     kubectl_bin get pods \
-        --selector=name=percona-xtradb-cluster-operator \
+        --selector=app.kubernetes.io/name=percona-xtradb-cluster-operator \
         -o 'jsonpath={.items[].metadata.name}' ${OPERATOR_NS:+-n $OPERATOR_NS}
 }
 


### PR DESCRIPTION
All the tests on the master started failing like:
```
++ get_operator_pod
++ kubectl_bin get pods --selector=name=percona-xtradb-cluster-operator -o 'jsonpath={.items[].metadata.name}'
+++ mktemp
++ local LAST_OUT=/tmp/tmp.McVRNLwvIS
+++ mktemp
++ local LAST_ERR=/tmp/tmp.fd9OVyT6Yc
++ local exit_status=0
+++ seq 0 2
++ for i in '$(seq 0 2)'
++ kubectl get pods --selector=name=percona-xtradb-cluster-operator -o 'jsonpath={.items[].metadata.name}'
++ exit_status=1
++ [[ hB != hxB ]]
++ echo '--- 0 stdout'
++ cat - /tmp/tmp.McVRNLwvIS
--- 0 stdout
++ [[ hB != hxB ]]
++ echo '--- 0 stderr'
++ cat - /tmp/tmp.fd9OVyT6Yc
--- 0 stderr
error: error executing jsonpath "{.items[].metadata.name}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
	template was:
		{.items[].metadata.name}
	object given to jsonpath engine was:
		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}
```