### PR TITLE
K8SPXC-632 Get last gtid from backup last gtid set

### DIFF
--- a/cmd/pitr/pxc/pxc.go
+++ b/cmd/pitr/pxc/pxc.go
@@ -180,16 +180,15 @@ func (p *PXC) GetBinLogFirstTimestamp(binlog string) (string, error) {
 	return timestamp, nil
 }
 
-func (p *PXC) IsGTIDSubset(subSet, gtidSet string) (bool, error) {
-	var isSubset bool
-	row := p.db.QueryRow("SELECT GTID_SUBSET(?,?)", subSet, gtidSet)
-
-	err := row.Scan(&isSubset)
+func (p *PXC) SubtractGTIDSet(set, subSet string) (string, error) {
+	var result string
+	row := p.db.QueryRow("SELECT GTID_SUBTRACT(?,?)", set, subSet)
+	err := row.Scan(&result)
 	if err != nil {
-		return false, errors.Wrap(err, "scan binlog timestamp")
+		return "", errors.Wrap(err, "scan gtid subtract result")
 	}
 
-	return isSubset, nil
+	return result, nil
 }
 
 func getNodesByServiceName(pxcServiceName string) ([]string, error) {

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -281,7 +281,7 @@ func getGTIDFromContent(content []byte) (string, error) {
 	se := bytes.Index(newOut, []byte("'"))
 	set := newOut[se+1 : e]
 
-	return getLastGTIDFromSet(string(set)), nil
+	return string(set), nil
 }
 
 func getDecompressedContent(infoObj io.Reader) ([]byte, error) {
@@ -331,11 +331,11 @@ func (r *Recoverer) setBinlogs() error {
 		}
 		binlogGTIDSet := string(content)
 		binlogs = append(binlogs, binlog)
-		isSubset, err := r.db.IsGTIDSubset(r.startGTID, binlogGTIDSet)
+		subResult, err := r.db.SubtractGTIDSet(r.startGTID, binlogGTIDSet)
 		if err != nil {
 			return errors.Wrapf(err, "check if '%s' is a subset of '%s", r.startGTID, binlogGTIDSet)
 		}
-		if isSubset {
+		if subResult != r.startGTID {
 			break
 		}
 	}
@@ -353,16 +353,4 @@ func reverse(list []string) {
 		opp := len(list) - 1 - i
 		list[i], list[opp] = list[opp], list[i]
 	}
-}
-
-func getLastGTIDFromSet(set string) string {
-	a := strings.Split(set, ":")
-	if len(a) < 2 {
-		return set
-	}
-	i := strings.Split(a[1], "-")
-	if len(i) < 2 {
-		return set
-	}
-	return a[0] + ":" + i[1]
 }

--- a/cmd/pitr/recoverer/recoverer_test.go
+++ b/cmd/pitr/recoverer/recoverer_test.go
@@ -72,33 +72,3 @@ func TestGetGTIDFromContent(t *testing.T) {
 		t.Error("set not test_set:1-10 but", set)
 	}
 }
-
-func TestGetLastGTIDFromSet(t *testing.T) {
-	type testCase struct {
-		gtidSet      string
-		expectedGTID string
-	}
-
-	cases := []testCase{
-		{
-			gtidSet:      "f2c837be-7069-11eb-900d-bb9b8c763e5b:1-17",
-			expectedGTID: "f2c837be-7069-11eb-900d-bb9b8c763e5b:17",
-		},
-		{
-			gtidSet:      "f2c837be-7069-11eb-900d-bb9b8c763e5b:1",
-			expectedGTID: "f2c837be-7069-11eb-900d-bb9b8c763e5b:1",
-		},
-		{
-			gtidSet:      "f2c837be-7069-11eb-900d-bb9b8c763e5b:17",
-			expectedGTID: "f2c837be-7069-11eb-900d-bb9b8c763e5b:17",
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.gtidSet, func(t *testing.T) {
-			set := getLastGTIDFromSet(c.gtidSet)
-			if set != c.expectedGTID {
-				t.Errorf("expect '%s', got '%s'", c.expectedGTID, set)
-			}
-		})
-	}
-}

--- a/cmd/pitr/recoverer/recoverer_test.go
+++ b/cmd/pitr/recoverer/recoverer_test.go
@@ -72,3 +72,33 @@ func TestGetGTIDFromContent(t *testing.T) {
 		t.Error("set not test_set:1-10 but", set)
 	}
 }
+
+func TestGetLastGTIDFromSet(t *testing.T) {
+	type testCase struct {
+		gtidSet      string
+		expectedGTID string
+	}
+
+	cases := []testCase{
+		{
+			gtidSet:      "f2c837be-7069-11eb-900d-bb9b8c763e5b:1-17",
+			expectedGTID: "f2c837be-7069-11eb-900d-bb9b8c763e5b:17",
+		},
+		{
+			gtidSet:      "f2c837be-7069-11eb-900d-bb9b8c763e5b:1",
+			expectedGTID: "f2c837be-7069-11eb-900d-bb9b8c763e5b:1",
+		},
+		{
+			gtidSet:      "f2c837be-7069-11eb-900d-bb9b8c763e5b:17",
+			expectedGTID: "f2c837be-7069-11eb-900d-bb9b8c763e5b:17",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.gtidSet, func(t *testing.T) {
+			set := getLastGTIDFromSet(c.gtidSet)
+			if set != c.expectedGTID {
+				t.Errorf("expect '%s', got '%s'", c.expectedGTID, set)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[![K8SPXC-632](https://badgen.net/badge/JIRA/K8SPXC-632/green)](https://jira.percona.com/browse/K8SPXC-632) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Backups information about last GTID can be present like set which larger than GTID set of binlog file. So we can't understand on which binlog file should stop recover process . In this PR we add logic to solve this issue by using GTID_SUBTRACT to detect that backups last-gtid-set contains GTID from binlog