### PR TITLE
env vars for dev building images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/.github/
+/adopters/
+/deploy/
+/docs/
+/e2e-tests/

--- a/e2e-tests/build
+++ b/e2e-tests/build
@@ -8,6 +8,13 @@ test_dir="$(dirname $0)"
 src_dir="$(realpath ${test_dir}/..)"
 IMAGE=$(echo "$IMAGE" | sed -e 's#percona/#perconalab/#')
 
+if [[ ${DOCKER_NOCACHE:-1} == 1 ]]; then
+	no_cache="--no-cache"
+fi
+if [[ ${DOCKER_SQUASH:-1} == 1 ]]; then
+	squash="--squash"
+fi
+
 build_operator() {
 	if [ "${RELEASE:-1}" = 0 ]; then
 		GO_LDFLAGS="-race"
@@ -21,8 +28,8 @@ build_operator() {
 		--build-arg GIT_BRANCH=$GIT_BRANCH \
 		--build-arg BUILD_TIME=$BUILD_TIME \
 		--build-arg GO_LDFLAGS="$GO_LDFLAGS" \
-		--squash \
-		--no-cache \
+		$squash \
+		$no_cache \
 		--progress plain \
 		-t "${IMAGE}" -f build/Dockerfile .
 	popd
@@ -33,8 +40,5 @@ if [[ $BUILD == "0" ]]; then
 	exit 0
 fi
 
-until docker ps; do
-	sleep 1
-done
-
+until docker ps; do sleep 1; done
 build_operator


### PR DESCRIPTION
2 env vars are added for `e2e-tests/build` script:

- `DOCKER_NOCACHE=0` disables `--no-cache` option for `docker build` command. Default `1`
- `DOCKER_SQUASH=0` disables `--squash` option for `docker build` command. Default `1`

it makes fast docker `build` and `push` operations. useful for local usage during development