### PR TITLE
K8SPXC-568 feature: Restrict running more than 5 pods of PXC if unsafe flag is not set

### DIFF
--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -668,6 +668,10 @@ func (cr *PerconaXtraDBCluster) CheckNSetDefaults(serverVersion *version.ServerV
 	return CRVerChanged || changed, nil
 }
 
+const (
+	maxSafePXCSize = 5
+)
+
 func setSafeDefaults(spec *PerconaXtraDBClusterSpec, log logr.Logger) {
 	if spec.AllowUnsafeConfig {
 		return
@@ -681,6 +685,9 @@ func setSafeDefaults(spec *PerconaXtraDBClusterSpec, log logr.Logger) {
 	if spec.PXC.Size < 3 {
 		loginfo("Cluster size will be changed from %d to %d due to safe config", spec.PXC.Size, 3)
 		spec.PXC.Size = 3
+	} else if spec.PXC.Size > maxSafePXCSize {
+		loginfo("Cluster size will be changed from %d to %d due to safe config", spec.PXC.Size, maxSafePXCSize)
+		spec.PXC.Size = maxSafePXCSize
 	}
 
 	if spec.PXC.Size%2 == 0 {


### PR DESCRIPTION
[![K8SPXC-568](https://badgen.net/badge/JIRA/K8SPXC-568/green)](https://jira.percona.com/browse/K8SPXC-568) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-568

Modified validation to restrict running more than 5 pods of PXC unless allowUnsafeConfigurations flag is set to true by changing PXC size to 5 if it's higher than that.