### PR TITLE
K8SPXC-627 Add logic for choosing host with oldest binlogs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,6 +124,7 @@ pipeline {
         VERSION = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}"
         CLUSTER_NAME = sh(script: "echo jenkins-pxc-${GIT_SHORT_COMMIT} | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()
         AUTHOR_NAME  = sh(script: "echo ${CHANGE_AUTHOR_EMAIL} | awk -F'@' '{print \$1}'", , returnStdout: true).trim()
+        IMAGE_BACKUP = "perconalab/percona-xtradb-cluster-operator:k8spxc-627-backup"
     }
     agent {
         label 'docker'

--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -122,10 +122,6 @@ func (c *Collector) close() error {
 	return c.db.Close()
 }
 
-func ChoosePodWithOlderLogs() (string, error) {
-	return "", nil
-}
-
 func (c *Collector) CollectBinLogs() error {
 	list, err := c.db.GetBinLogList()
 	if err != nil {

--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -93,11 +93,6 @@ func (c *Collector) Run() error {
 }
 
 func (c *Collector) newDB() error {
-	host, err := pxc.GetPXCLastHost(c.pxcServiceName)
-	if err != nil {
-		return errors.Wrap(err, "get host")
-	}
-
 	file, err := os.Open("/etc/mysql/mysql-users-secret/xtrabackup")
 	if err != nil {
 		return errors.Wrap(err, "open file")
@@ -107,6 +102,11 @@ func (c *Collector) newDB() error {
 		return errors.Wrap(err, "read password")
 	}
 	c.pxcPass = string(pxcPass)
+
+	host, err := pxc.GetPXCOldestBinlogHost(c.pxcServiceName, c.pxcUser, c.pxcPass)
+	if err != nil {
+		return errors.Wrap(err, "get host")
+	}
 
 	log.Println("Reading binlogs from pxc with hostname=", host)
 
@@ -120,6 +120,10 @@ func (c *Collector) newDB() error {
 
 func (c *Collector) close() error {
 	return c.db.Close()
+}
+
+func ChoosePodWithOlderLogs() (string, error) {
+	return "", nil
 }
 
 func (c *Collector) CollectBinLogs() error {

--- a/cmd/pitr/pxc/pxc.go
+++ b/cmd/pitr/pxc/pxc.go
@@ -113,6 +113,7 @@ func (p *PXC) GetBinLogNamesList() ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "show binary logs")
 	}
+	defer rows.Close()
 
 	var binlogs []string
 	for rows.Next() {

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -157,7 +157,7 @@ const (
 )
 
 func (r *Recoverer) Run() error {
-	host, err := pxc.GetPXCLastHost(r.pxcServiceName)
+	host, err := pxc.GetPXCFirstHost(r.pxcServiceName)
 	if err != nil {
 		return errors.Wrap(err, "get host")
 	}


### PR DESCRIPTION
[![K8SPXC-627](https://badgen.net/badge/JIRA/K8SPXC-627/green)](https://jira.percona.com/browse/K8SPXC-627) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When pod from where collector start uploading binlogs is failed collector should connect to pod with the oldest binlogs in cluster. We need to be sure that we didn't have gap between uploaded files