### PR TITLE
Fix for K8SPXC-824 Cluster may get into an unrecoverable state

### DIFF
--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -37,7 +37,7 @@ file_env() {
 	if [ "${!var:-}" ]; then
 		val="${!var}"
 	elif [ "${!fileVar:-}" ]; then
-		val="$(< "${!fileVar}")"
+		val="$(<"${!fileVar}")"
 	elif [ "${3:-}" ] && [ -f "/etc/mysql/mysql-users-secret/$3" ]; then
 		val="$(</etc/mysql/mysql-users-secret/$3)"
 	fi
@@ -180,12 +180,12 @@ fi
 grep -q "^progress=" $CFG && sed -i "s|^progress=.*|progress=1|" $CFG
 grep -q "^\[sst\]" "$CFG" || printf '[sst]\n' >>"$CFG"
 grep -q "^cpat=" "$CFG" || sed '/^\[sst\]/a cpat=.*\\.pem$\\|.*init\\.ok$\\|.*galera\\.cache$\\|.*wsrep_recovery_verbose\\.log$\\|.*readiness-check\\.sh$\\|.*liveness-check\\.sh$\\|.*sst_in_progress$\\|.*sst-xb-tmpdir$\\|.*\\.sst$\\|.*gvwstate\\.dat$\\|.*grastate\\.dat$\\|.*\\.err$\\|.*\\.log$\\|.*RPM_UPGRADE_MARKER$\\|.*RPM_UPGRADE_HISTORY$\\|.*pxc-entrypoint\\.sh$\\|.*unsafe-bootstrap\\.sh$\\|.*pxc-configure-pxc\\.sh\\|.*peer-list$' "$CFG" 1<>"$CFG"
-if [[ "$MYSQL_VERSION" == '8.0' ]]; then
-       if [[ $MYSQL_PATCH_VERSION -ge 26 ]]; then
-               grep -q "^skip_replica_start=ON" "$CFG" || sed -i "/\[mysqld\]/a skip_replica_start=ON" $CFG
-       else
-               grep -q "^skip_slave_start=ON" "$CFG" || sed -i "/\[mysqld\]/a skip_slave_start=ON" $CFG
-       fi
+if [[ $MYSQL_VERSION == '8.0' ]]; then
+	if [[ $MYSQL_PATCH_VERSION -ge 26 ]]; then
+		grep -q "^skip_replica_start=ON" "$CFG" || sed -i "/\[mysqld\]/a skip_replica_start=ON" $CFG
+	else
+		grep -q "^skip_slave_start=ON" "$CFG" || sed -i "/\[mysqld\]/a skip_slave_start=ON" $CFG
+	fi
 fi
 
 file_env 'XTRABACKUP_PASSWORD' 'xtrabackup' 'xtrabackup'
@@ -565,8 +565,8 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		is_primary_exists=$(get_primary)
 		is_manual_recovery
 		if [[ -z $is_primary_exists && -f $grastate_loc && $safe_to_bootstrap != 1 ]] \
-		|| [[ -z $is_primary_exists && -f "${DATADIR}/gvwstate.dat" ]] \
-		|| [[ -z $is_primary_exists && -f $grastate_loc && $safe_to_bootstrap == 1 && -n ${CLUSTER_JOIN} ]]; then
+			|| [[ -z $is_primary_exists && -f "${DATADIR}/gvwstate.dat" ]] \
+			|| [[ -z $is_primary_exists && -f $grastate_loc && $safe_to_bootstrap == 1 && -n ${CLUSTER_JOIN} ]]; then
 			trap '{ node_recovery "$@" ; }' USR1
 			touch /tmp/recovery-case
 			if [[ -z ${seqno} ]]; then

--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -564,7 +564,9 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 
 		is_primary_exists=$(get_primary)
 		is_manual_recovery
-		if [[ -z $is_primary_exists && -f $grastate_loc && $safe_to_bootstrap != 1 ]] || [[ -z $is_primary_exists && -f "${DATADIR}/gvwstate.dat" ]]; then
+		if [[ -z $is_primary_exists && -f $grastate_loc && $safe_to_bootstrap != 1 ]] \
+		|| [[ -z $is_primary_exists && -f "${DATADIR}/gvwstate.dat" ]] \
+		|| [[ -z $is_primary_exists && -f $grastate_loc && $safe_to_bootstrap == 1 && -n ${CLUSTER_JOIN} ]]; then
 			trap '{ node_recovery "$@" ; }' USR1
 			touch /tmp/recovery-case
 			if [[ -z ${seqno} ]]; then


### PR DESCRIPTION
[![K8SPXC-824](https://badgen.net/badge/JIRA/K8SPXC-824/green)](https://jira.percona.com/browse/K8SPXC-824) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fix for K8SPXC-824: Cluster may get into an unrecoverable state with incomplete full crash

Without this fix, it is possible to get an operator-controlled cluster into a state where some pxc pod other than the first one to start is the most advanced node and is ready for bootstrap, but it's neither bootstrapped nor does it fall under the (automatic) recovery conditions.

To recover from such condition, one must counter-intuitively edit `grastate.dat` and set `safe_to_bootstrap` to 0. That results in cluster falling fully into crash recovery.

Full reproduction procedure is available in https://jira.percona.com/browse/K8SPXC-824

This change adds the following condition to a list of conditions checked before pxc container falls into crash recovery:

- No primary component is found
- AND grastate.dat file exists
- AND safe_to_bootstrap is 1 in grastate.dat
- AND there are other PXC pods out there.

If we remove the "AND there are other PXC pods out there", first pod to start would go into crash recovery. We don't want that. If the first pod to start will go up cleanly (example: pause and unpause), then primary component will be found during the init of other pods and the new added condition doesn't trigger.