### PR TITLE
Update waits in e2e functions for Minikube

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -152,7 +152,7 @@ wait_backup() {
         sleep 1
         echo -n .
         let retry+=1
-        if [ $retry -ge 60 ]; then
+        if [ $retry -ge 120 ]; then
             kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod)
             echo max retry count $retry reached. something went wrong with operator or kubernetes cluster
             exit 1
@@ -212,6 +212,7 @@ deploy_operator() {
     sleep 10
 
     wait_pod "$(get_operator_pod)" "480" "${OPERATOR_NS}"
+    sleep 3
 }
 
 deploy_helm() {

--- a/e2e-tests/one-pod/run
+++ b/e2e-tests/one-pod/run
@@ -20,7 +20,7 @@ spinup_pxc() {
 
     desc 'check if all 3 Pods started'
     wait_for_running "$cluster-pxc" "$size"
-    sleep 10
+    sleep 15
 
     desc 'write data'
     run_mysql \


### PR DESCRIPTION
Update two waits for issues mostly seen in Minikube, but maybe they can be seen in other environments.

1. `one-pod` test was failing because it stops waiting for backup to finish, but the backup finishes a bit later. I have tried with value `90` also, but it doesn't seem to work (at least on minikube).
Since it will wait this long only if the test fails I don't think it's a problem to increase the value.
2. `validation-webhook` test was failing on minikube because the operator gets deployed, but we apply cr before the validation starts running, so this is to make sure that we give it some time for validation webhook to start running after operator pod running.