### PR TITLE
K8SPXC-808 - Fix init-deploy and haproxy on kubernetes 1.21

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -350,7 +350,8 @@ compare_kubectl() {
 		| yq d - '**.preemptionPolicy' \
 		| yq d - 'spec.ipFamilies' \
 		| yq d - 'spec.ipFamilyPolicy' \
-		| sed 's/namespace\:.*name/name/' \
+		| $sed "s#^apiVersion: policy/v1beta1#apiVersion: policy/v1#" \
+		| $sed 's/namespace\:.*name/name/' \
 			>${new_result}
 	# last sed is needed for backup cronjob content
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -36,6 +36,12 @@ if oc get projects; then
 	esac
 fi
 
+if [ $(kubectl version -o json | jq -r '.serverVersion.gitVersion' | grep "\-eks\-") ]; then
+	EKS=1
+else
+	EKS=0
+fi
+
 KUBE_VERSION=$(kubectl version -o json | jq -r '.serverVersion.major + "." + .serverVersion.minor' | $sed -r 's/[^0-9.]+//g')
 
 HELM_VERSION=$(helm version -c | $sed -re 's/.*SemVer:"([^"]+)".*/\1/; s/.*\bVersion:"([^"]+)".*/\1/')

--- a/e2e-tests/haproxy/compare/pdb_haproxy-haproxy.yml
+++ b/e2e-tests/haproxy/compare/pdb_haproxy-haproxy.yml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations: {}

--- a/e2e-tests/haproxy/run
+++ b/e2e-tests/haproxy/run
@@ -19,9 +19,7 @@ check_haproxy_writer() {
 main() {
 	create_infra $namespace
 
-	if [[ ${OPENSHIFT} == 4 ]]; then
-		apply_config "$test_dir/conf/container-rc.yaml"
-	elif [[ -z ${OPENSHIFT} ]] && [[ $(echo "$KUBE_VERSION >= 1.19" | bc -l) -eq 1 ]]; then
+	if version_gt "1.19" && [ $EKS -ne 1 ]; then
 		apply_config "$test_dir/conf/container-rc.yaml"
 	else
 		apply_config "$test_dir/conf/docker-rc.yaml"

--- a/e2e-tests/init-deploy/compare/pdb_some-name-proxysql.yml
+++ b/e2e-tests/init-deploy/compare/pdb_some-name-proxysql.yml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations: {}

--- a/e2e-tests/init-deploy/compare/pdb_some-name-pxc.yml
+++ b/e2e-tests/init-deploy/compare/pdb_some-name-pxc.yml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations: {}


### PR DESCRIPTION
[![K8SPXC-808](https://badgen.net/badge/JIRA/K8SPXC-808/green)](https://jira.percona.com/browse/K8SPXC-808) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

init-deploy diff:
```
+ diff -u /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/init-deploy/compare/pdb_some-name-pxc.yml /tmp/tmp.neI9Mv1Jq5/pdb_some-name-pxc.yml
--- /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/init-deploy/compare/pdb_some-name-pxc.yml	2021-07-13 09:36:04.000000000 +0000
+++ /tmp/tmp.neI9Mv1Jq5/pdb_some-name-pxc.yml	2021-07-13 09:53:50.591878346 +0000
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations: {}
```

haproxy diff:
```
+ diff -u /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/haproxy/compare/pdb_haproxy-haproxy.yml /tmp/tmp.d9quOGtZlS/pdb_haproxy-haproxy.yml
--- /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/haproxy/compare/pdb_haproxy-haproxy.yml	2021-07-13 09:36:04.000000000 +0000
+++ /tmp/tmp.d9quOGtZlS/pdb_haproxy-haproxy.yml	2021-07-13 10:14:50.097220742 +0000
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations: {}
```

As for `haproxy` I have copied the same code we already added in PSMDB for checking EKS and versions in the tests for container runtime.
Self-healing tests are failing because of proxysql versions. That will be fixed in another PR if needed.