### PR TITLE
K8SPXC-868 - Fix examples for custom sidecar resources in cr.yaml

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -101,6 +101,13 @@ spec:
 #      command: ["/bin/sh"]
 #      args: ["-c", "while true; do trap 'exit 0' SIGINT SIGTERM SIGQUIT SIGKILL; done;"]
 #      name: my-sidecar-1
+#      resources:
+#        requests:
+#          memory: 100M
+#          cpu: 100m
+#        limits:
+#          memory: 200M
+#          cpu: 200m
 #    envVarsSecret: my-env-var-secrets
     resources:
       requests:
@@ -113,13 +120,6 @@ spec:
 #        ephemeral-storage: 1G
 #    nodeSelector:
 #      disktype: ssd
-#    sidecarResources:
-#      requests:
-#        memory: 1G
-#        cpu: 500m
-#      limits:
-#        memory: 2G
-#        cpu: 600m
     affinity:
       antiAffinityTopologyKey: "kubernetes.io/hostname"
 #      advanced:
@@ -213,6 +213,13 @@ spec:
 #      command: ["/bin/sh"]
 #      args: ["-c", "while true; do trap 'exit 0' SIGINT SIGTERM SIGQUIT SIGKILL; done;"]
 #      name: my-sidecar-1
+#      resources:
+#        requests:
+#          memory: 100M
+#          cpu: 100m
+#        limits:
+#          memory: 200M
+#          cpu: 200m
 #    envVarsSecret: my-env-var-secrets
     resources:
       requests:
@@ -325,6 +332,13 @@ spec:
 #      command: ["/bin/sh"]
 #      args: ["-c", "while true; do trap 'exit 0' SIGINT SIGTERM SIGQUIT SIGKILL; done;"]
 #      name: my-sidecar-1
+#      resources:
+#        requests:
+#          memory: 100M
+#          cpu: 100m
+#        limits:
+#          memory: 200M
+#          cpu: 200m
 #    envVarsSecret: my-env-var-secrets
     resources:
       requests:


### PR DESCRIPTION
[![K8SPXC-868](https://badgen.net/badge/JIRA/K8SPXC-868/green)](https://jira.percona.com/browse/K8SPXC-868) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

1. adds requests/limits to haproxy/proxysql custom sidecar example
2. removes `sidecarResources` from PXC pods since it does nothing there