### PR TITLE
fix K8SPXC-716 by checking ownership and uid before deleting sts

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -974,8 +974,7 @@ func (r *ReconcilePerconaXtraDBCluster) deleteStatefulSet(cr *api.PerconaXtraDBC
 		return nil
 	}
 
-	uid := sfsWithOwner.UID
-	err = r.client.Delete(context.TODO(), sfs.StatefulSet(), &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}})
+	err = r.client.Delete(context.TODO(), &sfsWithOwner, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &sfsWithOwner.UID}})
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return errors.Wrapf(err, "delete statefulset: %s", sfs.StatefulSet().Name)
 	}

--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -957,10 +957,11 @@ func (r *ReconcilePerconaXtraDBCluster) deleteStatefulSetPods(namespace string, 
 }
 
 func (r *ReconcilePerconaXtraDBCluster) deleteStatefulSet(cr *api.PerconaXtraDBCluster, sfs api.StatefulApp, deletePVC bool) error {
+	sfsWithOwner := appsv1.StatefulSet{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{
 		Name:      sfs.StatefulSet().Name,
 		Namespace: cr.Namespace,
-	}, &appsv1.StatefulSet{})
+	}, &sfsWithOwner)
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return errors.Wrapf(err, "get statefulset: %s", sfs.StatefulSet().Name)
 	}
@@ -969,7 +970,12 @@ func (r *ReconcilePerconaXtraDBCluster) deleteStatefulSet(cr *api.PerconaXtraDBC
 		return nil
 	}
 
-	err = r.client.Delete(context.TODO(), sfs.StatefulSet())
+	if !metav1.IsControlledBy(&sfsWithOwner, cr){
+		return nil
+	}
+
+	uid := sfsWithOwner.UID
+	err = r.client.Delete(context.TODO(), sfs.StatefulSet(), &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}})
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return errors.Wrapf(err, "delete statefulset: %s", sfs.StatefulSet().Name)
 	}


### PR DESCRIPTION
[![K8SPXC-716](https://badgen.net/badge/JIRA/K8SPXC-716/green)](https://jira.percona.com/browse/K8SPXC-716) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fix https://jira.percona.com/browse/K8SPXC-716 by ensuring that the sts belongs to the xtradb cluster before deletion. We also double check the uid of the sts in case the controller reads stale sts information