### PR TITLE
CLOUD-651 fix: smartupdate starts after pod deletion

### DIFF
--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -250,10 +250,14 @@ func (r *ReconcilePerconaXtraDBCluster) smartUpdate(sfs api.StatefulApp, cr *api
 	); err != nil {
 		return errors.Wrap(err, "get pod list")
 	}
+	update := false
 	for _, pod := range list.Items {
 		if pod.ObjectMeta.Labels["controller-revision-hash"] != currentSet.Status.UpdateRevision {
+			update = true
 			break
 		}
+	}
+	if !update {
 		return nil
 	}
 

--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -240,7 +240,20 @@ func (r *ReconcilePerconaXtraDBCluster) smartUpdate(sfs api.StatefulApp, cr *api
 		return errors.Wrap(err, "failed to get current sfs")
 	}
 
-	if currentSet.Status.UpdatedReplicas >= currentSet.Status.Replicas {
+	list := corev1.PodList{}
+	if err := r.client.List(context.TODO(),
+		&list,
+		&client.ListOptions{
+			Namespace:     currentSet.Namespace,
+			LabelSelector: labels.SelectorFromSet(sfs.Labels()),
+		},
+	); err != nil {
+		return errors.Wrap(err, "get pod list")
+	}
+	for _, pod := range list.Items {
+		if pod.ObjectMeta.Labels["controller-revision-hash"] != currentSet.Status.UpdateRevision {
+			break
+		}
 		return nil
 	}
 
@@ -261,17 +274,6 @@ func (r *ReconcilePerconaXtraDBCluster) smartUpdate(sfs api.StatefulApp, cr *api
 	if currentSet.Status.ReadyReplicas < currentSet.Status.Replicas {
 		logger.Info("can't start/continue 'SmartUpdate': waiting for all replicas are ready")
 		return nil
-	}
-
-	list := corev1.PodList{}
-	if err := r.client.List(context.TODO(),
-		&list,
-		&client.ListOptions{
-			Namespace:     currentSet.Namespace,
-			LabelSelector: labels.SelectorFromSet(sfs.Labels()),
-		},
-	); err != nil {
-		return errors.Wrap(err, "get pod list")
 	}
 
 	primary, err := r.getPrimaryPod(cr)

--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -250,14 +250,14 @@ func (r *ReconcilePerconaXtraDBCluster) smartUpdate(sfs api.StatefulApp, cr *api
 	); err != nil {
 		return errors.Wrap(err, "get pod list")
 	}
-	update := false
+	statefulSetChanged := false
 	for _, pod := range list.Items {
 		if pod.ObjectMeta.Labels["controller-revision-hash"] != currentSet.Status.UpdateRevision {
-			update = true
+			statefulSetChanged = true
 			break
 		}
 	}
-	if !update {
+	if !statefulSetChanged {
 		return nil
 	}
 


### PR DESCRIPTION
[![CLOUD-651](https://badgen.net/badge/JIRA/CLOUD-651/green)](https://jira.percona.com/browse/CLOUD-651) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/CLOUD-651

Fix statefulSet change detection logic