### PR TITLE
K8SPXC-784: parameterize operator deployment name with env var from helm chart

### DIFF
--- a/pkg/webhook/hook.go
+++ b/pkg/webhook/hook.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/pkg/errors"
@@ -304,9 +305,13 @@ func sendResponse(uid types.UID, meta metav1.TypeMeta, w http.ResponseWriter, er
 }
 
 func (h *hook) operatorDeployment() (*appsv1.Deployment, error) {
+	operatorDeploymentName := os.Getenv("OPERATOR_NAME")
+	if operatorDeploymentName == "" {
+		operatorDeploymentName = "percona-xtradb-cluster-operator"
+	}
 	deployment := &appsv1.Deployment{}
 	err := h.cl.Get(context.TODO(), types.NamespacedName{
-		Name:      "percona-xtradb-cluster-operator",
+		Name:      operatorDeploymentName,
 		Namespace: h.namespace,
 	}, deployment)
 	return deployment, err


### PR DESCRIPTION
[![K8SPXC-784](https://badgen.net/badge/JIRA/K8SPXC-784/green)](https://jira.percona.com/browse/K8SPXC-784) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is written to match the [helm chart](https://github.com/percona/percona-helm-charts/blob/main/charts/pxc-operator/templates/deployment.yaml#L49-L50)