### PR TITLE
Remove clusterIPs from e2e tests diff comparison

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -309,6 +309,7 @@ compare_kubectl() {
 		| yq d - '**.creationTimestamp' \
 		| yq d - '**.image' \
 		| yq d - '**.clusterIP' \
+		| yq d - '**.clusterIPs' \
 		| yq d - '**.dataSource' \
 		| yq d - '**.procMount' \
 		| yq d - '**.storageClassName' \


### PR DESCRIPTION
some tests are failing on 1.20 like:
```
+ diff -u /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-100.yml /tmp/tmp.lh2mueDKDc/service_some-name-pxc.yml
--- /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-100.yml	2021-03-30 05:30:02.000000000 +0000
+++ /tmp/tmp.lh2mueDKDc/service_some-name-pxc.yml	2021-03-30 07:28:12.176775782 +0000
@@ -11,6 +11,8 @@
       kind: PerconaXtraDBCluster
       name: some-name
 spec:
+  clusterIPs:
+    - None
   ports:
     - name: mysql
       port: 3306
```