### PR TITLE
K8SPXC-895 - Fixes in tests for kubernetes 1.22

### DIFF
--- a/e2e-tests/default-cr/compare/service_cluster1-haproxy-k122.yml
+++ b/e2e-tests/default-cr/compare/service_cluster1-haproxy-k122.yml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: haproxy
+    app.kubernetes.io/instance: cluster1
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: cluster1-haproxy
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: cluster1
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: proxy-protocol
+      port: 3309
+      protocol: TCP
+      targetPort: 3309
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+    - name: mysqlx
+      port: 33060
+      protocol: TCP
+      targetPort: 33060
+  selector:
+    app.kubernetes.io/component: haproxy
+    app.kubernetes.io/instance: cluster1
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/default-cr/compare/service_cluster1-pxc-k122.yml
+++ b/e2e-tests/default-cr/compare/service_cluster1-pxc-k122.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: cluster1
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: cluster1-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: cluster1
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+    - name: mysqlx
+      port: 33060
+      protocol: TCP
+      targetPort: 33060
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: cluster1
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -364,6 +364,21 @@ compare_kubectl() {
 			>${new_result}
 	# last sed is needed for backup cronjob content
 
+	if version_gt "1.21"; then
+		if [[ $expected_result == */service*-proxysql-unready* ]]; then
+			yq d -i ${new_result} 'metadata.annotations'
+		fi
+	fi
+	if version_gt "1.22"; then
+		yq d -i ${new_result} 'spec.internalTrafficPolicy'
+		yq d -i ${new_result} 'spec.allocateLoadBalancerNodePorts'
+		if [[ $expected_result == */job* ]]; then
+			yq d -i ${new_result} 'metadata.generation'
+			yq d -i ${new_result} 'spec.completionMode'
+			yq d -i ${new_result} 'spec.suspend'
+		fi
+	fi
+
 	diff -u ${expected_result} ${new_result}
 }
 
@@ -924,6 +939,12 @@ function vault_tls() {
 	SECRET_NAME=$name
 	CSR_NAME=vault-csr-${RANDOM}
 
+	if version_gt "1.22"; then
+		CSR_API_VER="v1"
+	else
+		CSR_API_VER="v1beta1"
+	fi
+
 	openssl genrsa -out ${tmp_dir}/vault.key 2048
 	cat <<EOF >${tmp_dir}/csr.conf
 [req]
@@ -946,7 +967,7 @@ EOF
 	openssl req -new -key ${tmp_dir}/vault.key -subj "/CN=${SERVICE}.${NAMESPACE}.svc" -out ${tmp_dir}/server.csr -config ${tmp_dir}/csr.conf
 
 	cat <<EOF >${tmp_dir}/csr.yaml
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/${CSR_API_VER}
 kind: CertificateSigningRequest
 metadata:
   name: ${CSR_NAME}
@@ -954,6 +975,7 @@ spec:
   groups:
   - system:authenticated
   request: $(cat ${tmp_dir}/server.csr | base64 | tr -d '\n')
+  signerName: kubernetes.io/kubelet-serving
   usages:
   - digital signature
   - key encipherment
@@ -1008,7 +1030,7 @@ start_vault() {
 		vault_tls "$name"
 		helm install $name hashicorp/vault \
 			--disable-openapi-validation \
-			--version 0.6.0 \
+			--version 0.16.1 \
 			--namespace "$name" \
 			--set dataStorage.enabled=false \
 			--set global.tlsDisable=false \
@@ -1032,7 +1054,7 @@ storage \"file\" {
 	else
 		helm install $name hashicorp/vault \
 			--disable-openapi-validation \
-			--version 0.6.0 \
+			--version 0.16.1 \
 			--namespace "$name" \
 			--set dataStorage.enabled=false \
 			--set global.platform="${platform}"

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -364,19 +364,10 @@ compare_kubectl() {
 			>${new_result}
 	# last sed is needed for backup cronjob content
 
-	if version_gt "1.21"; then
-		if [[ $expected_result == */service*-proxysql-unready* ]]; then
-			yq d -i ${new_result} 'metadata.annotations'
-		fi
-	fi
-	if version_gt "1.22"; then
-		yq d -i ${new_result} 'spec.internalTrafficPolicy'
-		yq d -i ${new_result} 'spec.allocateLoadBalancerNodePorts'
-		if [[ $expected_result == */job* ]]; then
-			yq d -i ${new_result} 'metadata.generation'
-			yq d -i ${new_result} 'spec.completionMode'
-			yq d -i ${new_result} 'spec.suspend'
-		fi
+	if version_gt "1.22" && [ -f ${expected_result//.yml/-k122.yml} ]; then
+		expected_result=${expected_result//.yml/-k122.yml}
+	elif version_gt "1.21" && [ -f ${expected_result//.yml/-k121.yml} ]; then
+		expected_result=${expected_result//.yml/-k121.yml}
 	fi
 
 	diff -u ${expected_result} ${new_result}

--- a/e2e-tests/haproxy/compare/service_haproxy-haproxy-k122.yml
+++ b/e2e-tests/haproxy/compare/service_haproxy-haproxy-k122.yml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: haproxy
+    app.kubernetes.io/instance: haproxy
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: haproxy-haproxy
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: haproxy
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: proxy-protocol
+      port: 3309
+      protocol: TCP
+      targetPort: 3309
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+    - name: mysqlx
+      port: 33060
+      protocol: TCP
+      targetPort: 33060
+  selector:
+    app.kubernetes.io/component: haproxy
+    app.kubernetes.io/instance: haproxy
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/haproxy/compare/service_haproxy-haproxy-replicas-k122.yml
+++ b/e2e-tests/haproxy/compare/service_haproxy-haproxy-replicas-k122.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: haproxy
+    app.kubernetes.io/instance: haproxy
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: haproxy-haproxy-replicas
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: haproxy
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql-replicas
+      port: 3306
+      protocol: TCP
+      targetPort: 3307
+  selector:
+    app.kubernetes.io/component: haproxy
+    app.kubernetes.io/instance: haproxy
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/haproxy/compare/service_haproxy-proxysql-k122.yml
+++ b/e2e-tests/haproxy/compare/service_haproxy-proxysql-k122.yml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: haproxy
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: haproxy-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: haproxy
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: haproxy
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/haproxy/run
+++ b/e2e-tests/haproxy/run
@@ -79,6 +79,7 @@ main() {
 	compare_mysql_cmd_local "ping_timeout_server" \
 		"SELECT * FROM global_variables WHERE variable_name = '\''mysql-ping_timeout_server'\'';" \
 		"-h127.0.0.1 -P6032 -uproxyadmin -padmin_password" "$cluster-proxysql-0" "-secret" -c'proxysql'
+	wait_cluster_consistency "$cluster" 3 2
 
 	desc 're-enable haproxy'
 	apply_config "$test_dir/conf/$cluster.yml"
@@ -91,7 +92,7 @@ main() {
 	diff --strip-trailing-cr "$tmp_dir"/haproxy_maxconn.txt "$test_dir"/compare/haproxy_maxconn.txt
 
 	apply_config "$test_dir/conf/config-secret-haproxy.yaml"
-	sleep 50
+	sleep 100
 	compare_kubectl statefulset/$cluster-haproxy "-secret"
 	kubectl_bin exec haproxy-haproxy-0 -c haproxy -it -- bash -c 'echo "show info" | socat stdio unix-connect:/etc/haproxy/pxc/haproxy.sock' \
 		| grep "Maxconn:" >"$tmp_dir"/haproxy_maxconn.txt

--- a/e2e-tests/init-deploy/compare/service_no-proxysql-pxc-k122.yml
+++ b/e2e-tests/init-deploy/compare/service_no-proxysql-pxc-k122.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: no-proxysql
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: no-proxysql-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: no-proxysql
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+    - name: mysqlx
+      port: 33060
+      protocol: TCP
+      targetPort: 33060
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: no-proxysql
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/init-deploy/compare/service_some-name-proxysql-k122.yml
+++ b/e2e-tests/init-deploy/compare/service_some-name-proxysql-k122.yml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/init-deploy/compare/service_some-name-proxysql-unready-k121.yml
+++ b/e2e-tests/init-deploy/compare/service_some-name-proxysql-unready-k121.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: some-name-proxysql-unready
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: proxyadm
+      port: 6032
+      protocol: TCP
+      targetPort: 6032
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/init-deploy/compare/service_some-name-proxysql-unready-k122.yml
+++ b/e2e-tests/init-deploy/compare/service_some-name-proxysql-unready-k122.yml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: some-name-proxysql-unready
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: proxyadm
+      port: 6032
+      protocol: TCP
+      targetPort: 6032
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/init-deploy/compare/service_some-name-pxc-k122.yml
+++ b/e2e-tests/init-deploy/compare/service_some-name-pxc-k122.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+    - name: mysqlx
+      port: 33060
+      protocol: TCP
+      targetPort: 33060
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/service_side-car-proxysql-k122.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/service_side-car-proxysql-k122.yml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: side-car
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: side-car-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: side-car
+spec:
+  allocateLoadBalancerNodePorts: true
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: side-car
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: LoadBalancer

--- a/e2e-tests/run
+++ b/e2e-tests/run
@@ -6,9 +6,9 @@ set -o errexit
 dir=$(realpath "$(dirname "$0")")
 
 fail() {
-    local test=$1
-    echo "test $test failed"
-    exit 1
+	local test=$1
+	echo "test $test failed"
+	exit 1
 }
 
 $dir/init-deploy/run || fail "init-deploy"

--- a/e2e-tests/security-context/compare/job.batch_restore-job-restore-pvc-sec-context-k122.yml
+++ b/e2e-tests/security-context/compare/job.batch_restore-job-restore-pvc-sec-context-k122.yml
@@ -1,0 +1,85 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    job-name: restore-job-restore-pvc-sec-context
+  name: restore-job-restore-pvc-sec-context
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterRestore
+      name: restore-pvc
+spec:
+  backoffLimit: 4
+  completionMode: NonIndexed
+  completions: 1
+  parallelism: 1
+  selector:
+    matchLabels: {}
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        openshift.io/scc: privileged
+      labels:
+        job-name: restore-job-restore-pvc-sec-context
+    spec:
+      containers:
+        - command:
+            - recovery-pvc-joiner.sh
+          env:
+            - name: RESTORE_SRC_SERVICE
+              value: restore-src-restore-pvc-sec-context
+            - name: XB_USE_MEMORY
+              value: "750000000"
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1G
+            requests:
+              memory: 1G
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /datadir
+              name: datadir
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        supplementalGroups:
+          - 1001
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir-sec-context-pxc-0
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: false
+            secretName: some-name-ssl
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: sec-context-vault

--- a/e2e-tests/security-context/compare/job.batch_restore-job-restore-s3-sec-context-k122.yml
+++ b/e2e-tests/security-context/compare/job.batch_restore-job-restore-s3-sec-context-k122.yml
@@ -1,0 +1,92 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    job-name: restore-job-restore-s3-sec-context
+  name: restore-job-restore-s3-sec-context
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterRestore
+      name: restore-s3
+spec:
+  backoffLimit: 4
+  completionMode: NonIndexed
+  completions: 1
+  parallelism: 1
+  selector:
+    matchLabels: {}
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        openshift.io/scc: privileged
+      labels:
+        job-name: restore-job-restore-s3-sec-context
+    spec:
+      containers:
+        - command:
+            - recovery-s3.sh
+          env:
+            - name: ENDPOINT
+              value: http://minio-service:9000/
+            - name: DEFAULT_REGION
+              value: us-east-1
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_ACCESS_KEY_ID
+                  name: minio-secret
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_SECRET_ACCESS_KEY
+                  name: minio-secret
+            - name: PXC_SERVICE
+              value: sec-context-pxc
+            - name: PXC_USER
+              value: xtrabackup
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: XB_USE_MEMORY
+              value: "750000000"
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1G
+            requests:
+              memory: 1G
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /datadir
+              name: datadir
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        supplementalGroups:
+          - 1001
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir-sec-context-pxc-0
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: sec-context-vault

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc-k122.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc-k122.yml
@@ -1,0 +1,97 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  generation: 1
+  labels:
+    cluster: sec-context
+    job-name: xb-on-demand-backup-pvc
+    type: xtrabackup
+  name: xb-on-demand-backup-pvc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterBackup
+      name: on-demand-backup-pvc
+spec:
+  backoffLimit: 10
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: true
+  parallelism: 1
+  selector:
+    matchLabels:
+      cluster: sec-context
+      job-name: xb-on-demand-backup-pvc
+      type: xtrabackup
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        openshift.io/scc: privileged
+      labels:
+        cluster: sec-context
+        job-name: xb-on-demand-backup-pvc
+        type: xtrabackup
+    spec:
+      containers:
+        - command:
+            - bash
+            - /usr/bin/backup.sh
+          env:
+            - name: BACKUP_DIR
+              value: /backup
+            - name: PXC_SERVICE
+              value: sec-context-pxc
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /backup
+              name: xtrabackup
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+          - 1002
+          - 1003
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: xtrabackup
+          persistentVolumeClaim:
+            claimName: xb-on-demand-backup-pvc
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: sec-context-vault

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3-k122.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3-k122.yml
@@ -1,0 +1,108 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  generation: 1
+  labels:
+    cluster: sec-context
+    job-name: xb-on-demand-backup-s3
+    type: xtrabackup
+  name: xb-on-demand-backup-s3
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterBackup
+      name: on-demand-backup-s3
+spec:
+  backoffLimit: 10
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: true
+  parallelism: 1
+  selector:
+    matchLabels:
+      cluster: sec-context
+      job-name: xb-on-demand-backup-s3
+      type: xtrabackup
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        openshift.io/scc: privileged
+      labels:
+        cluster: sec-context
+        job-name: xb-on-demand-backup-s3
+        type: xtrabackup
+    spec:
+      containers:
+        - command:
+            - bash
+            - /usr/bin/backup.sh
+          env:
+            - name: BACKUP_DIR
+              value: /backup
+            - name: PXC_SERVICE
+              value: sec-context-pxc
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_ACCESS_KEY_ID
+                  name: minio-secret
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_SECRET_ACCESS_KEY
+                  name: minio-secret
+            - name: DEFAULT_REGION
+              value: us-east-1
+            - name: ENDPOINT
+              value: http://minio-service:9000/
+            - name: S3_BUCKET
+              value: operator-testing
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+          - 1002
+          - 1003
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: sec-context-vault

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-100-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-100-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-110-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-110-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-1100-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-1100-k122.yml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-120-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-120-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-130-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-130-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-140-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-140-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-150-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-150-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-160-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-160-k122.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-170-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-170-k122.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-180-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-180-k122.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-190-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-190-k122.yml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: some-name-proxysql
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: proxysql
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-100-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-100-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-110-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-110-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-1100-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-1100-k122.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+    - name: mysqlx
+      port: 33060
+      protocol: TCP
+      targetPort: 33060
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-120-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-120-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-130-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-130-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-140-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-140-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-150-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-150-k122.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-160-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-160-k122.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-170-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-170-k122.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-180-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-180-k122.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-190-k122.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-190-k122.yml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
+  name: some-name-pxc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBCluster
+      name: some-name
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: 3306
+    - name: mysql-admin
+      port: 33062
+      protocol: TCP
+      targetPort: 33062
+    - name: mysqlx
+      port: 33060
+      protocol: TCP
+      targetPort: 33060
+  selector:
+    app.kubernetes.io/component: pxc
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/name: percona-xtradb-cluster
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/run
+++ b/e2e-tests/upgrade-consistency/run
@@ -30,6 +30,18 @@ wait_for_sts_generation() {
 	set -o xtrace
 }
 
+apply_fixed_rbac() {
+	local git_tag="$1"
+
+	if version_gt "1.22"; then
+		curl -s "https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/${git_tag}/deploy/rbac.yaml" >"${tmp_dir}/rbac_${git_tag}.yaml"
+		$sed -i -e "s^apiVersion: rbac.authorization.k8s.io/v1beta1^apiVersion: rbac.authorization.k8s.io/v1^" "${tmp_dir}/rbac_${git_tag}.yaml"
+		kubectl_bin apply -f "${tmp_dir}/rbac_${git_tag}.yaml"
+	else
+		kubectl_bin apply -f https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/${git_tag}/deploy/rbac.yaml
+	fi
+}
+
 main() {
 	create_infra $namespace
 
@@ -99,7 +111,7 @@ main() {
 
 	# test 1.5.0
 	API="pxc.percona.com/v1-5-0"
-	kubectl_bin apply -f https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/v1.5.0/deploy/rbac.yaml
+	apply_fixed_rbac "v1.5.0"
 	kubectl_bin patch pxc "$cluster" --type=merge --patch '{
         "spec": {"crVersion":"1.5.0", "proxysql": { "image": "percona/percona-xtradb-cluster-operator:1.5.0-proxysql" }}
     }'
@@ -113,7 +125,7 @@ main() {
 
 	# test 1.6.0
 	API="pxc.percona.com/v1-6-0"
-	kubectl_bin apply -f https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/v1.6.0/deploy/rbac.yaml
+	apply_fixed_rbac "v1.6.0"
 	kubectl_bin patch pxc "$cluster" --type=merge --patch '{
         "spec": {"crVersion":"1.6.0"}
     }'
@@ -127,7 +139,7 @@ main() {
 
 	# test 1.7.0
 	API="pxc.percona.com/v1-7-0"
-	kubectl_bin apply -f https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/v1.7.0/deploy/rbac.yaml
+	apply_fixed_rbac "v1.7.0"
 	kubectl_bin patch pxc "$cluster" --type=merge --patch '{
         "spec": {"crVersion":"1.7.0"}
     }'
@@ -141,7 +153,7 @@ main() {
 
 	# test 1.8.0
 	API="pxc.percona.com/v1-8-0"
-	kubectl_bin apply -f https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/v1.8.0/deploy/rbac.yaml
+	apply_fixed_rbac "v1.8.0"
 	kubectl_bin patch pxc "$cluster" --type=merge --patch '{
         "spec": {"crVersion":"1.8.0"}
     }'


### PR DESCRIPTION
[![K8SPXC-895](https://badgen.net/badge/JIRA/K8SPXC-895/green)](https://jira.percona.com/browse/K8SPXC-895) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Here's the test run with 1.22: https://cloud.cd.percona.com/view/PXC/job/pxc-operator-gke-version/810/#showFailuresLink
- 3 chaos-mesh tests failed because chaos-mesh helm chart doesn't support 1.22 yet
- `scheduled-backup` fails a lot so we will probably need to investigate it more (although in the above test run it passed, but after many failures)

Some of the diffs this fixes:
```
+ diff -u /mnt/jenkins/workspace/pxc-operator-gke-latest/source/e2e-tests/proxysql-sidecar-res-limits/compare/service_side-car-proxysql.yml /tmp/tmp.fPAY2stbOt/service_side-car-proxysql.yml
--- /mnt/jenkins/workspace/pxc-operator-gke-latest/source/e2e-tests/proxysql-sidecar-res-limits/compare/service_side-car-proxysql.yml	2021-10-19 00:05:35.000000000 +0000
+++ /tmp/tmp.fPAY2stbOt/service_side-car-proxysql.yml	2021-10-19 01:41:17.990410614 +0000
@@ -14,7 +14,9 @@
       kind: PerconaXtraDBCluster
       name: side-car
 spec:
+  allocateLoadBalancerNodePorts: true
   externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
   ports:
     - name: mysql
       port: 3306
```

```
+ diff -u /mnt/jenkins/workspace/pxc-operator-gke-latest/source/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc.yml /tmp/tmp.adrHH7uZmM/job.batch_xb-on-demand-backup-pvc.yml
--- /mnt/jenkins/workspace/pxc-operator-gke-latest/source/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc.yml	2021-10-19 00:05:35.000000000 +0000
+++ /tmp/tmp.adrHH7uZmM/job.batch_xb-on-demand-backup-pvc.yml	2021-10-19 00:47:01.448299286 +0000
@@ -3,6 +3,7 @@
 metadata:
   annotations:
     openshift.io/scc: privileged
+  generation: 1
   labels:
     cluster: sec-context
     job-name: xb-on-demand-backup-pvc
@@ -14,6 +15,7 @@
       name: on-demand-backup-pvc
 spec:
   backoffLimit: 10
+  completionMode: NonIndexed
   completions: 1
   manualSelector: true
   parallelism: 1
@@ -22,6 +24,7 @@
       cluster: sec-context
       job-name: xb-on-demand-backup-pvc
       type: xtrabackup
+  suspend: false
   template:
     metadata:
       annotations:
```

```
+ diff -u /mnt/jenkins/workspace/cloud-pxc-operator_PR-1023/e2e-tests/init-deploy/compare/service_some-name-proxysql-unready.yml /tmp/tmp.8tUVrddmnN/service_some-name-proxysql-unready.yml
--- /mnt/jenkins/workspace/cloud-pxc-operator_PR-1023/e2e-tests/init-deploy/compare/service_some-name-proxysql-unready.yml	2021-10-19 09:24:27.931233339 +0000
+++ /tmp/tmp.8tUVrddmnN/service_some-name-proxysql-unready.yml	2021-10-19 09:59:57.513813927 +0000
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations: {}
   labels:
     app.kubernetes.io/component: proxysql
     app.kubernetes.io/instance: some-name
```

demand-backup-encrypted-with-tls:
```
error: unable to recognize "/var/folders/fw/lxhtthdn7d9610w5p3wb33340000gn/T/tmp.7TW56kSg/csr.yaml": no matches for kind "CertificateSigningRequest" in version "certificates.k8s.io/v1beta1"

error: error validating "/var/folders/fw/lxhtthdn7d9610w5p3wb33340000gn/T/tmp.4mTk05HK/csr.yaml": error validating data: ValidationError(CertificateSigningRequest.spec): missing required field "signerName" in io.k8s.api.certificates.v1.CertificateSigningRequestSpec; if you choose to ignore these errors, turn validation off with --validate=false
```