### PR TITLE
Use hostname instead of IP

### DIFF
--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -7,7 +7,14 @@ ACCESS_KEY_ID=${ACCESS_KEY_ID:-}
 SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY:-}
 ENDPOINT=${ENDPOINT:-}
 DEFAULT_REGION=${DEFAULT_REGION:-us-east-1}
-xbcloud=$(which xbcloud) # it is needed to have full path to xbcloud on some platforms
+
+# it is needed to have full path to xbcloud on some platforms
+if ! xbcloud=$(which xbcloud); then
+  echo "No xtrabackup binaries found, please install them:"
+  echo "https://www.percona.com/downloads/Percona-XtraBackup-LATEST"
+  echo "https://formulae.brew.sh/formula/percona-xtrabackup"
+  exit 1
+fi
 
 check_ctrl() {
     if [ -x "$(command -v kubectl)" ]; then
@@ -28,6 +35,7 @@ usage() {
 		    <backup-name>  the backup name
 		                   it can be obtained with the "$ctrl get pxc-backup" command
 		    <local/dir>    the name of destination directory on local machine
+		    <namespace>    optionally specify a namespace
 	EOF
     exit 1
 }
@@ -68,58 +76,84 @@ enable_logging() {
     fi
 }
 
-check_input() {
-    local backup_dest=$1
-    local dest_dir=$2
+check_input_namespace() {
+    local namespace=${1}
 
-    echo
-    if [ -z "$backup_dest" ] || [ -z "$dest_dir" ]; then
-        usage
+    if [ -n "$namespace" ]; then
+        ctrl="$ctrl -n $namespace"
     fi
+}
 
-    if [ ! -e "$dest_dir" ]; then
-        mkdir -p "$dest_dir"
-    fi
+check_input_destination() {
+  local backup_dest=$1
+  local dest_dir=$2
 
-    if [ "${backup_dest:0:4}" = "pvc/" ]; then
-        if ! $ctrl get "$backup_dest" 1>/dev/null; then
-            printf "[ERROR] '%s' PVC doesn't exists.\n\n" "$backup_dest"
-            usage
-        fi
-    elif [ "${backup_dest:0:5}" = "s3://" ]; then
-        env -i $CREDENTIALS $xbcloud get ${backup_dest} xtrabackup_info 1>/dev/null
-    else
-        usage
-    fi
+  if [ -z "$backup_dest" ] || [ -z "$dest_dir" ]; then
+      usage
+  fi
 
-    if [ ! -d "$dest_dir" ]; then
-        printf "[ERROR] '%s' is not local directory.\n\n" "$dest_dir"
-        usage
-    fi
+  if [ ! -e "$dest_dir" ]; then
+      mkdir -p "$dest_dir"
+  fi
+
+  if [ "${backup_dest:0:4}" = "pvc/" ]; then
+      if ! $ctrl get "$backup_dest" 1>/dev/null; then
+          printf "[ERROR] '%s' PVC doesn't exists.\n\n" "$backup_dest"
+          usage
+      fi
+  elif [ "${backup_dest:0:5}" = "s3://" ]; then
+      env -i $CREDENTIALS $xbcloud get ${backup_dest} xtrabackup_info 1>/dev/null
+  else
+      echo "Can't find $backup_dest backup"
+      usage
+  fi
+
+  if [ ! -d "$dest_dir" ]; then
+      printf "[ERROR] '%s' is not local directory.\n\n" "$dest_dir"
+      usage
+  fi
+
 }
 
 start_tmp_pod() {
     local backup_pvc=$1
 
-    $ctrl delete pod/backup-access 2>/dev/null || :
-    cat - <<-EOF | $ctrl apply -f -
-		apiVersion: v1
-		kind: Pod
-		metadata:
-		  name: backup-access
-		spec:
-		      containers:
-		      - name: xtrabackup
-		        image: percona/percona-xtradb-cluster-operator:0.3.0-backup
-		        volumeMounts:
-		        - name: backup
-		          mountPath: /backup
-		      restartPolicy: Never
-		      volumes:
-		      - name: backup
-		        persistentVolumeClaim:
-		          claimName: ${backup_pvc#pvc/}
-	EOF
+    if [ -n "$namespace" ]; then
+      $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
+kind: Pod
+metadata:
+  name: backup-access
+  namespace: $namespace
+spec:
+  containers:
+  - name: xtrabackup
+    image: percona/percona-xtradb-cluster-operator:0.3.0-backup
+    volumeMounts:
+    - name: backup
+      mountPath: /backup
+  restartPolicy: Never
+  volumes:
+  - name: backup
+    persistentVolumeClaim:
+      claimName: ${backup_pvc#pvc/}" | tee /tmp/nm | $ctrl apply -f -
+    else
+      $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
+kind: Pod
+metadata:
+  name: backup-access
+spec:
+  containers:
+  - name: xtrabackup
+    image: percona/percona-xtradb-cluster-operator:0.3.0-backup
+    volumeMounts:
+    - name: backup
+      mountPath: /backup
+  restartPolicy: Never
+  volumes:
+  - name: backup
+    persistentVolumeClaim:
+      claimName: ${backup_pvc#pvc/}" | tee /tmp/nm | $ctrl apply -f -
+    fi
 
     echo -n Starting pod.
     until $ctrl get pod/backup-access -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null | grep -q 'true'; do
@@ -159,13 +193,15 @@ stop_tmp_pod() {
 main() {
     local backup=$1
     local dest_dir=$2
+    local namespace=$3
     local backup_dest
 
     check_ctrl
     enable_logging
+    check_input_namespace "$namespace"
     get_backup_dest "$backup"
     backup_dest=$(get_backup_dest "$backup")
-    check_input "$backup_dest" "$dest_dir"
+    check_input_destination "$backup_dest" "$dest_dir" "$namespace"
 
     if [ "${backup_dest:0:4}" = "pvc/" ]; then
         start_tmp_pod "$backup_dest"

--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -118,8 +118,11 @@ check_input_destination() {
 start_tmp_pod() {
     local backup_pvc=$1
 
+    $ctrl delete pod/backup-access 2>/dev/null || :
+
     if [ -n "$namespace" ]; then
-      $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
+      cat - <<-EOF | $ctrl apply -f -
+apiVersion: v1
 kind: Pod
 metadata:
   name: backup-access
@@ -135,9 +138,11 @@ spec:
   volumes:
   - name: backup
     persistentVolumeClaim:
-      claimName: ${backup_pvc#pvc/}" | $ctrl apply -f -
+      claimName: ${backup_pvc#pvc/}
+EOF
     else
-      $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
+      cat - <<-EOF | $ctrl apply -f -
+apiVersion: v1
 kind: Pod
 metadata:
   name: backup-access
@@ -152,7 +157,8 @@ spec:
   volumes:
   - name: backup
     persistentVolumeClaim:
-      claimName: ${backup_pvc#pvc/}" | $ctrl apply -f -
+      claimName: ${backup_pvc#pvc/}
+EOF
     fi
 
     echo -n Starting pod.

--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -135,7 +135,7 @@ spec:
   volumes:
   - name: backup
     persistentVolumeClaim:
-      claimName: ${backup_pvc#pvc/}" | tee /tmp/nm | $ctrl apply -f -
+      claimName: ${backup_pvc#pvc/}" | $ctrl apply -f -
     else
       $ctrl delete pod/backup-access 2>/dev/null || echo "apiVersion: v1
 kind: Pod
@@ -152,7 +152,7 @@ spec:
   volumes:
   - name: backup
     persistentVolumeClaim:
-      claimName: ${backup_pvc#pvc/}" | tee /tmp/nm | $ctrl apply -f -
+      claimName: ${backup_pvc#pvc/}" | $ctrl apply -f -
     fi
 
     echo -n Starting pod.
@@ -201,7 +201,7 @@ main() {
     check_input_namespace "$namespace"
     get_backup_dest "$backup"
     backup_dest=$(get_backup_dest "$backup")
-    check_input_destination "$backup_dest" "$dest_dir" "$namespace"
+    check_input_destination "$backup_dest" "$dest_dir"
 
     if [ "${backup_dest:0:4}" = "pvc/" ]; then
         start_tmp_pod "$backup_dest"


### PR DESCRIPTION
This is an improvement in `wsrep_cluster_address` to ensure hostnames instead of IPs.

PLEASE NOTE: it requires `yum install -y bind-utils` in a `Dockerfile`, in case you think PR is useful for merge

Motivation:

* Kubernetes can change pod IP (e.g. in the event of network drop when Calico or other tunnel is reinitialised, pod deletion, etc.). So I thought it's good idea to avoid reaching this line https://github.com/percona/percona-xtradb-cluster-operator/blob/main/build/pxc-configure-pxc.sh#L55

* At the moment, it already prefers hostnames collected via `mysql` command https://github.com/percona/percona-xtradb-cluster-operator/blob/main/build/pxc-configure-pxc.sh#L50 , but I've got some edge case, I'll explain

----

I've worked on migration to another cluster and somehow my operator's secret was incorrect (maybe used some weird special character, accidentally changed it or just incorrect password used so this is about human failure)

New cluster successfully started from backup and I was using it for some days without noticing an issue:

```
$ ~/Documents/git $ k logs -n mm-p mattermost-cluster-pxc-2 pxc | grep -B 3 ERROR
++ mysql_root_exec 10.233.76.59 'select @@hostname'
++ local server=10.233.76.59
++ local 'query=select @@hostname'
ERROR 1045 (28000): Access denied for user 'operator'@'10.233.100.252' (using password: YES)
```

gcomm connectors were:

```
k exec -it mattermost-cluster-pxc-0 -n mm-p -c pxc -- grep wsrep_cluster_address /etc/mysql/node.cnf
wsrep_cluster_address=gcomm://

k exec -it mattermost-cluster-pxc-1 -n mm-p -c pxc -- grep wsrep_cluster_address /etc/mysql/node.cnf
wsrep_cluster_address=gcomm://10.233.76.59

k exec -it mattermost-cluster-pxc-2 -n mm-p -c pxc -- grep wsrep_cluster_address /etc/mysql/node.cnf
wsrep_cluster_address=gcomm://10.233.76.59,10.233.86.125
```

So I understand why it placed IPs (where personally I would prefer hostnames, because IPs are not guaranteed in Kubernetes)

In addition, I've tried to drain one node for the test and had some issue with it until pod came back online. Maybe because of these `wsrep_cluster_address` values.

Anyway, I don't have any issue to register as I'm aware how to get hostnames by fixing operator's password and restarting instances. So cluster is working well now, but I believe this PR could be useful to help others to not face this edge case or at least improve the situation.

The PR focus is better handling of hostnames/improving situation of using `svc` DNSes, in general.

Please let me know what are your plans.

Many thanks!