### PR TITLE
K8SPXC-614: Fix updateOrCreate function

### DIFF
--- a/e2e-tests/security-context/compare/cronjob_adc5a-each-hour-pvc.yml
+++ b/e2e-tests/security-context/compare/cronjob_adc5a-each-hour-pvc.yml
@@ -35,7 +35,7 @@ spec:
             - args:
                 - sh
                 - -c
-                - "\n\t\t\t\t\t\t\tcat <<-EOF | kubectl apply -f -\n\t\t\t\t\t\t\t\t\tapiVersion: pxc.percona.com/v1\n\t\t\t\t\t\t\t\t\tkind: PerconaXtraDBClusterBackup\n\t\t\t\t\t\t\t\t\tmetadata:\n\t\t\t\t\t\t\t\t\t  name: \"cron-${pxcCluster:0:16}-pvc-$(date -u \"+%Y%m%d%H%M%S\")-${suffix}\"\n\t\t\t\t\t\t\t\t\t  labels:\n\t\t\t\t\t\t\t\t\t    ancestor: \"adc5a-each-hour-pvc\"\n\t\t\t\t\t\t\t\t\t    cluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t    type: \"cron\"\n\t\t\t\t\t\t\t\t\tspec:\n\t\t\t\t\t\t\t\t\t  pxcCluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t  storageName: \"pvc\"\n\t\t\t\t\t\t\tEOF\n\t\t\t\t\t\t\t"
+                - "\n\t\t\t\t\t\t\tcat <<-EOF | kubectl apply -f -\n\t\t\t\t\t\t\t\t\tapiVersion: pxc.percona.com/v1\n\t\t\t\t\t\t\t\t\tkind: PerconaXtraDBClusterBackup\n\t\t\t\t\t\t\t\t\tmetadata:\n\t\t\t\t\t\t\t\t\t  finalizers: [ ]\n\t\t\t\t\t\t\t\t\t  name: \"cron-${pxcCluster:0:16}-pvc-$(date -u \"+%Y%m%d%H%M%S\")-${suffix}\"\n\t\t\t\t\t\t\t\t\t  labels:\n\t\t\t\t\t\t\t\t\t    ancestor: \"adc5a-each-hour-pvc\"\n\t\t\t\t\t\t\t\t\t    cluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t    type: \"cron\"\n\t\t\t\t\t\t\t\t\tspec:\n\t\t\t\t\t\t\t\t\t  pxcCluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t  storageName: \"pvc\"\n\t\t\t\t\t\t\tEOF\n\t\t\t\t\t\t\t"
               env:
                 - name: pxcCluster
                   value: sec-context

--- a/pkg/pxc/service.go
+++ b/pkg/pxc/service.go
@@ -212,12 +212,14 @@ func NewServiceHAProxy(cr *api.PerconaXtraDBCluster, owners ...metav1.OwnerRefer
 	if cr.Spec.HAProxy != nil && len(cr.Spec.HAProxy.ServiceType) > 0 {
 		svcType = cr.Spec.HAProxy.ServiceType
 	}
+
 	serviceAnnotations := make(map[string]string)
 	loadBalancerSourceRanges := []string{}
 	if cr.Spec.HAProxy != nil {
 		serviceAnnotations = cr.Spec.HAProxy.ServiceAnnotations
 		loadBalancerSourceRanges = cr.Spec.HAProxy.LoadBalancerSourceRanges
 	}
+
 	obj := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",


### PR DESCRIPTION
[![K8SPXC-614](https://badgen.net/badge/JIRA/K8SPXC-614/green)](https://jira.percona.com/browse/K8SPXC-614) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR fixes `createOrUpdate` func
Previously `DeepCopyObject` was used. Somewhy after we get deep copy of object and use it as an input of `client.Get` it returns us equal object. This is why I create new empty object and use it as an input of `client.Get`