### PR TITLE
K8SPXC-621: check error buffer before closing pipe

### DIFF
--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -307,5 +307,11 @@ func readBinlog(file *os.File, pipe *io.PipeWriter, errBuf *bytes.Buffer, binlog
 		pipe.Write(b[:n])
 		isEmpty = false
 	}
+	// in case of any errors from mysqlbinlog it sends EOF to pipe
+	// to prevent this, need to check error buffer before closing pipe without error
+	if errBuf.Len() != 0 {
+		pipe.CloseWithError(errors.New("mysqlbinlog error:" + errBuf.String()))
+		return
+	}
 	pipe.Close()
 }

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -287,7 +287,8 @@ func (r *Recoverer) setBinlogs() error {
 
 		infoObj, err := r.storage.GetObject(binlog + "-gtid-set")
 		if err != nil {
-			return errors.Wrapf(err, "get %s object with gtid set", binlog)
+			log.Println("Can't get binlog object with gtid set. Name:", binlog, "error", err)
+			continue
 		}
 		content, err := ioutil.ReadAll(infoObj)
 		if err != nil {


### PR DESCRIPTION
[![K8SPXC-621](https://badgen.net/badge/JIRA/K8SPXC-621/green)](https://jira.percona.com/browse/K8SPXC-621) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

pitr: check error buffer before closing pipe

We need this check because if any error occures, mysqlbinlog sends EOF
    to file, and we process further as normal situation.

Now, before closing pipe, we check the error buffer, and if any error
    happens, we cancel upload to s3 and return error correctly.

We will process the failed binlog on next collector iteration