### PR TITLE
Fix init-deploy to use cert manager as issuer

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -454,7 +454,7 @@ deploy_cert_manager() {
     kubectl_bin create namespace cert-manager || :
     kubectl_bin label namespace cert-manager certmanager.k8s.io/disable-validation=true || :
     kubectl_bin apply -f https://github.com/jetstack/cert-manager/releases/download/v0.15.1/cert-manager.yaml --validate=false || : 2>/dev/null
-    sleep 30
+    sleep 45
 }
 
 destroy() {

--- a/e2e-tests/init-deploy/run
+++ b/e2e-tests/init-deploy/run
@@ -7,10 +7,17 @@ test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
 create_infra $namespace
+deploy_cert_manager
 
 desc 'create first PXC cluster'
 cluster="some-name"
-spinup_pxc "$cluster" "$conf_dir/$cluster.yml"
+spinup_pxc "$cluster" "$conf_dir/$cluster.yml" "3" "10" "${conf_dir}/secrets_without_tls.yml"
+
+desc 'check if cert-manager issued ssl certificates'
+if [ "$(kubectl get secrets ${cluster}-ssl -o jsonpath='{.metadata.annotations.cert-manager\.io/issuer-kind}')" != "Issuer" ]; then
+  echo "Cert manager didn't create the ssl certificates! Something went wrong."
+  exit 1
+fi
 
 desc 'check if service and statefulset created with expected config'
 compare_kubectl statefulset/$cluster-pxc

--- a/e2e-tests/upgrade-haproxy/run
+++ b/e2e-tests/upgrade-haproxy/run
@@ -59,7 +59,6 @@ function main() {
     fi
 
     deploy_cert_manager
-    sleep 30
 
     # we cannot use create_infra and deploy_operator from functions since they deploy from the current source tree
     # so we fetch last officially released images and yaml files as initial state for upgrade from github

--- a/e2e-tests/upgrade-proxysql/run
+++ b/e2e-tests/upgrade-proxysql/run
@@ -59,7 +59,6 @@ function main() {
     fi
 
     deploy_cert_manager
-    sleep 30
 
     # we cannot use create_infra and deploy_operator from functions since they deploy from the current source tree
     # so we fetch last officially released images and yaml files as initial state for upgrade from github


### PR DESCRIPTION
This is fixing the init-deploy test which was depending on cert-manager before.

Other tests seem to be failing because of the issues which are already reported in jira:
operator-self-healing: https://jira.percona.com/browse/K8SPXC-531
limits and one-pod: https://jira.percona.com/browse/K8SPXC-537
upgrade tests: https://jira.percona.com/browse/K8SPXC-538