### PR TITLE
Fix timeout in Jenkinsfile and cleanup of upgrade tests

### DIFF
--- a/e2e-tests/upgrade-haproxy/run
+++ b/e2e-tests/upgrade-haproxy/run
@@ -50,14 +50,6 @@ fi
 
 
 function main() {
-    kubectl_bin delete -f "${src_dir}/deploy/crd.yaml" || true
-    if [[ -n "${OPERATOR_NS}" ]]; then
-        kubectl_bin delete ns "${OPERATOR_NS}" --force --grace-period=0 || true
-        kubectl_bin delete -f "${src_dir}/deploy/cw-rbac.yaml" || true
-    else
-        kubectl_bin delete -f "${src_dir}/deploy/rbac.yaml" || true
-    fi
-
     deploy_cert_manager
 
     # we cannot use create_infra and deploy_operator from functions since they deploy from the current source tree
@@ -142,14 +134,6 @@ function main() {
     compare_kubectl "statefulset/${CLUSTER}-haproxy"
 
     desc 'cleanup'
-    kubectl_bin delete -f "${src_dir}/deploy/crd.yaml" || :
-    kubectl_bin delete pvc --all
-    if [[ -n "${OPERATOR_NS}" ]]; then
-        kubectl_bin delete ns "${OPERATOR_NS}" || :
-        kubectl_bin delete -f "${src_dir}/deploy/cw-rbac.yaml" || :
-    else
-        kubectl_bin delete -f "${src_dir}/deploy/rbac.yaml" || :
-    fi
     destroy "${namespace}"
 }
 

--- a/e2e-tests/upgrade-proxysql/run
+++ b/e2e-tests/upgrade-proxysql/run
@@ -50,14 +50,6 @@ fi
 
 
 function main() {
-    kubectl_bin delete -f "${src_dir}/deploy/crd.yaml" || true
-    if [[ -n "${OPERATOR_NS}" ]]; then
-        kubectl_bin delete ns "${OPERATOR_NS}" --force --grace-period=0 || true
-        kubectl_bin delete -f "${src_dir}/deploy/cw-rbac.yaml" || true
-    else
-        kubectl_bin delete -f "${src_dir}/deploy/rbac.yaml" || true
-    fi
-
     deploy_cert_manager
 
     # we cannot use create_infra and deploy_operator from functions since they deploy from the current source tree
@@ -142,14 +134,6 @@ function main() {
     compare_kubectl "statefulset/${CLUSTER}-proxysql"
 
     desc 'cleanup'
-    kubectl_bin delete -f "${src_dir}/deploy/crd.yaml" || :
-    kubectl_bin delete pvc --all
-    if [[ -n "${OPERATOR_NS}" ]]; then
-        kubectl_bin delete ns "${OPERATOR_NS}" || :
-        kubectl_bin delete -f "${src_dir}/deploy/cw-rbac.yaml" || :
-    else
-        kubectl_bin delete -f "${src_dir}/deploy/rbac.yaml" || :
-    fi
     destroy "${namespace}"
 }
 


### PR DESCRIPTION
There are few problems:
1. The 3 hour timeout for test stage doesn't work properly, there are some jenkins bugs around this, probably it's related to 
`waitUntil` and `tryCatch` inside `runTest` function and that's why our test runs never finished.
2. Cleaning up crd in a messy situation when test fails can be problematic, a lot of users faced issues like that in kubernetes.

So this change is putting a 90min timeout for the command which is executing a particular test, which means the whole test run could take longer than 3 hrs, but at least it will not be left hanging forever and the proper cleanup will be done after test run.
Also for 2 upgrade tests seems cleanest and least problematic to just shutdown cluster and start a new one, the whole run will take few minutes longer but at least issue with upgrade will not affect other tests.

The example test run can be seen here: https://cloud.cd.percona.com/job/cloud-pxc-operator/view/change-requests/job/PR-676/