### PR TITLE
Fix restore-on-pitr-minio.yaml config in PITR e2e test

### DIFF
--- a/e2e-tests/pitr/conf/restore-on-pitr-minio.yaml
+++ b/e2e-tests/pitr/conf/restore-on-pitr-minio.yaml
@@ -4,14 +4,13 @@ metadata:
   name: on-pitr-minio
 spec:
   pxcCluster: pitr
-  backupName: on-pitr-minio
   backupSource:
-      destination: <destination>
-      s3:
-        bucket: operator-testing
-        credentialsSecret: minio-secret
-        endpointUrl: http://minio-service:9000
-        region: us-east-1
+    destination: <destination>
+    s3:
+      bucket: operator-testing
+      credentialsSecret: minio-secret
+      endpointUrl: http://minio-service:9000
+      region: us-east-1
   pitr:
     type: latest
     backupSource:


### PR DESCRIPTION
There seems to be some misalignment and as per the docs `backupName` and `backupSource` should not be used together.
Which also brings the question should we add a check and throw an error if both are specified at the same time in restore.