### PR TITLE
Fix get_operator_pod to recognize old and new operator pod labels

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -73,8 +73,13 @@ create_namespace() {
 }
 
 get_operator_pod() {
+    local label_prefix="app.kubernetes.io/"
+    local check_label=$(kubectl get pods --selector=app.kubernetes.io/name=percona-xtradb-cluster-operator ${OPERATOR_NS:+-n $OPERATOR_NS} | grep -c "percona-xtradb-cluster-operator")
+    if [[ ${check_label} -eq 0 ]]; then
+        label_prefix=""
+    fi
     kubectl_bin get pods \
-        --selector=app.kubernetes.io/name=percona-xtradb-cluster-operator \
+        --selector=${label_prefix}name=percona-xtradb-cluster-operator \
         -o 'jsonpath={.items[].metadata.name}' ${OPERATOR_NS:+-n $OPERATOR_NS}
 }
 


### PR DESCRIPTION
We have changed the labels for the operator pod and changed `get_operator_pod` to recognise them, but they don't work for upgrade tests which start from earlier version since they don't have these same labels so the function needs to recognise both `name=percona-xtradb-cluster-operator` and `app.kubernetes.io/name=percona-xtradb-cluster-operator`.