### PR TITLE
K8SPXC-808 - Fix security-context test for GKE 1.21

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -356,7 +356,8 @@ compare_kubectl() {
 		| yq d - '**.preemptionPolicy' \
 		| yq d - 'spec.ipFamilies' \
 		| yq d - 'spec.ipFamilyPolicy' \
-		| $sed "s#^apiVersion: policy/v1beta1#apiVersion: policy/v1#" \
+		| $sed 's#^apiVersion: policy/v1beta1#apiVersion: policy/v1#' \
+		| $sed 's/name: kube-api-access-.*$/name: kube-api-access/' \
 		| $sed 's/namespace\:.*name/name/' \
 			>${new_result}
 	# last sed is needed for backup cronjob content

--- a/e2e-tests/security-context/compare/pod_restore-src-restore-pvc-sec-context-120.yml
+++ b/e2e-tests/security-context/compare/pod_restore-src-restore-pvc-sec-context-120.yml
@@ -30,9 +30,6 @@ spec:
           name: ssl-internal
         - mountPath: /etc/mysql/vault-keyring-secret
           name: vault-keyring-secret
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: kube-api-access
-          readOnly: true
   dnsPolicy: ClusterFirst
   priority: 0
   restartPolicy: Always
@@ -74,21 +71,3 @@ spec:
         defaultMode: 420
         optional: true
         secretName: sec-context-vault
-    - name: kube-api-access
-      projected:
-        defaultMode: 420
-        sources:
-          - serviceAccountToken:
-              expirationSeconds: 3607
-              path: token
-          - configMap:
-              items:
-                - key: ca.crt
-                  path: ca.crt
-              name: kube-root-ca.crt
-          - downwardAPI:
-              items:
-                - fieldRef:
-                    apiVersion: v1
-                    fieldPath: metadata.namespace
-                  path: namespace

--- a/e2e-tests/security-context/run
+++ b/e2e-tests/security-context/run
@@ -10,14 +10,14 @@ create_infra $namespace
 deploy_cert_manager
 
 kubectl_bin apply -f "$test_dir/conf/service-account.yml"
-if [[ ! -z "${OPENSHIFT}" ]]; then
-    oc adm policy add-scc-to-user privileged -z percona-xtradb-cluster-operator-workload
+if [[ -n ${OPENSHIFT} ]]; then
+	oc adm policy add-scc-to-user privileged -z percona-xtradb-cluster-operator-workload
 
-    if [ -n "$OPERATOR_NS" ]; then
-        oc patch clusterrole/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]' ${OPERATOR_NS:+-n $OPERATOR_NS}
-    else
-        oc patch role/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]'
-    fi
+	if [ -n "$OPERATOR_NS" ]; then
+		oc patch clusterrole/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]' ${OPERATOR_NS:+-n $OPERATOR_NS}
+	else
+		oc patch role/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]'
+	fi
 fi
 
 desc 'create first PXC cluster'
@@ -52,7 +52,11 @@ restore="restore-pvc"
 kubectl_bin apply -f "$test_dir/conf/$cluster-$restore.yml"
 wait_pod restore-src-$restore-$cluster
 kubectl_bin get -o yaml pod/restore-src-restore-pvc-sec-context
-compare_kubectl pod/restore-src-$restore-$cluster
+if version_gt "1.21"; then
+	compare_kubectl pod/restore-src-$restore-$cluster
+else
+	compare_kubectl pod/restore-src-$restore-$cluster "-120"
+fi
 wait_backup_restore $restore
 compare_kubectl job.batch/restore-job-$restore-$cluster
 
@@ -72,7 +76,7 @@ kubectl_bin apply -f "$test_dir/conf/$cluster-$restore.yml"
 wait_backup_restore $restore
 compare_kubectl job.batch/restore-job-$restore-$cluster
 
-if [[ ! -z "${OPENSHIFT}" ]]; then
-    oc adm policy remove-scc-from-user privileged -z percona-xtradb-cluster-operator-workload
+if [[ -n ${OPENSHIFT} ]]; then
+	oc adm policy remove-scc-from-user privileged -z percona-xtradb-cluster-operator-workload
 fi
 destroy $namespace


### PR DESCRIPTION
[![K8SPXC-808](https://badgen.net/badge/JIRA/K8SPXC-808/green)](https://jira.percona.com/browse/K8SPXC-808) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection

Not sure if we should remove this mount altogether, but it is part of array so something like `yq d - 'spec.containers[0].volumeMounts[4]' | yq d - 'spec.volumes[4]'` doesn't look to proficient.
Name like `kube-api-access-w2g4v` is also variable so I have made it fixed to `kube-api-access` here.

Diff on GKE 1.21:
```
+ diff -u /Users/plavi/Development/percona/kubernetes-operators/production/percona-xtradb-cluster-operator/e2e-tests/security-context/compare/pod_restore-src-restore-pvc-sec-context.yml /var/folders/fw/lxhtthdn7d9610w5p3wb33340000gn/T/tmp.tzHYhSRg/pod_restore-src-restore-pvc-sec-context.yml
--- /Users/plavi/Development/percona/kubernetes-operators/production/percona-xtradb-cluster-operator/e2e-tests/security-context/compare/pod_restore-src-restore-pvc-sec-context.yml 2021-01-14 08:57:54.000000000 +0100
+++ /var/folders/fw/lxhtthdn7d9610w5p3wb33340000gn/T/tmp.tzHYhSRg/pod_restore-src-restore-pvc-sec-context.yml 2021-07-13 15:42:45.000000000 +0200
@@ -30,6 +30,9 @@
           name: ssl-internal
         - mountPath: /etc/mysql/vault-keyring-secret
           name: vault-keyring-secret
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-w2g4v
+          readOnly: true
   dnsPolicy: ClusterFirst
   priority: 0
   restartPolicy: Always
@@ -71,3 +74,21 @@
         defaultMode: 420
         optional: true
         secretName: sec-context-vault
+    - name: kube-api-access-w2g4v
+      projected:
+        defaultMode: 420
+        sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+                - key: ca.crt
+                  path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
```