### PR TITLE
K8SPXC-727: improve pitr on frequent uploads

### DIFF
--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -462,22 +462,29 @@ func (r *Recoverer) setBinlogs() error {
 }
 
 func getExtendGTIDSet(gtidSet, gtid string) (string, error) {
+	if gtidSet == gtid {
+		return gtid, nil
+	}
+
 	s := strings.Split(gtidSet, ":")
 	if len(s) < 2 {
 		return "", errors.Errorf("incorrect source in gtid set %s", gtidSet)
 	}
 
+	eidx := 1
 	e := strings.Split(s[1], "-")
-	if len(e) < 2 {
-		return "", errors.Errorf("incorrect id range in %s", gtidSet)
+	if len(e) == 1 {
+		eidx = 0
 	}
+
 	gs := strings.Split(gtid, ":")
 	if len(gs) < 2 {
 		return "", errors.Errorf("incorrect source in gtid set %s", gtid)
 	}
+
 	es := strings.Split(gs[1], "-")
 
-	return gs[0] + ":" + es[0] + "-" + e[1], nil
+	return gs[0] + ":" + es[0] + "-" + e[eidx], nil
 }
 
 func reverse(list []string) {


### PR DESCRIPTION
[![K8SPXC-727](https://badgen.net/badge/JIRA/K8SPXC-727/green)](https://jira.percona.com/browse/K8SPXC-727) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Before, if we specify very short upload rate, we will flush binlogs too fast. In this case, we will have 1-2 transactions in each binlog file, which causes errors during restore.