### PR TITLE
K8SPXC-876 use PublishNotReadyAddresses instead of annotation

### DIFF
--- a/e2e-tests/init-deploy/compare/service_some-name-proxysql-unready.yml
+++ b/e2e-tests/init-deploy/compare/service_some-name-proxysql-unready.yml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   labels:
     app.kubernetes.io/component: proxysql
     app.kubernetes.io/instance: some-name
@@ -28,6 +26,7 @@ spec:
       port: 33062
       protocol: TCP
       targetPort: 33062
+  publishNotReadyAddresses: true
   selector:
     app.kubernetes.io/component: proxysql
     app.kubernetes.io/instance: some-name

--- a/pkg/pxc/service.go
+++ b/pkg/pxc/service.go
@@ -118,6 +118,11 @@ func NewServicePXCUnready(cr *api.PerconaXtraDBCluster) *corev1.Service {
 		)
 	}
 
+	if cr.CompareVersionWith("1.10.0") >= 0 {
+		obj.Spec.PublishNotReadyAddresses = true
+		delete(obj.ObjectMeta.Annotations, "service.alpha.kubernetes.io/tolerate-unready-endpoints")
+	}
+
 	return obj
 }
 
@@ -171,6 +176,11 @@ func NewServiceProxySQLUnready(cr *api.PerconaXtraDBCluster) *corev1.Service {
 		obj.ObjectMeta.Labels["app.kubernetes.io/component"] = "proxysql"
 		obj.ObjectMeta.Labels["app.kubernetes.io/managed-by"] = "percona-xtradb-cluster-operator"
 		obj.ObjectMeta.Labels["app.kubernetes.io/part-of"] = "percona-xtradb-cluster"
+	}
+
+	if cr.CompareVersionWith("1.10.0") >= 0 {
+		obj.Spec.PublishNotReadyAddresses = true
+		delete(obj.ObjectMeta.Annotations, "service.alpha.kubernetes.io/tolerate-unready-endpoints")
 	}
 
 	return obj


### PR DESCRIPTION
[![K8SPXC-876](https://badgen.net/badge/JIRA/K8SPXC-876/green)](https://jira.percona.com/browse/K8SPXC-876) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-876
"service.alpha.kubernetes.io/tolerate-unready-endpoints" annotation has been
deprecated since Kuberneets 1.8 and the spec.publishNotReadyAddresses
parameter replacing it has been correctly implemented in Kubernetes 1.11
(see kubernetes/kubernetes#63742)