### PR TITLE
K8SPXC-808 - Update functions to filter annotations for GKE in tests

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -324,6 +324,7 @@ compare_kubectl() {
 		| yq d - 'metadata.deletionTimestamp' \
 		| yq d - 'metadata.annotations."k8s.v1.cni.cncf.io*"' \
 		| yq d - 'metadata.annotations."kubernetes.io/psp"' \
+		| yq d - 'metadata.annotations."cloud.google.com/neg"' \
 		| yq d - '**.(name==percona-xtradb-cluster-operator-workload-token*)' \
 		| yq d - '**.creationTimestamp' \
 		| yq d - '**.image' \


### PR DESCRIPTION
[![K8SPXC-808](https://badgen.net/badge/JIRA/K8SPXC-808/green)](https://jira.percona.com/browse/K8SPXC-808) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`init-deploy` and `proxysql-sidecar-res-limits` are failing on GKE 1.21 like so:
```
+ diff -u /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/init-deploy/compare/service_some-name-proxysql.yml /tmp/tmp.ZiC8sHn1p2/service_some-name-proxysql.yml
--- /mnt/jenkins/workspace/pxc-operator-gke-version/source/e2e-tests/init-deploy/compare/service_some-name-proxysql.yml 2021-08-02 06:29:39.000000000 +0000
+++ /tmp/tmp.ZiC8sHn1p2/service_some-name-proxysql.yml  2021-08-02 06:44:43.626951928 +0000
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations: {}
+  annotations:
+    cloud.google.com/neg: '{"ingress":true}'
   labels:
     app.kubernetes.io/component: proxysql
     app.kubernetes.io/instance: some-name
```