### PR TITLE
K8SPXC-608 Wait for operator namespace deletion on 3.11

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -523,6 +523,9 @@ destroy() {
         oc delete --grace-period=0 --force=true project "$namespace" &
         if [ -n "$OPERATOR_NS" ]; then
             oc delete --grace-period=0 --force=true project "$OPERATOR_NS" &
+            if [ "${OPENSHIFT}" == "3.11" ]; then
+                wait_for_delete "project/$OPERATOR_NS"     # 3.11 Does not delete namespace immediately, let's wait at least 120 seconds till the next step
+            fi
         fi
     else
         kubectl_bin delete --grace-period=0 --force=true namespace "$namespace" &


### PR DESCRIPTION
[![K8SPXC-608](https://badgen.net/badge/JIRA/K8SPXC-608/green)](https://jira.percona.com/browse/K8SPXC-608) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Since 3.11 does not remove namespaces immediately, we need to wait
for namespace removal in order to proceed with further tests