### PR TITLE
Fix diff in security-context e2e test

### DIFF
--- a/e2e-tests/security-context/compare/cronjob_adc5a-each-hour-pvc.yml
+++ b/e2e-tests/security-context/compare/cronjob_adc5a-each-hour-pvc.yml
@@ -35,7 +35,7 @@ spec:
             - args:
                 - sh
                 - -c
-                - "\n\t\t\t\t\t\t\tcat <<-EOF | kubectl apply -f -\n\t\t\t\t\t\t\t\t\tapiVersion: pxc.percona.com/v1\n\t\t\t\t\t\t\t\t\tkind: PerconaXtraDBClusterBackup\n\t\t\t\t\t\t\t\t\tmetadata:\n\t\t\t\t\t\t\t\t\t  name: \"cron-${pxcCluster:0:16}-pvc-$(date -u \"+%Y%m%d%H%M%S\")-${suffix}\"\n\t\t\t\t\t\t\t\t\t  labels:\n\t\t\t\t\t\t\t\t\t    ancestor: \"adc5a-each-hour-pvc\"\n\t\t\t\t\t\t\t\t\t    cluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t    type: \"cron\"\n\t\t\t\t\t\t\t\t\tspec:\n\t\t\t\t\t\t\t\t\t  pxcCluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t  storageName: \"pvc\"\n\t\t\t\t\t\t\tEOF\n\t\t\t\t\t\t\t"
+                - "\n\t\t\t\t\t\t\tcat <<-EOF | kubectl apply -f -\n\t\t\t\t\t\t\t\t\tapiVersion: pxc.percona.com/v1\n\t\t\t\t\t\t\t\t\tkind: PerconaXtraDBClusterBackup\n\t\t\t\t\t\t\t\t\tmetadata:\n\t\t\t\t\t\t\t\t\t  finalizers: [ ]\n\t\t\t\t\t\t\t\t\t  name: \"cron-${pxcCluster:0:16}-pvc-$(date -u \"+%Y%m%d%H%M%S\")-${suffix}\"\n\t\t\t\t\t\t\t\t\t  labels:\n\t\t\t\t\t\t\t\t\t    ancestor: \"adc5a-each-hour-pvc\"\n\t\t\t\t\t\t\t\t\t    cluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t    type: \"cron\"\n\t\t\t\t\t\t\t\t\tspec:\n\t\t\t\t\t\t\t\t\t  pxcCluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t  storageName: \"pvc\"\n\t\t\t\t\t\t\tEOF\n\t\t\t\t\t\t\t"
               env:
                 - name: pxcCluster
                   value: sec-context


### PR DESCRIPTION
this was the diff:
```
+ diff -u /Users/plavi/Development/percona/kubernetes-operators/production/percona-xtradb-cluster-operator/e2e-tests/security-context/compare/cronjob_adc5a-each-hour-pvc.yml /var/folders/dp/lhps6h090mgbd_h950k16wg40000gn/T/tmp.imOHBfwd/cronjob_adc5a-each-hour-pvc.yml
--- /Users/plavi/Development/percona/kubernetes-operators/production/percona-xtradb-cluster-operator/e2e-tests/security-context/compare/cronjob_adc5a-each-hour-pvc.yml 2021-02-03 10:28:29.000000000 +0100
+++ /var/folders/dp/lhps6h090mgbd_h950k16wg40000gn/T/tmp.imOHBfwd/cronjob_adc5a-each-hour-pvc.yml 2021-03-18 09:38:45.000000000 +0100
@@ -35,7 +35,7 @@
             - args:
                 - sh
                 - -c
-                - "\n\t\t\t\t\t\t\tcat <<-EOF | kubectl apply -f -\n\t\t\t\t\t\t\t\t\tapiVersion: pxc.percona.com/v1\n\t\t\t\t\t\t\t\t\tkind: PerconaXtraDBClusterBackup\n\t\t\t\t\t\t\t\t\tmetadata:\n\t\t\t\t\t\t\t\t\t  name: \"cron-${pxcCluster:0:16}-pvc-$(date -u \"+%Y%m%d%H%M%S\")-${suffix}\"\n\t\t\t\t\t\t\t\t\t  labels:\n\t\t\t\t\t\t\t\t\t    ancestor: \"adc5a-each-hour-pvc\"\n\t\t\t\t\t\t\t\t\t    cluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t    type: \"cron\"\n\t\t\t\t\t\t\t\t\tspec:\n\t\t\t\t\t\t\t\t\t  pxcCluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t  storageName: \"pvc\"\n\t\t\t\t\t\t\tEOF\n\t\t\t\t\t\t\t"
+                - "\n\t\t\t\t\t\t\tcat <<-EOF | kubectl apply -f -\n\t\t\t\t\t\t\t\t\tapiVersion: pxc.percona.com/v1\n\t\t\t\t\t\t\t\t\tkind: PerconaXtraDBClusterBackup\n\t\t\t\t\t\t\t\t\tmetadata:\n\t\t\t\t\t\t\t\t\t  finalizers: [ ]\n\t\t\t\t\t\t\t\t\t  name: \"cron-${pxcCluster:0:16}-pvc-$(date -u \"+%Y%m%d%H%M%S\")-${suffix}\"\n\t\t\t\t\t\t\t\t\t  labels:\n\t\t\t\t\t\t\t\t\t    ancestor: \"adc5a-each-hour-pvc\"\n\t\t\t\t\t\t\t\t\t    cluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t    type: \"cron\"\n\t\t\t\t\t\t\t\t\tspec:\n\t\t\t\t\t\t\t\t\t  pxcCluster: \"${pxcCluster}\"\n\t\t\t\t\t\t\t\t\t  storageName: \"pvc\"\n\t\t\t\t\t\t\tEOF\n\t\t\t\t\t\t\t"
               env:
                 - name: pxcCluster
                   value: sec-context
```