### PR TITLE
K8SPXC-588 - Change replicasServiceEnabled in cr.yaml

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -155,7 +155,7 @@ spec:
     enabled: true
     size: 3
     image: perconalab/percona-xtradb-cluster-operator:main-haproxy
-#    replicasServiceEnabled: true
+#    replicasServiceEnabled: false
 #    imagePullPolicy: Always
 #    schedulerName: mycustom-scheduler
 #    configuration: |


### PR DESCRIPTION
[![K8SPXC-588](https://badgen.net/badge/JIRA/K8SPXC-588/green)](https://jira.percona.com/browse/K8SPXC-588) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Since `replicasServiceEnabled` is enabled by default it might make more sense to keep the commented option as `false` so if user wants to change it he just needs to uncomment the option.