### PR TITLE
K8SPXC-761 use numeric id in USER instruction

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,4 +41,4 @@ COPY build/pxc-configure-pxc.sh /pxc-configure-pxc.sh
 COPY build/liveness-check.sh /liveness-check.sh
 COPY build/readiness-check.sh /readiness-check.sh
 
-USER nobody
+USER 2


### PR DESCRIPTION
1. Use numeric id instead of username in USER instruction
2. Use id 2(daemon), reasons:
   - nobody user id changed in rhel/centos/ubi 8 from 2 to 65534
   - unify with percona-postgresql-operator