### PR TITLE
K8SPXC-808 - Fix diff in tests for Kubernetes 1.21

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -348,6 +348,8 @@ compare_kubectl() {
 		| yq d - 'metadata.ownerReferences.*.apiVersion' \
 		| yq d - '**.controller-uid' \
 		| yq d - '**.preemptionPolicy' \
+		| yq d - 'spec.ipFamilies' \
+		| yq d - 'spec.ipFamilyPolicy' \
 		| sed 's/namespace\:.*name/name/' \
 			>${new_result}
 	# last sed is needed for backup cronjob content


### PR DESCRIPTION
[![K8SPXC-808](https://badgen.net/badge/JIRA/K8SPXC-808/green)](https://jira.percona.com/browse/K8SPXC-808) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Some tests are failing with:
```
+ diff -u /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-100.yml /tmp/tmp.OvDghnycxE/service_some-name-pxc.yml
--- /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-100.yml	2021-07-07 08:56:44.000000000 +0000
+++ /tmp/tmp.OvDghnycxE/service_some-name-pxc.yml	2021-07-07 11:33:21.544176570 +0000
@@ -11,6 +11,9 @@
       kind: PerconaXtraDBCluster
       name: some-name
 spec:
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
   ports:
     - name: mysql
       port: 3306
```