### PR TITLE
K8SPXC-503 - read initImage on initial deployment

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -567,6 +567,9 @@ func (r *ReconcilePerconaXtraDBCluster) deploy(cr *api.PerconaXtraDBCluster) err
 		if cr.CompareVersionWith("1.6.0") >= 0 {
 			initResources = cr.Spec.PXC.Resources
 		}
+		if len(cr.Spec.InitImage) > 0 {
+			imageName = cr.Spec.InitImage
+		}
 		initC, err := statefulset.EntrypointInitContainer(imageName, initResources, cr.Spec.PXC.ContainerSecurityContext)
 		if err != nil {
 			return err


### PR DESCRIPTION
[![K8SPXC-503](https://badgen.net/badge/JIRA/K8SPXC-503/green)](https://jira.percona.com/browse/K8SPXC-503)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We have added same here: https://github.com/percona/percona-xtradb-cluster-operator/blob/master/pkg/controller/pxc/controller.go#L276-L278
but from what I see this is ignored on initial deployment, so this is another PR to fix this - that is if I'm not wrong, but it seems to work for me
This one is in `deploy` function and the first one is in `Reconcile`.