### PR TITLE
add namespace support in copy-backup script

### DIFF
--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -7,7 +7,14 @@ ACCESS_KEY_ID=${ACCESS_KEY_ID:-}
 SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY:-}
 ENDPOINT=${ENDPOINT:-}
 DEFAULT_REGION=${DEFAULT_REGION:-us-east-1}
-xbcloud=$(which xbcloud) # it is needed to have full path to xbcloud on some platforms
+
+# it is needed to have full path to xbcloud on some platforms
+if ! xbcloud=$(which xbcloud); then
+  echo "No xtrabackup binaries found, please install them:"
+  echo "https://www.percona.com/downloads/Percona-XtraBackup-LATEST"
+  echo "https://formulae.brew.sh/formula/percona-xtrabackup"
+  exit 1
+fi
 
 check_ctrl() {
     if [ -x "$(command -v kubectl)" ]; then
@@ -28,6 +35,7 @@ usage() {
 		    <backup-name>  the backup name
 		                   it can be obtained with the "$ctrl get pxc-backup" command
 		    <local/dir>    the name of destination directory on local machine
+		    <namespace>    optionally specify a namespace
 	EOF
     exit 1
 }
@@ -68,58 +76,84 @@ enable_logging() {
     fi
 }
 
-check_input() {
-    local backup_dest=$1
-    local dest_dir=$2
+check_input_namespace() {
+    local namespace=${1}
 
-    echo
-    if [ -z "$backup_dest" ] || [ -z "$dest_dir" ]; then
-        usage
+    if [ -n "$namespace" ]; then
+        ctrl="$ctrl -n $namespace"
     fi
+}
 
-    if [ ! -e "$dest_dir" ]; then
-        mkdir -p "$dest_dir"
-    fi
+check_input_destination() {
+  local backup_dest=$1
+  local dest_dir=$2
 
-    if [ "${backup_dest:0:4}" = "pvc/" ]; then
-        if ! $ctrl get "$backup_dest" 1>/dev/null; then
-            printf "[ERROR] '%s' PVC doesn't exists.\n\n" "$backup_dest"
-            usage
-        fi
-    elif [ "${backup_dest:0:5}" = "s3://" ]; then
-        env -i $CREDENTIALS $xbcloud get ${backup_dest} xtrabackup_info 1>/dev/null
-    else
-        usage
-    fi
+  if [ -z "$backup_dest" ] || [ -z "$dest_dir" ]; then
+      usage
+  fi
 
-    if [ ! -d "$dest_dir" ]; then
-        printf "[ERROR] '%s' is not local directory.\n\n" "$dest_dir"
-        usage
-    fi
+  if [ ! -e "$dest_dir" ]; then
+      mkdir -p "$dest_dir"
+  fi
+
+  if [ "${backup_dest:0:4}" = "pvc/" ]; then
+      if ! $ctrl get "$backup_dest" 1>/dev/null; then
+          printf "[ERROR] '%s' PVC doesn't exists.\n\n" "$backup_dest"
+          usage
+      fi
+  elif [ "${backup_dest:0:5}" = "s3://" ]; then
+      env -i $CREDENTIALS $xbcloud get ${backup_dest} xtrabackup_info 1>/dev/null
+  else
+      echo "Can't find $backup_dest backup"
+      usage
+  fi
+
+  if [ ! -d "$dest_dir" ]; then
+      printf "[ERROR] '%s' is not local directory.\n\n" "$dest_dir"
+      usage
+  fi
+
 }
 
 start_tmp_pod() {
     local backup_pvc=$1
 
-    $ctrl delete pod/backup-access 2>/dev/null || :
-    cat - <<-EOF | $ctrl apply -f -
-		apiVersion: v1
-		kind: Pod
-		metadata:
-		  name: backup-access
-		spec:
-		      containers:
-		      - name: xtrabackup
-		        image: percona/percona-xtradb-cluster-operator:0.3.0-backup
-		        volumeMounts:
-		        - name: backup
-		          mountPath: /backup
-		      restartPolicy: Never
-		      volumes:
-		      - name: backup
-		        persistentVolumeClaim:
-		          claimName: ${backup_pvc#pvc/}
-	EOF
+    if [ -n "$namespace" ]; then
+      $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
+kind: Pod
+metadata:
+  name: backup-access
+  namespace: $namespace
+spec:
+  containers:
+  - name: xtrabackup
+    image: percona/percona-xtradb-cluster-operator:0.3.0-backup
+    volumeMounts:
+    - name: backup
+      mountPath: /backup
+  restartPolicy: Never
+  volumes:
+  - name: backup
+    persistentVolumeClaim:
+      claimName: ${backup_pvc#pvc/}" | tee /tmp/nm | $ctrl apply -f -
+    else
+      $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
+kind: Pod
+metadata:
+  name: backup-access
+spec:
+  containers:
+  - name: xtrabackup
+    image: percona/percona-xtradb-cluster-operator:0.3.0-backup
+    volumeMounts:
+    - name: backup
+      mountPath: /backup
+  restartPolicy: Never
+  volumes:
+  - name: backup
+    persistentVolumeClaim:
+      claimName: ${backup_pvc#pvc/}" | tee /tmp/nm | $ctrl apply -f -
+    fi
 
     echo -n Starting pod.
     until $ctrl get pod/backup-access -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null | grep -q 'true'; do
@@ -159,13 +193,15 @@ stop_tmp_pod() {
 main() {
     local backup=$1
     local dest_dir=$2
+    local namespace=$3
     local backup_dest
 
     check_ctrl
     enable_logging
+    check_input_namespace "$namespace"
     get_backup_dest "$backup"
     backup_dest=$(get_backup_dest "$backup")
-    check_input "$backup_dest" "$dest_dir"
+    check_input_destination "$backup_dest" "$dest_dir" "$namespace"
 
     if [ "${backup_dest:0:4}" = "pvc/" ]; then
         start_tmp_pod "$backup_dest"

--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -120,28 +120,7 @@ start_tmp_pod() {
 
     $ctrl delete pod/backup-access 2>/dev/null || :
 
-    if [ -n "$namespace" ]; then
-      cat - <<-EOF | $ctrl apply -f -
-apiVersion: v1
-kind: Pod
-metadata:
-  name: backup-access
-  namespace: $namespace
-spec:
-  containers:
-  - name: xtrabackup
-    image: percona/percona-xtradb-cluster-operator:0.3.0-backup
-    volumeMounts:
-    - name: backup
-      mountPath: /backup
-  restartPolicy: Never
-  volumes:
-  - name: backup
-    persistentVolumeClaim:
-      claimName: ${backup_pvc#pvc/}
-EOF
-    else
-      cat - <<-EOF | $ctrl apply -f -
+    cat - <<-EOF | $ctrl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -159,7 +138,6 @@ spec:
     persistentVolumeClaim:
       claimName: ${backup_pvc#pvc/}
 EOF
-    fi
 
     echo -n Starting pod.
     until $ctrl get pod/backup-access -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null | grep -q 'true'; do

--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -118,8 +118,11 @@ check_input_destination() {
 start_tmp_pod() {
     local backup_pvc=$1
 
+    $ctrl delete pod/backup-access 2>/dev/null || :
+
     if [ -n "$namespace" ]; then
-      $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
+      cat - <<-EOF | $ctrl apply -f -
+apiVersion: v1
 kind: Pod
 metadata:
   name: backup-access
@@ -135,9 +138,11 @@ spec:
   volumes:
   - name: backup
     persistentVolumeClaim:
-      claimName: ${backup_pvc#pvc/}" | $ctrl apply -f -
+      claimName: ${backup_pvc#pvc/}
+EOF
     else
-      $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
+      cat - <<-EOF | $ctrl apply -f -
+apiVersion: v1
 kind: Pod
 metadata:
   name: backup-access
@@ -152,7 +157,8 @@ spec:
   volumes:
   - name: backup
     persistentVolumeClaim:
-      claimName: ${backup_pvc#pvc/}" | $ctrl apply -f -
+      claimName: ${backup_pvc#pvc/}
+EOF
     fi
 
     echo -n Starting pod.

--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -135,7 +135,7 @@ spec:
   volumes:
   - name: backup
     persistentVolumeClaim:
-      claimName: ${backup_pvc#pvc/}" | tee /tmp/nm | $ctrl apply -f -
+      claimName: ${backup_pvc#pvc/}" | $ctrl apply -f -
     else
       $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
 kind: Pod
@@ -152,7 +152,7 @@ spec:
   volumes:
   - name: backup
     persistentVolumeClaim:
-      claimName: ${backup_pvc#pvc/}" | tee /tmp/nm | $ctrl apply -f -
+      claimName: ${backup_pvc#pvc/}" | $ctrl apply -f -
     fi
 
     echo -n Starting pod.
@@ -201,7 +201,7 @@ main() {
     check_input_namespace "$namespace"
     get_backup_dest "$backup"
     backup_dest=$(get_backup_dest "$backup")
-    check_input_destination "$backup_dest" "$dest_dir" "$namespace"
+    check_input_destination "$backup_dest" "$dest_dir"
 
     if [ "${backup_dest:0:4}" = "pvc/" ]; then
         start_tmp_pod "$backup_dest"


### PR DESCRIPTION
* I think namespace parameter is more often used by people than having it in a context

* This change has backwards compatibility to not use namespace as parameter if that's preferable by user

* Additionally, the script was tested in Mac OS so it covers more users

* Restore option tested from this backup, but using restore.yaml which is personally better than restore-backup.sh so didn't touch it in this PR

Summary: please feel free to decline if the script is not planned to use, doesn't fit into your plan or give me a guide on how to adjust my changes to be ready for merge based on your style, process, requirements, etc.

Thank you