### PR TITLE
K8SPXC-647 allow change replicas count with "kubectl scale" command

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -68,6 +68,10 @@ spec:
       JSONPath: .metadata.creationTimestamp
   subresources:
     status: {}
+    scale:
+      specReplicasPath: .spec.pxc.size
+      statusReplicasPath: .status.pxc.ready
+      labelSelectorPath: .status.pxc.labelSelectorPath
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -138,12 +138,13 @@ type ClusterCondition struct {
 }
 
 type AppStatus struct {
-	Size    int32    `json:"size,omitempty"`
-	Ready   int32    `json:"ready,omitempty"`
-	Status  AppState `json:"status,omitempty"`
-	Message string   `json:"message,omitempty"`
-	Version string   `json:"version,omitempty"`
-	Image   string   `json:"image,omitempty"`
+	Size              int32    `json:"size,omitempty"`
+	Ready             int32    `json:"ready,omitempty"`
+	Status            AppState `json:"status,omitempty"`
+	Message           string   `json:"message,omitempty"`
+	Version           string   `json:"version,omitempty"`
+	Image             string   `json:"image,omitempty"`
+	LabelSelectorPath string   `json:"labelSelectorPath,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -313,8 +313,9 @@ func (r *ReconcilePerconaXtraDBCluster) appStatus(app api.StatefulApp, podSpec *
 	}
 
 	status := api.AppStatus{
-		Size:   podSpec.Size,
-		Status: api.AppStateInit,
+		Size:              podSpec.Size,
+		Status:            api.AppStateInit,
+		LabelSelectorPath: labels.SelectorFromSet(app.Labels()).String(),
 	}
 
 	for _, pod := range list.Items {


### PR DESCRIPTION
[![K8SPXC-647](https://badgen.net/badge/JIRA/K8SPXC-647/green)](https://jira.percona.com/browse/K8SPXC-647) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

it should be possible to scale up and scale down with the following command
```
kubectl scale --replicas=5 pxc/cluster1
```
also, it should be possible to use HPA with config similar to the next
```
apiVersion: autoscaling/v2beta1
kind: HorizontalPodAutoscaler
metadata:
  name: cluster1
spec:
  minReplicas: 3
  maxReplicas: 5
  metrics:
  - resource:
      name: cpu
      targetAverageUtilization: 2
    type: Resource
  scaleTargetRef:
    apiVersion: pxc.percona.com/v1
    kind: PerconaXtraDBCluster
    name: cluster1
```