### PR TITLE
Change autoRecovery option in cr.yaml

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -35,7 +35,7 @@ spec:
   pxc:
     size: 3
     image: percona/percona-xtradb-cluster:8.0.21-12.1
-#    autoRecovery: false
+    autoRecovery: true
 #    schedulerName: mycustom-scheduler
 #    readinessDelaySec: 15
 #    livenessDelaySec: 600


### PR DESCRIPTION
autoRecovery is by default set to `true` so better to have it that way in cr.yaml so it's clear immediately