### PR TITLE
K8SPXC-608 Allow log check only for 1.7.0 or greater

### DIFF
--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -325,13 +325,12 @@ func (r *ReconcilePerconaXtraDBCluster) appStatus(app api.StatefulApp, podSpec *
 					if !isPXC(app) {
 						status.Ready++
 					} else {
-						isPodWaitingForRecovery, _, err := r.isPodWaitingForRecovery(namespace, pod.Name)
-						if err != nil {
-							return api.AppStatus{}, fmt.Errorf("parse %s pod logs: %v", pod.Name, err)
-						}
-
-						isPodReady := !isPodWaitingForRecovery
+						isPodReady := true
 						if cr170OrGreater {
+							isPodReady, _, err := r.isPodWaitingForRecovery(namespace, pod.Name)
+							if err != nil {
+								return api.AppStatus{}, fmt.Errorf("parse %s pod logs: %v", pod.Name, err)
+							}
 							isPodReady = isPodReady && pod.ObjectMeta.Labels["controller-revision-hash"] == sfs.Status.UpdateRevision
 						}
 

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -331,8 +331,7 @@ func (r *ReconcilePerconaXtraDBCluster) appStatus(app api.StatefulApp, podSpec *
 							if err != nil {
 								return api.AppStatus{}, fmt.Errorf("parse %s pod logs: %v", pod.Name, err)
 							}
-							isPodReady = !isPodWaitingForRecovery
-							isPodReady = isPodReady && pod.ObjectMeta.Labels["controller-revision-hash"] == sfs.Status.UpdateRevision
+							isPodReady = !isPodWaitingForRecovery && pod.ObjectMeta.Labels["controller-revision-hash"] == sfs.Status.UpdateRevision
 						}
 
 						if isPodReady {

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -327,10 +327,11 @@ func (r *ReconcilePerconaXtraDBCluster) appStatus(app api.StatefulApp, podSpec *
 					} else {
 						isPodReady := true
 						if cr170OrGreater {
-							isPodReady, _, err := r.isPodWaitingForRecovery(namespace, pod.Name)
+							isPodWaitingForRecovery, _, err := r.isPodWaitingForRecovery(namespace, pod.Name)
 							if err != nil {
 								return api.AppStatus{}, fmt.Errorf("parse %s pod logs: %v", pod.Name, err)
 							}
+							isPodReady = !isPodWaitingForRecovery
 							isPodReady = isPodReady && pod.ObjectMeta.Labels["controller-revision-hash"] == sfs.Status.UpdateRevision
 						}
 


### PR DESCRIPTION
[![K8SPXC-608](https://badgen.net/badge/JIRA/K8SPXC-608/green)](https://jira.percona.com/browse/K8SPXC-608) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

As you may guess from title the operator tries to check
pod logs even for 1.5.0 cr version. It leads to errors since
the corresponding RBAC rule was introduced only since 1.7.0.
As a result cluster status is stucked in initializing state.

`{"level":"error","ts":1610800996.7042642,"logger":"controller_perconaxtradbcluster","msg":"Update status","error":"get pxc status: parse some-name-pxc-2 pod logs: get logs from some-name-pxc-2 pod: get pod logs stream: pods \"some-name-pxc-2\" is forbidden: User \"system:serviceaccount:upgrade-consistency-17013:percona-xtradb-cluster-operator\" cannot get resource \"pods/log\" in API group \"\" in the namespace \"upgrade-consistency-17013\"","stacktrace":"github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc.(*ReconcilePerconaXtraDBCluster).Reconcile.func1\n\t/go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:217\ngithub.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc.(*ReconcilePerconaXtraDBCluster).Reconcile\n\t/go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:557\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/percona/percona-xtrad...
`

`crVersion: 1.5.0`

`status:
  proxysql:
    ready: 1
    size: 1
    status: ready
  pxc:
    ready: 2
    size: 3
    status: initializing
`