### PR TITLE
K8SPXC-598 Add support for compressed backups for PITR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,6 +124,7 @@ pipeline {
         VERSION = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}"
         CLUSTER_NAME = sh(script: "echo jenkins-pxc-${GIT_SHORT_COMMIT} | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
         AUTHOR_NAME  = sh(script: "echo ${CHANGE_AUTHOR_EMAIL} | awk -F'@' '{print \$1}'", , returnStdout: true).trim()
+        IMAGE_BACKUP = "perconalab/percona-xtradb-cluster-operator:k8spxc-598-backup"
     }
     agent {
         label 'docker'

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -269,7 +269,7 @@ func (r *Recoverer) recover() (err error) {
 func getLastBackupGTID(infoObj io.Reader, format string) (string, error) {
 	content, err := getDecompressedContent(infoObj, format)
 	if err != nil {
-		return "", errors.Wrap(err, "read object")
+		return "", errors.Wrap(err, "get content")
 	}
 
 	return getGTIDFromContent(content)
@@ -307,7 +307,7 @@ func getDecompressedContent(infoObj io.Reader, format string) ([]byte, error) {
 
 	content, err := ioutil.ReadAll(infoObj)
 	if err != nil {
-		return nil, errors.Wrap(err, "read object")
+		return nil, errors.Wrap(err, "read info object")
 	}
 	_, err = tmpFile.Write(content)
 	if err != nil {

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -141,19 +141,17 @@ func getStartGTIDSet(c BackupS3) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "list %s info fies", prefix)
 	}
-	sort.Strings(listInfo)
-
-	var lastGTID string
 	if len(listInfo) == 0 {
 		return "", errors.New("no info files in backup")
 	}
+	sort.Strings(listInfo)
 
 	infoObj, err := s3.GetObject(listInfo[0])
 	if err != nil {
 		return "", errors.Wrapf(err, "get %s info", prefix)
 	}
 
-	lastGTID, err = getLastBackupGTID(infoObj)
+	lastGTID, err := getLastBackupGTID(infoObj)
 	if err != nil {
 		return "", errors.Wrap(err, "get last backup gtid")
 	}
@@ -298,7 +296,7 @@ func getDecompressedContent(infoObj io.Reader) ([]byte, error) {
 	cmd.Stderr = &errb
 	err := cmd.Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "xbsream cmd run. stderr: %s, stdout: %s", errb.String(), outb.String())
+		return nil, errors.Wrapf(err, "xbsream cmd run. stderr: %s, stdout: %s", errb, outb)
 	}
 	if errb.Len() > 0 {
 		return nil, errors.Errorf("run xbstream error: %s", &errb)

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -296,7 +296,7 @@ func getDecompressedContent(infoObj io.Reader) ([]byte, error) {
 	cmd.Stderr = &errb
 	err := cmd.Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "xbsream cmd run. stderr: %s, stdout: %s", errb, outb)
+		return nil, errors.Wrapf(err, "xbsream cmd run. stderr: %s, stdout: %s", &errb, &outb)
 	}
 	if errb.Len() > 0 {
 		return nil, errors.Errorf("run xbstream error: %s", &errb)

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -277,7 +277,6 @@ func getGTIDFromContent(content []byte) (string, error) {
 	if e == -1 {
 		return "", errors.New("can't find gtid data in backup")
 	}
-	content = content[:e]
 
 	se := bytes.Index(newOut, []byte("'"))
 	set := newOut[se+1 : e]

--- a/cmd/pitr/recoverer/recoverer_test.go
+++ b/cmd/pitr/recoverer/recoverer_test.go
@@ -1,7 +1,6 @@
 package recoverer
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -61,11 +60,11 @@ func TestGetBucketAndPrefix(t *testing.T) {
 	}
 }
 
-func TestGetLastBackupGTID(t *testing.T) {
-	s := `sometext GTID of the last set 'test_set:1-10'
-	`
-	buf := bytes.NewBuffer([]byte(s))
-	set, err := getLastBackupGTID(buf)
+func TestGetGTIDFromContent(t *testing.T) {
+	c := []byte(`sometext GTID of the last set 'test_set:1-10'
+	`)
+
+	set, err := getGTIDFromContent(c)
 	if err != nil {
 		t.Error("get last gtid set", err.Error())
 	}

--- a/e2e-tests/pitr/conf/pitr.yml
+++ b/e2e-tests/pitr/conf/pitr.yml
@@ -13,6 +13,11 @@ spec:
   pxc:
     size: 3
     image: -pxc
+    configuration: |
+      [sst]
+      xbstream-opts=--decompress
+      [xtrabackup]
+      compress=lz4
     resources:
       requests:
         memory: 0.1G


### PR DESCRIPTION
[![K8SPXC-598](https://badgen.net/badge/JIRA/K8SPXC-598/green)](https://jira.percona.com/browse/K8SPXC-598) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PITR needs information about last GTID stored in backup. This information stored in file which can be compressed by xtrabackup, so this PR add functionality that decompress needed file using xbstream tool. If file was not compressed xbstream just return its content