### PR TITLE
K8SPXC-801: fix update and scale down concurrent

### DIFF
--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
-	v1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/queries"
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
 )
 
 func (r *ReconcilePerconaXtraDBCluster) updatePod(sfs api.StatefulApp, podSpec *api.PodSpec, cr *api.PerconaXtraDBCluster, initContainers []corev1.Container) error {
@@ -307,6 +308,15 @@ func (r *ReconcilePerconaXtraDBCluster) applyNWait(cr *api.PerconaXtraDBCluster,
 		}
 	}
 
+	orderInSts, err := getPodOrderInSts(sfs.Name, pod.Name)
+	if err != nil {
+		return errors.Errorf("compute pod order err, sfs name: %s, pod name: %s", sfs.Name, pod.Name)
+	}
+	if int32(orderInSts) >= *sfs.Spec.Replicas {
+		logger.Info(fmt.Sprintf("sfs %s is scaled down, pod %s will not be started ", sfs.Name, pod.Name))
+		return nil
+	}
+
 	if err := r.waitPodRestart(sfs.Status.UpdateRevision, pod, waitLimit, logger); err != nil {
 		return errors.Wrap(err, "failed to wait pod")
 	}
@@ -320,6 +330,10 @@ func (r *ReconcilePerconaXtraDBCluster) applyNWait(cr *api.PerconaXtraDBCluster,
 	}
 
 	return nil
+}
+
+func getPodOrderInSts(stsName string, podName string) (int, error) {
+	return strconv.Atoi(podName[len(stsName)+1:])
 }
 
 func (r *ReconcilePerconaXtraDBCluster) waitUntilOnline(cr *api.PerconaXtraDBCluster, sfsName string, pod *corev1.Pod, waitLimit int, logger logr.Logger) error {


### PR DESCRIPTION
[![K8SPXC-801](https://badgen.net/badge/JIRA/K8SPXC-801/green)](https://jira.percona.com/browse/K8SPXC-801) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

when the pxc sts is update and pxc size scale down concurrent, the operator will block until timeout because the pod will not restart in scaling down