### PR TITLE
K8SPXC-587 Intelligent release CRD application

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1103,7 +1103,12 @@ function deploy_operator_gh() {
     local git_tag="$1"
 
     desc 'start operator'
-    kubectl_bin apply -f "https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/${git_tag}/deploy/crd.yaml" > "${tmp_dir}/crd_${git_tag}.yaml"
+    if [[ -n $(kubectl_bin get crds -o jsonpath='{.items[?(@.metadata.name == "perconaxtradbclusters.pxc.percona.com")].metadata.name}') ]]\
+       && [[ -n $(kubectl_bin get crd/perconaxtradbclusters.pxc.percona.com -o jsonpath='{.spec.versions[?(@.name == "'"${git_tag//\./-}"'")].name}') ]]; then
+       echo "Target CRD for ${git_tag} is in place"
+    else
+        kubectl_bin apply -f "https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/${git_tag}/deploy/crd.yaml" > "${tmp_dir}/crd_${git_tag}.yaml"
+    fi
 
     local rbac_yaml="rbac"
     local operator_yaml="operator.yaml"


### PR DESCRIPTION
[![K8SPXC-587](https://badgen.net/badge/JIRA/K8SPXC-587/green)](https://jira.percona.com/browse/K8SPXC-587) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

From time to time CRD from a release tag an CRD from
master branch could not be applied on the same cluster.
Thus we need to check wheather we need to apply older
CRD or not.