### PR TITLE
Fix diff in self-healing test for PXC 5.7

### DIFF
--- a/e2e-tests/self-healing/compare/proxy-vars.sql
+++ b/e2e-tests/self-healing/compare/proxy-vars.sql
@@ -30,7 +30,7 @@ admin-stats_system_memory	60
 admin-telnet_admin_ifaces	(null)
 admin-telnet_stats_ifaces	(null)
 admin-vacuum_stats	true
-admin-version	2.0.14-percona-1.1
+admin-version	2.0.15-percona-1.1
 admin-web_enabled	false
 admin-web_port	6080
 mysql-add_ldap_user_comment	
@@ -88,6 +88,7 @@ mysql-max_allowed_packet	67108864
 mysql-max_connections	2048
 mysql-max_stmts_cache	10000
 mysql-max_stmts_per_connection	20
+mysql-max_transaction_idle_time	14400000
 mysql-max_transaction_time	14400000
 mysql-min_num_servers_lantency_awareness	1000
 mysql-mirror_max_concurrency	16
@@ -142,7 +143,7 @@ mysql-query_processor_iterations	0
 mysql-query_retries_on_failure	1
 mysql-reset_connection_algorithm	2
 mysql-server_capabilities	571947
-mysql-server_version	5.7.31
+mysql-server_version	5.7.32
 mysql-servers_stats	true
 mysql-session_idle_ms	1000
 mysql-session_idle_show_processlist	true


### PR DESCRIPTION
Fix the diff for self-healing test for 5.7:
```
+ diff -u /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/self-healing/compare/proxy-vars.sql /tmp/tmp.NCCAVD6Hzf/proxy-vars1.sql
--- /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/self-healing/compare/proxy-vars.sql	2021-01-21 12:35:23.000000000 +0000
+++ /tmp/tmp.NCCAVD6Hzf/proxy-vars1.sql	2021-01-21 13:05:27.068301607 +0000
@@ -30,7 +30,7 @@
 admin-telnet_admin_ifaces	(null)
 admin-telnet_stats_ifaces	(null)
 admin-vacuum_stats	true
-admin-version	2.0.14-percona-1.1
+admin-version	2.0.15-percona-1.1
 admin-web_enabled	false
 admin-web_port	6080
 mysql-add_ldap_user_comment	
@@ -88,6 +88,7 @@
 mysql-max_connections	2048
 mysql-max_stmts_cache	10000
 mysql-max_stmts_per_connection	20
+mysql-max_transaction_idle_time	14400000
 mysql-max_transaction_time	14400000
 mysql-min_num_servers_lantency_awareness	1000
 mysql-mirror_max_concurrency	16
@@ -142,7 +143,7 @@
 mysql-query_retries_on_failure	1
 mysql-reset_connection_algorithm	2
 mysql-server_capabilities	571947
-mysql-server_version	5.7.31
+mysql-server_version	5.7.32
 mysql-servers_stats	true
 mysql-session_idle_ms	1000
 mysql-session_idle_show_processlist	true
```