### PR TITLE
Cleanup of deploy_cert_manager usage

### DIFF
--- a/e2e-tests/big-data/run
+++ b/e2e-tests/big-data/run
@@ -13,7 +13,7 @@ main() {
 
     desc 'create first PXC cluster'
     cluster="some-name"
-    spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml"
+    spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml" "3" "10" "${conf_dir}/secrets_without_tls.yml"
 
     kubectl_bin apply -f "${conf_dir}/cloud-secret.yml" 
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -454,6 +454,7 @@ deploy_cert_manager() {
     kubectl_bin create namespace cert-manager || :
     kubectl_bin label namespace cert-manager certmanager.k8s.io/disable-validation=true || :
     kubectl_bin apply -f https://github.com/jetstack/cert-manager/releases/download/v0.15.1/cert-manager.yaml --validate=false || : 2>/dev/null
+    sleep 30
 }
 
 destroy() {

--- a/e2e-tests/init-deploy/run
+++ b/e2e-tests/init-deploy/run
@@ -7,7 +7,6 @@ test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
 create_infra $namespace
-deploy_cert_manager
 
 desc 'create first PXC cluster'
 cluster="some-name"

--- a/e2e-tests/proxysql-sidecar-res-limits/run
+++ b/e2e-tests/proxysql-sidecar-res-limits/run
@@ -11,7 +11,7 @@ deploy_cert_manager
 
 desc 'create PXC cluster'
 cluster="side-car"
-spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml"
+spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml" "3" "10" "${conf_dir}/secrets_without_tls.yml"
 
 desc 'check if service and statefulset created with expected config'
 compare_kubectl service/$cluster-proxysql

--- a/e2e-tests/security-context/run
+++ b/e2e-tests/security-context/run
@@ -22,7 +22,7 @@ fi
 
 desc 'create first PXC cluster'
 cluster="sec-context"
-spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml"
+spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml" "3" "10" "${conf_dir}/secrets_without_tls.yml"
 
 kubectl_bin apply -f "${conf_dir}/cloud-secret.yml"
 

--- a/e2e-tests/smart-update/run
+++ b/e2e-tests/smart-update/run
@@ -66,7 +66,6 @@ function check_last_pod_to_update {
 
 main() {
     create_infra $namespace
-    deploy_cert_manager
 
     kubectl_bin patch crd perconaxtradbclusters.pxc.percona.com --type='json' -p '[{"op":"add","path":"/spec/versions/-", "value":{"name": "v9-9-9", "served": true, "storage": false}}]'
 

--- a/e2e-tests/tls-issue-cert-manager-ref/run
+++ b/e2e-tests/tls-issue-cert-manager-ref/run
@@ -13,8 +13,6 @@ main() {
   desc 'deploy cert manager'
   deploy_cert_manager
 
-  sleep 30
-
   desc 'create issuer'
   apply_config "$test_dir/conf/issuer.yml"
 

--- a/e2e-tests/tls-issue-cert-manager/run
+++ b/e2e-tests/tls-issue-cert-manager/run
@@ -13,8 +13,6 @@ main() {
   desc 'deploy cert manager'
   deploy_cert_manager
 
-  sleep 30
-
   desc 'create pxc cluster'
   spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml" 3 10 "$conf_dir/secrets_without_tls.yml" "$test_dir/conf/client.yml"
 

--- a/e2e-tests/users/run
+++ b/e2e-tests/users/run
@@ -7,7 +7,6 @@ test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
 create_infra $namespace
-deploy_cert_manager
 
 desc 'create PXC cluster'
 


### PR DESCRIPTION
Where we use cert manager we use `secrets_without_tls.yml` and otherwise standard `secrets.yml` are used which include ssl secrets.