### PR TITLE
K8SPXC-734: Include namespace in maual recovery command

### DIFF
--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -531,7 +531,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			echo "It is $NODE_NAME node with sequence number (seqno): $seqno"
 			echo 'Cluster will recover automatically from the crash now.'
 			echo 'If you have set spec.pxc.autoRecovery to false, run the following command to recover manually from this node:'
-			echo "kubectl exec $(hostname) -c pxc -- sh -c 'kill -s USR1 1'"
+			echo "kubectl -n $POD_NAMESPACE exec $(hostname) -c pxc -- sh -c 'kill -s USR1 1'"
 			#DO NOT CHANGE THE LINE BELOW. OUR AUTO-RECOVERY IS USING IT TO DETECT SEQNO OF CURRENT NODE. See K8SPXC-564
 			echo "#####################################################LAST_LINE:$NODE_NAME:$seqno:#####################################################"
 

--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -445,6 +445,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	grep -v wsrep_sst_auth "$CFG"
 fi
 
+POD_NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+
 wsrep_start_position_opt=""
 if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 	DATADIR="$(_get_config 'datadir' "$@")"

--- a/pkg/pxc/app/statefulset/node.go
+++ b/pkg/pxc/app/statefulset/node.go
@@ -136,6 +136,12 @@ func (c *Node) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXt
 					SecretKeyRef: app.SecretKeySelector(secrets, "monitor"),
 				},
 			},
+			{
+				Name: "POD_NAMESPACE",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.namespace"},
+				},
+			},
 		},
 		SecurityContext: spec.ContainerSecurityContext,
 	}

--- a/pkg/pxc/app/statefulset/node.go
+++ b/pkg/pxc/app/statefulset/node.go
@@ -136,12 +136,6 @@ func (c *Node) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXt
 					SecretKeyRef: app.SecretKeySelector(secrets, "monitor"),
 				},
 			},
-			{
-				Name: "POD_NAMESPACE",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.namespace"},
-				},
-			},
 		},
 		SecurityContext: spec.ContainerSecurityContext,
 	}


### PR DESCRIPTION
[![K8SPXC-734](https://badgen.net/badge/JIRA/K8SPXC-734/green)](https://jira.percona.com/browse/K8SPXC-734) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Make our life easier to run the `kubectl exec` command when recovering manually. No need to config the correct namespace in the current context or manually adding the `-n <namespace>` argument into the recovery command.

Using the downward API to inject the pod namespace as `MY_POD_NAMESPACE` environment variable