### PR TITLE
K8SPXC-509 Make peer-list handle SIGUSR1

### DIFF
--- a/cmd/peer-list/main.go
+++ b/cmd/peer-list/main.go
@@ -25,9 +25,11 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"regexp"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -70,6 +72,16 @@ func shellOut(sendStdin, script string) {
 }
 
 func main() {
+	// Custom signal handler for SIGUSR1. This is needed because the
+	// Docker image (percona/percona-xtradb-cluster-operator:$version-haproxy)
+	// sets the STOPSIGNAL to SIGUSR1 to shutdown HAProxy gracefully.
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGUSR1)
+	go func() {
+		<-signalChan
+		os.Exit(0)
+	}()
+
 	flag.Parse()
 
 	ns := *namespace


### PR DESCRIPTION
[![K8SPXC-509](https://badgen.net/badge/JIRA/K8SPXC-509/green)](https://jira.percona.com/browse/K8SPXC-509) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The Docker image percona/percona-xtradb-cluster-operator:$version-haproxy configures the STOPSIGNAL to SIGUSR1 to shutdown HAProxy gracefully. peer-list needs to handle this as well because it is bundled in the same container.
Otherwise peer-list will just ignore the signal which leads to the pod staying in `Terminating` status for quite a while.

Closes [K8SPXC-509](https://jira.percona.com/browse/K8SPXC-509).

(Disclaimer: I'm "new" to Go, please tell me if this doesn't make sense)