### PR TITLE
Fix operator-self-healing test for non cluster-wide environment

### DIFF
--- a/e2e-tests/operator-self-healing/run
+++ b/e2e-tests/operator-self-healing/run
@@ -88,8 +88,10 @@ netem_pod() {
 main() {
     create_infra $namespace
 
-    kubectl_bin patch clusterrole percona-xtradb-cluster-operator --type=json -p '[{"op":"remove","path":"/rules/1"}]'
-    kubectl_bin delete validatingwebhookconfigurations.admissionregistration.k8s.io percona-xtradbcluster-webhook
+    if [ -n "$OPERATOR_NS" ]; then
+        kubectl_bin patch clusterrole percona-xtradb-cluster-operator --type=json -p '[{"op":"remove","path":"/rules/1"}]'
+        kubectl_bin delete validatingwebhookconfigurations.admissionregistration.k8s.io percona-xtradbcluster-webhook
+    fi
 
     kubectl_bin apply -f "$test_dir/conf/pumba.yml" ${OPERATOR_NS:+-n $OPERATOR_NS}
 


### PR DESCRIPTION
If running in non cluster wide it was failing with:
```
kubectl_bin patch clusterrole percona-xtradb-cluster-operator --type=json -p '[{"op":"remove","path":"/rules/1"}]'
Error from server (NotFound): clusterroles.rbac.authorization.k8s.io "percona-xtradb-cluster-operator" not found
```