### PR TITLE
CLOUD-615 automatically cleanup obsolete tests results in PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,6 +144,7 @@ pipeline {
                     }
                 }
                 sh '''
+                    env
                     if [ ! -d $HOME/google-cloud-sdk/bin ]; then
                         rm -rf $HOME/google-cloud-sdk
                         curl https://sdk.cloud.google.com | bash

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -290,6 +290,13 @@ pipeline {
                     slackSend channel: '#cloud-dev-ci', color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL} owner: @${AUTHOR_NAME}"
                 }
                 if (env.CHANGE_URL) {
+                    for (comment in pullRequest.comments) {
+                        println("Author: ${comment.user}, Comment: ${comment.body}")
+                        if (comment.user.equals('JNKPercona')) {
+                            println("delete comment")
+                            comment.delete()
+                        }
+                    }
                     makeReport()
                     unstash 'IMAGE'
                     def IMAGE = sh(returnStdout: true, script: "cat results/docker/TAG").trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -303,12 +303,16 @@ pipeline {
                         makeReport()
                         pullRequest.comment(TestsReport)
                         println('all')
-                        println(pullRequest.comments)
+                        count = 0
                         for (comment in pullRequest.comments) {
                             println("Author: ${comment.user}, Comment: ${comment.body}")
-                            sh '''
-                                echo ${comment.user}
-                            '''
+                            if (comment.user.equals('JNKPercona')) {
+                                println('user JNKPercona found')
+                                count++
+                                if (count > 1) {
+                                    println('delete comment?')
+                                }
+                            }
                         }
                     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-GKERegion = us-east1-b
+GKERegion='us-east1-b'
 
 void CreateCluster(String CLUSTER_PREFIX) {
     withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {
@@ -11,7 +11,7 @@ void CreateCluster(String CLUSTER_PREFIX) {
             source $HOME/google-cloud-sdk/path.bash.inc
             gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
             gcloud config set project $GCP_PROJECT
-            gcloud container clusters create --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version 1.18 --machine-type n1-standard-4 --preemptible --num-nodes=\$NODES_NUM --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} --no-enable-autoupgrade
+            gcloud container clusters create --zone=${GKERegion} $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version=1.18 --machine-type=n1-standard-4 --preemptible --num-nodes=\$NODES_NUM --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} --no-enable-autoupgrade
             kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user jenkins@"$GCP_PROJECT".iam.gserviceaccount.com
         """
    }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -301,7 +301,7 @@ pipeline {
                 if (env.CHANGE_URL) {
                     withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_API_TOKEN')]) {
                         makeReport()
-                        pullRequest.addLabel('tests')
+                        pullRequest.comment("${TestsReport}")
                         for (comment in pullRequest.comments) {
                             echo "Author: ${comment.user}, Comment: ${comment.body}"
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -301,9 +301,9 @@ pipeline {
                 if (env.CHANGE_URL) {
                     withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_API_TOKEN')]) {
                         makeReport()
-                        pullRequest.comment("${TestsReport}")
+                        pullRequest.comment(TestsReport)
                         for (comment in pullRequest.comments) {
-                            echo "Author: ${comment.user}, Comment: ${comment.body}"
+                            println("Author: ${comment.user}, Comment: ${comment.body}")
                         }
                     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -270,13 +270,70 @@ pipeline {
                         CreateCluster('upgrade')
                         runTest('upgrade-haproxy', 'upgrade')
                         ShutdownCluster('upgrade')
+                        CreateCluster('upgrade')
+                        runTest('upgrade-proxysql', 'upgrade')
+                        ShutdownCluster('upgrade')
+                        CreateCluster('upgrade')
+                        runTest('smart-update', 'upgrade')
+                        runTest('upgrade-consistency', 'upgrade')
+                        ShutdownCluster('upgrade')
                     }
                 }
                 stage('E2E Basic Tests') {
                     steps {
                         CreateCluster('basic')
                         runTest('haproxy', 'basic')
+                        runTest('init-deploy', 'basic')
+                        runTest('limits', 'basic')
+                        runTest('monitoring-2-0', 'basic')
+                        runTest('affinity', 'basic')
+                        runTest('one-pod', 'basic')
+                        runTest('auto-tuning', 'basic')
+                        runTest('proxysql-sidecar-res-limits', 'basic')
+                        runTest('users', 'basic')
+                        runTest('tls-issue-self','basic')
+                        runTest('tls-issue-cert-manager','basic')
+                        runTest('tls-issue-cert-manager-ref','basic')
+                        runTest('validation-hook','basic')
                         ShutdownCluster('basic')
+                    }
+                }
+                stage('E2E Scaling') {
+                    steps {
+                        CreateCluster('scaling')
+                        runTest('scaling', 'scaling')
+                        runTest('scaling-proxysql', 'scaling')
+                        runTest('security-context', 'scaling')
+                        ShutdownCluster('scaling')
+                    }
+                }
+                stage('E2E SelfHealing') {
+                    steps {
+                        CreateCluster('selfhealing')
+                        runTest('storage', 'selfhealing')
+                        runTest('self-healing', 'selfhealing')
+                        runTest('self-healing-advanced', 'selfhealing')
+                        runTest('operator-self-healing', 'selfhealing')
+                        ShutdownCluster('selfhealing')
+                    }
+                }
+                stage('E2E Backups') {
+                    steps {
+                        CreateCluster('backups')
+                        runTest('recreate', 'backups')
+                        runTest('restore-to-encrypted-cluster', 'backups')
+                        runTest('demand-backup', 'backups')
+                        runTest('pitr', 'backups')
+                        runTest('demand-backup-encrypted-with-tls', 'backups')
+                        runTest('scheduled-backup', 'backups')
+                        ShutdownCluster('backups')
+                    }
+                }
+                stage('E2E BigData') {
+                    steps {
+                        CreateCluster('bigdata')
+                        runTest('big-data', 'bigdata')
+                        ShutdownCluster('bigdata')
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -283,24 +283,22 @@ pipeline {
                     slackSend channel: '#cloud-dev-ci', color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL} owner: @${AUTHOR_NAME}"
                 }
                 if (env.CHANGE_URL) {
+                    makeReport()
                     unstash 'IMAGE'
                     def IMAGE = sh(returnStdout: true, script: "cat results/docker/TAG").trim()
-                    TestsReport = TestsReport + "\r\n\r\ncommit: ${env.CHANGE_URL}/commits/${env.GIT_COMMIT}\r\nimage: ${IMAGE}"
-                    withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_API_TOKEN')]) {
-                        makeReport()
-                        count = 0
-                        for (comment in pullRequest.comments) {
-                            println("Author: ${comment.user}, Comment: ${comment.body}")
-                            if (comment.user.equals('JNKPercona')) {
-                                count++
-                                if (count == 1) {
-                                    println("change comment body")
-                                    comment.body = TestsReport
-                                }
-                                if (count > 1) {
-                                    println("delete comment")
-                                    comment.delete()
-                                }
+                    TestsReport = TestsReport + "\r\n\r\ncommit: ${env.CHANGE_URL}/commits/${env.GIT_COMMIT}\r\nimage: `${IMAGE}`\r\n"
+                    count = 0
+                    for (comment in pullRequest.comments) {
+                        println("Author: ${comment.user}, Comment: ${comment.body}")
+                        if (comment.user.equals('JNKPercona')) {
+                            count++
+                            if (count == 1) {
+                                println("change comment body")
+                                comment.body = TestsReport
+                            }
+                            if (count > 1) {
+                                println("delete comment")
+                                comment.delete()
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+GKERegion = us-east1-b
 
 void CreateCluster(String CLUSTER_PREFIX) {
     withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {
@@ -10,7 +11,7 @@ void CreateCluster(String CLUSTER_PREFIX) {
             source $HOME/google-cloud-sdk/path.bash.inc
             gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
             gcloud config set project $GCP_PROJECT
-            gcloud container clusters create --zone us-central1-a $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version 1.17 --machine-type n1-standard-4 --preemptible --num-nodes=\$NODES_NUM --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} --no-enable-autoupgrade
+            gcloud container clusters create --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version 1.18 --machine-type n1-standard-4 --preemptible --num-nodes=\$NODES_NUM --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} --no-enable-autoupgrade
             kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user jenkins@"$GCP_PROJECT".iam.gserviceaccount.com
         """
    }
@@ -22,7 +23,7 @@ void ShutdownCluster(String CLUSTER_PREFIX) {
             source $HOME/google-cloud-sdk/path.bash.inc
             gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
             gcloud config set project $GCP_PROJECT
-            gcloud container clusters delete --zone us-central1-a $CLUSTER_NAME-${CLUSTER_PREFIX}
+            gcloud container clusters delete --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX}
         """
    }
 }
@@ -365,7 +366,7 @@ pipeline {
                             source $HOME/google-cloud-sdk/path.bash.inc
                             gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
                             gcloud config set project $GCP_PROJECT
-                            gcloud container clusters delete --zone us-central1-a $CLUSTER_NAME-basic $CLUSTER_NAME-scaling $CLUSTER_NAME-selfhealing $CLUSTER_NAME-backups $CLUSTER_NAME-bigdata $CLUSTER_NAME-upgrade | true
+                            gcloud container clusters delete --zone $GKERegion $CLUSTER_NAME-basic $CLUSTER_NAME-scaling $CLUSTER_NAME-selfhealing $CLUSTER_NAME-backups $CLUSTER_NAME-bigdata $CLUSTER_NAME-upgrade | true
                             sudo docker rmi -f \$(sudo docker images -q) || true
 
                             sudo rm -rf $HOME/google-cloud-sdk

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-GKERegion='us-east1-b'
+GKERegion='us-central1'
 
 void CreateCluster(String CLUSTER_PREFIX) {
     withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ void installRpms() {
 }
 
 def skipBranchBulds = true
-if ( env.CHANGE_URL ) {
+if ( env.CHANGE_ID ) {
     skipBranchBulds = false
 }
 
@@ -298,12 +298,17 @@ pipeline {
                 }
             }
             script {
-                if (env.CHANGE_URL) {
+                if (env.CHANGE_ID) {
                     withCredentials([string(credentialsId: 'GITHUB_API_TOKEN', variable: 'GITHUB_API_TOKEN')]) {
                         makeReport()
                         pullRequest.comment(TestsReport)
+                        println('all')
+                        println(pullRequest.comments)
                         for (comment in pullRequest.comments) {
                             println("Author: ${comment.user}, Comment: ${comment.body}")
+                            sh '''
+                                echo ${comment.user}
+                            '''
                         }
                     }
 


### PR DESCRIPTION
[![CLOUD-615](https://badgen.net/badge/JIRA/CLOUD-615/green)](https://jira.percona.com/browse/CLOUD-615) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

each time when we push to commit to PR or rerun tests the new comment is added into the GitHub PR.
As a result, we have tens of huge obsolete messages in each PR.
It is better to automatically clean up obsolete test results before push the newest test results.
