### PR TITLE
K8SPXC-845: do not stuck in case of wrong cr

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -244,7 +244,7 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(request reconcile.Request) (re
 		return rr, err
 	}
 
-	// wait untill token issued to run PXC in data encrypted mode.
+	// wait until token issued to run PXC in data encrypted mode.
 	if o.ShouldWaitForTokenIssue() {
 		reqLogger.Info("wait for token issuing")
 		return rr, nil


### PR DESCRIPTION
[![K8SPXC-845](https://badgen.net/badge/JIRA/K8SPXC-845/green)](https://jira.percona.com/browse/K8SPXC-845) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Before, if we provide a wrong cr and then try to delete the
cluster, we will stuck, because finalizers are processed only
after checking this cr. For now, we check if cluster is deleted
first.