### PR TITLE
K8SPXC-808 - Fix tests on different platforms

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -397,7 +397,7 @@ run_mysql_local() {
 	[[ ${-/x/} != $- ]] && echo "+ kubectl exec -it $pod -- bash -c \"printf '$command\n' | mysql -sN $uri\"" >&$BASH_XTRACEFD
 
 	set +o xtrace
-	kubectl_bin exec $pod $container_name -- \
+	kubectl_bin exec $pod ${container_name:+-c $container_name} -- \
 		bash -c "printf '$command\n' | mysql -sN $uri" 2>&1 \
 		| sed -e 's/mysql: //' \
 		| (egrep -v 'Using a password on the command line interface can be insecure.|Defaulted container|Defaulting container name|see all of the containers in this pod' || :)

--- a/e2e-tests/init-deploy/run
+++ b/e2e-tests/init-deploy/run
@@ -34,8 +34,8 @@ desc 'check if MySQL users created'
 compare_mysql_user "-h $cluster-pxc -uroot -proot_password"
 compare_mysql_user "-h $cluster-pxc -umonitor -pmonitor"
 compare_mysql_user "-h $cluster-pxc -uproxyuser -ps3cret"
-compare_mysql_user_local "-uxtrabackup -pbackup_password" "$cluster-pxc-0" "" -c' pxc'
-compare_mysql_user_local "-uclustercheck -pclustercheckpassword" "$cluster-pxc-0" "" -c'pxc'
+compare_mysql_user_local "-uxtrabackup -pbackup_password" "$cluster-pxc-0" "" "pxc"
+compare_mysql_user_local "-uclustercheck -pclustercheckpassword" "$cluster-pxc-0" "" "pxc"
 # check that pmm server user don't have access
 compare_mysql_user "-h $cluster-pxc -upmmserver -pmonitor"
 

--- a/e2e-tests/pitr/run
+++ b/e2e-tests/pitr/run
@@ -31,7 +31,7 @@ run_recovery_check_pitr() {
 	kubectl_bin delete -f "$test_dir/conf/${restore}.yaml"
 	wait_for_running "$cluster-proxysql" 1
 	wait_for_running "$cluster-pxc" 3
-	sleep 35
+	sleep 45
 	desc 'check data after backup' $restore
 	compare_mysql_cmd $compare "SELECT * from test.test;" "-h $cluster-pxc-0.$cluster-pxc -uroot -proot_password"
 	compare_mysql_cmd $compare "SELECT * from test.test;" "-h $cluster-pxc-1.$cluster-pxc -uroot -proot_password"

--- a/e2e-tests/pitr/run
+++ b/e2e-tests/pitr/run
@@ -31,7 +31,7 @@ run_recovery_check_pitr() {
 	kubectl_bin delete -f "$test_dir/conf/${restore}.yaml"
 	wait_for_running "$cluster-proxysql" 1
 	wait_for_running "$cluster-pxc" 3
-	sleep 45
+	sleep 35
 	desc 'check data after backup' $restore
 	compare_mysql_cmd $compare "SELECT * from test.test;" "-h $cluster-pxc-0.$cluster-pxc -uroot -proot_password"
 	compare_mysql_cmd $compare "SELECT * from test.test;" "-h $cluster-pxc-1.$cluster-pxc -uroot -proot_password"
@@ -103,6 +103,9 @@ main() {
 	time_now=$(run_mysql "SELECT now();" "-h $proxy -uroot -proot_password")
 	gtid=$(run_mysql "SHOW BINLOG EVENTS IN 'binlog.000005';" "-h $proxy -uroot -proot_password" | grep Gtid | tail -c 43)
 
+	desc 'show binlog events in binlog.000005'
+	run_mysql "SHOW BINLOG EVENTS IN 'binlog.000005';" "-h $proxy -uroot -proot_password"
+
 	sleep 60
 	write_data_for_pitr "$cluster"
 	sleep 80 # need to wait while collector catch new data
@@ -117,7 +120,7 @@ main() {
 	dest=$(sed 's,/,\\/,g' <<<$(kubectl get pxc-backup on-pitr-minio -o jsonpath='{.status.destination}'))
 	run_recovery_check_pitr "$cluster" "restore-on-pitr-minio" "on-pitr-minio" "select-4" "" "$dest" ""
 	echo "done latest type"
-	
+
 	desc 'check if we restore data from binlogs'
 	kubectl patch pxc pitr --type=merge -p '{"spec":{"backup":{"pitr":{"enabled":true}}}}'
 	sleep 20

--- a/e2e-tests/self-healing-chaos/compare/proxy-vars.sql
+++ b/e2e-tests/self-healing-chaos/compare/proxy-vars.sql
@@ -154,7 +154,7 @@ mysql-query_processor_iterations	0
 mysql-query_retries_on_failure	1
 mysql-reset_connection_algorithm	2
 mysql-server_capabilities	571947
-mysql-server_version	5.7.33
+mysql-server_version	5.7.34
 mysql-servers_stats	true
 mysql-session_idle_ms	1000
 mysql-session_idle_show_processlist	true

--- a/e2e-tests/self-healing/compare/proxy-vars.sql
+++ b/e2e-tests/self-healing/compare/proxy-vars.sql
@@ -154,7 +154,7 @@ mysql-query_processor_iterations	0
 mysql-query_retries_on_failure	1
 mysql-reset_connection_algorithm	2
 mysql-server_capabilities	571947
-mysql-server_version	5.7.33
+mysql-server_version	5.7.34
 mysql-servers_stats	true
 mysql-session_idle_ms	1000
 mysql-session_idle_show_processlist	true

--- a/e2e-tests/users/run
+++ b/e2e-tests/users/run
@@ -37,13 +37,13 @@ kubectl_bin patch pxc some-name --type=merge -p="{\"spec\":{\"proxysql\":{\"size
 patch_secret "my-cluster-secrets" "xtrabackup" "$newpassencrypted"
 sleep 30
 wait_cluster_consistency "$cluster" 3 2
-compare_mysql_cmd_local "select-3" "SHOW DATABASES;" "-h localhost -uxtrabackup -p$newpass" "$cluster-pxc-0" "" -c'pxc'
+compare_mysql_cmd_local "select-3" "SHOW DATABASES;" "-h 127.0.0.1 -uxtrabackup -p$newpass" "$cluster-pxc-0" "" -c'pxc'
 
 desc 'test clustercheck'
 patch_secret "my-cluster-secrets" "clustercheck" "$newpassencrypted"
 sleep 30
 wait_cluster_consistency "$cluster" 3 2
-compare_mysql_cmd_local "select-5" "SHOW DATABASES;" "-h localhost -uclustercheck -p$newpass" "$cluster-pxc-0" "" -c'pxc'
+compare_mysql_cmd_local "select-5" "SHOW DATABASES;" "-h 127.0.0.1 -uclustercheck -p$newpass" "$cluster-pxc-0" "" -c'pxc'
 
 desc 'test monitor'
 patch_secret "my-cluster-secrets" "monitor" "$newpassencrypted"

--- a/e2e-tests/users/run
+++ b/e2e-tests/users/run
@@ -79,7 +79,7 @@ desc 'test new users sync'
 run_mysql \
         "CREATE USER 'testsync'@'%' IDENTIFIED BY '$newpass';" \
         "-h $cluster-pxc -uroot -p$newpass"
-sleep 20
+sleep 30
 compare_mysql_cmd "select-4" "SHOW TABLES;" "-h $cluster-proxysql -utestsync -p$newpass"
 
 pass=$(getSecretData "internal-some-name" "operator")
@@ -91,7 +91,8 @@ compare_mysql_cmd "select-4" "SHOW TABLES;" "-h $cluster-proxysql -uoperator -p$
 
 newpass="test-password2"
 newpassencrypted=$(echo -n "$newpass" | base64)
-spinup_pxc "$cluster" "$test_dir/conf/some-name.yml" 3 10
+apply_config "$test_dir/conf/some-name.yml"
+sleep 15
 wait_cluster_consistency "$cluster" 3 3
 patch_secret "my-cluster-secrets" "monitor" "$newpassencrypted"
 sleep 15

--- a/e2e-tests/users/run
+++ b/e2e-tests/users/run
@@ -21,8 +21,6 @@ patch_secret "my-cluster-secrets" "root" "$newpassencrypted"
 sleep 15
 compare_mysql_cmd "select-4" "SHOW TABLES;" "-h $cluster-proxysql -uroot -p$newpass"
 
-
-
 desc 'test proxyadmin'
 kubectl_bin patch pxc some-name --type=merge -p="{\"spec\":{\"proxysql\":{\"size\":3}}}"
 sleep 15
@@ -33,8 +31,6 @@ wait_cluster_consistency "$cluster" 3 3
 compare_mysql_cmd_local "select-2" "SHOW TABLES;" "-h127.0.0.1 -P6032 -uproxyadmin -p$newpass" "$cluster-proxysql-0" "" -c'proxysql'
 compare_mysql_cmd_local "select-2" "SHOW TABLES;" "-h127.0.0.1 -P6032 -uproxyadmin -p$newpass" "$cluster-proxysql-1" "" -c'proxysql'
 compare_mysql_cmd_local "select-2" "SHOW TABLES;" "-h127.0.0.1 -P6032 -uproxyadmin -p$newpass" "$cluster-proxysql-2" "" -c'proxysql'
-
-
 
 desc 'test xtrabackup'
 kubectl_bin patch pxc some-name --type=merge -p="{\"spec\":{\"proxysql\":{\"size\":1}}}"
@@ -77,15 +73,15 @@ compare_mysql_cmd "select-4" "SHOW TABLES;" "-h $cluster-proxysql -uoperator -p$
 newpass=$(getSecretData "my-cluster-secrets-2" "root")
 desc 'test new users sync'
 run_mysql \
-        "CREATE USER 'testsync'@'%' IDENTIFIED BY '$newpass';" \
-        "-h $cluster-pxc -uroot -p$newpass"
+	"CREATE USER 'testsync'@'%' IDENTIFIED BY '$newpass';" \
+	"-h $cluster-pxc -uroot -p$newpass"
 sleep 30
 compare_mysql_cmd "select-4" "SHOW TABLES;" "-h $cluster-proxysql -utestsync -p$newpass"
 
 pass=$(getSecretData "internal-some-name" "operator")
 desc 'check secret without operator'
 kubectl_bin apply \
-        -f "$test_dir/conf/secrets.yml"
+	-f "$test_dir/conf/secrets.yml"
 sleep 15
 compare_mysql_cmd "select-4" "SHOW TABLES;" "-h $cluster-proxysql -uoperator -p$pass"
 


### PR DESCRIPTION
[![K8SPXC-808](https://badgen.net/badge/JIRA/K8SPXC-808/green)](https://jira.percona.com/browse/K8SPXC-808) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

1. `init-deploy` was failing on kubernetes `1.17` because of default container selection in the pod
```
bash-3.2$ kubectl exec some-name-proxysql-0 proxysql -- bash -c 'printf '\''SELECT hostname FROM runtime_mysql_servers WHERE hostgroup_id=11 AND status="ONLINE";\n'\'' | mysql -sN -h127.0.0.1 -P6032 -uproxyadmin -padmin_password'
Defaulting container name to proxysql.
Use 'kubectl describe pod/some-name-proxysql-0 -n init-deploy-863' to see all of the containers in this pod.
2021-07-19 17:31:27 main.cpp:886:ProxySQL_Main_process_global_variables(): [WARNING] Unable to open config file printf 'SELECT hostname FROM runtime_mysql_servers WHERE hostgroup_id=11 AND status="ONLINE";\n' | mysql -sN -h127.0.0.1 -P6032 -uproxyadmin -padmin_password
2021-07-19 17:31:27 main.cpp:888:ProxySQL_Main_process_global_variables(): [ERROR] Unable to open config file printf 'SELECT hostname FROM runtime_mysql_servers WHERE hostgroup_id=11 AND status="ONLINE";\n' | mysql -sN -h127.0.0.1 -P6032 -uproxyadmin -padmin_password specified in the command line. Aborting!
```
2. `users` - `spinup_pxc` function is changed to `apply_config`, because spinup_pxc should be used only for first start of the cluster, not later updating config - it was failing many times randomly (it starts the smartupdate which updates pods in order 2-1-0, but spinup_pxc is checking pod start in order 0-1-2 so 0 and 1 check pass then it waits for 2 to finish starting and claims the cluster started ok, but actually it's in the middle of update process).
3. `users`- `localhost` is also changed to `127.0.0.1` because it started failing that it cannot connect to local mysql through socket (not sure why/how it worked before)
```
$ kubectl exec -it some-name-pxc-0 -- bash -c "printf 'SHOW DATABASES;\n' | mysql -sN -h 127.0.0.1 -uxtrabackup -ptest-password"
Defaulting container name to logs.
Use 'kubectl describe pod/some-name-pxc-0 -n users-20360' to see all of the containers in this pod.
mysql: [Warning] Using a password on the command line interface can be insecure.
information_schema
myApp
mysql
performance_schema
sys

$ kubectl exec -it some-name-pxc-0 -- bash -c "printf 'SHOW DATABASES;\n' | mysql -sN -h localhost -uxtrabackup -ptest-password"
Defaulting container name to logs.
Use 'kubectl describe pod/some-name-pxc-0 -n users-20360' to see all of the containers in this pod.
mysql: [Warning] Using a password on the command line interface can be insecure.
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (2)
command terminated with exit code 1
```
4. `pitr` - added additional display of content in `binlog.00005` for debugging purposes - the logic here is not too good because binlog sometimes rotates in the middle of these test statements and the test then fails because `binlog.00005` doesn't include expected information (but at the moment I don't have better solution).