### PR TITLE
CLOUD-625 gke started to use containerd from 1.19

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1104,7 +1104,7 @@ deploy_chaos_mesh() {
 	kubectl_bin delete ns chaos-testing || :
 	helm repo add chaos-mesh https://charts.chaos-mesh.org
 	kubectl_bin create ns chaos-testing
-	if version_gt "1.20"; then
+	if version_gt "1.19"; then
 		helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --set dashboard.create=false
 	else
 		helm install chaos-mesh chaos-mesh/chaos-mesh --namespace=chaos-testing --set dashboard.create=false

--- a/e2e-tests/haproxy/run
+++ b/e2e-tests/haproxy/run
@@ -21,7 +21,7 @@ main() {
 
 	if [[ ${OPENSHIFT} == 4 ]]; then
 		apply_config "$test_dir/conf/container-rc.yaml"
-	elif [[ -z ${OPENSHIFT} ]] && [[ $(echo "$KUBE_VERSION >= 1.20" | bc -l) -eq 1 ]]; then
+	elif [[ -z ${OPENSHIFT} ]] && [[ $(echo "$KUBE_VERSION >= 1.19" | bc -l) -eq 1 ]]; then
 		apply_config "$test_dir/conf/container-rc.yaml"
 	else
 		apply_config "$test_dir/conf/docker-rc.yaml"

--- a/e2e-tests/operator-self-healing/run
+++ b/e2e-tests/operator-self-healing/run
@@ -7,8 +7,8 @@ test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 cluster="no-limits"
 
-if version_gt "1.20"; then
-	echo "Kubernetes version is 1.20+ so skipping this test because of pumba support."
+if version_gt "1.19"; then
+	echo "Kubernetes version is 1.19+ so skipping this test because of pumba support."
 	exit 0
 fi
 

--- a/e2e-tests/self-healing-advanced/run
+++ b/e2e-tests/self-healing-advanced/run
@@ -7,8 +7,8 @@ test_dir=$(realpath $(dirname $0))
 . "${test_dir}"/../functions
 cluster="self-healing-advanced"
 
-if version_gt "1.20"; then
-	echo "Kubernetes version is 1.20+ so skipping this test because of pumba support."
+if version_gt "1.19"; then
+	echo "Kubernetes version is 1.19+ so skipping this test because of pumba support."
 	exit 0
 fi
 

--- a/e2e-tests/self-healing/run
+++ b/e2e-tests/self-healing/run
@@ -7,8 +7,8 @@ test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 cluster="some-name"
 
-if version_gt "1.20"; then
-	echo "Kubernetes version is 1.20+ so skipping this test because of pumba support."
+if version_gt "1.19"; then
+	echo "Kubernetes version is 1.19+ so skipping this test because of pumba support."
 	exit 0
 fi
 


### PR DESCRIPTION
[![CLOUD-625](https://badgen.net/badge/JIRA/CLOUD-625/green)](https://jira.percona.com/browse/CLOUD-625) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

