### PR TITLE
K8SPXC-808 - Fix custom example config for PXC and HAProxy

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -54,7 +54,7 @@ spec:
 #    forceUnsafeBootstrap: false
 #    configuration: |
 #      [mysqld]
-#      wsrep_debug=ON
+#      wsrep_debug=CLIENT
 #      wsrep_provider_options="gcache.size=1G; gcache.recover=yes"
 #      [sst]
 #      xbstream-opts=--decompress
@@ -145,6 +145,7 @@ spec:
 #      global
 #        maxconn 2048
 #        external-check
+#        insecure-fork-wanted
 #        stats socket /var/run/haproxy.sock mode 600 expose-fd listeners level user
 #
 #      defaults
@@ -157,7 +158,7 @@ spec:
 #
 #      frontend galera-in
 #        bind *:3309 accept-proxy
-#        bind *:3306 accept-proxy
+#        bind *:3306
 #        mode tcp
 #        option clitcpka
 #        default_backend galera-nodes


### PR DESCRIPTION
1. wsrep_debug in 8.0 is not ON|OFF but has different values: https://jira.percona.com/browse/PXC-3034
2. insecure-fork-wanted we have added into our default config, if not specified following happens
```
[ALERT] 188/090028 (576) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.
[ALERT] 188/090029 (576) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.
[ALERT] 188/090029 (576) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.
```
3. if `bind *:3306 accept-proxy` is specified with `accept-proxy` readiness/liveness probe timeout