### PR TITLE
K8SPXC-895 - Fix certificate generation for vault server on 1.22

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -956,7 +956,11 @@ DNS.4 = ${SERVICE}.${NAMESPACE}.svc.cluster.local
 IP.1 = 127.0.0.1
 EOF
 
-	openssl req -new -key ${tmp_dir}/vault.key -subj "/CN=${SERVICE}.${NAMESPACE}.svc" -out ${tmp_dir}/server.csr -config ${tmp_dir}/csr.conf
+	if version_gt "1.22"; then
+		openssl req -new -key ${tmp_dir}/vault.key -subj "/CN=system:node:${SERVICE}.${NAMESPACE}.svc;/O=system:nodes" -out ${tmp_dir}/server.csr -config ${tmp_dir}/csr.conf
+	else
+		openssl req -new -key ${tmp_dir}/vault.key -subj "/CN=${SERVICE}.${NAMESPACE}.svc" -out ${tmp_dir}/server.csr -config ${tmp_dir}/csr.conf
+	fi
 
 	cat <<EOF >${tmp_dir}/csr.yaml
 apiVersion: certificates.k8s.io/${CSR_API_VER}


### PR DESCRIPTION
[![K8SPXC-895](https://badgen.net/badge/JIRA/K8SPXC-895/green)](https://jira.percona.com/browse/K8SPXC-895) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This fixes the issue with demand-backup-encrypted-with-tls test.
Fix is commented here: https://github.com/kubernetes/kubernetes/issues/99504
Issue looked like:
```
$ kubectl get csr vault-csr-14845 -oyaml
apiVersion: certificates.k8s.io/v1
kind: CertificateSigningRequest
metadata:
  creationTimestamp: "2021-11-10T10:44:30Z"
  name: vault-csr-14845
  resourceVersion: "1062060"
  uid: c756936c-170f-47fb-9308-a59cea77b97f
spec:
  groups:
  - system:masters
  - system:authenticated
  request: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0KTUlJRGl6Q0NBbk1DQVFBd09qRTRNRFlHQTFVRUF3d3ZkbUYxYkhRdGMyVnlkbWxqWlMweExUTXhOVFUwTG5aaApkV3gwTFhObGNuWnBZMlV0TVMwek1UVTFOQzV6ZG1Nd2dnRWlNQTBHQ1NxR1NJYjNEU
UVCQVFVQUE0SUJEd0F3CmdnRUtBb0lCQVFDc1c0ZVJWSGVXMjNOcldIZkhPdlMrUzQ1Q1R0SUwvS0MyV1UvejliYXo2U0l5ckF3a0JoRUIKYUliYThwb2djekxXbHNsMU1rbnh1bE1SemgwUC9UdUZ3UFVld2VKWWdwdjlhTUdEeXAxczhsQ0ttTU83b2hWYgpxb2FNMS8xSG81Mytqe
jk2dG9nVHJieGdFelhWZm9sRFpMSFRad1ZxbGJEZzMvTzZ3K0l1S1Y1UldWeGFyTTZFCjdGVThFeUEycXRFSHlGWGIzcEYyNmVUR2djTk1OL3dDYUE1RGZDS0krNVlKZXhIM3Q3R2xZT0ZlTWsxUCtuMHoKdWtuenVNaEVleWMrdGZrZ0ZOU0xTVjF4dU5vWUR1Ly8ycThCcmNMQ0JNZ
WFwKzNGZTJFSEozclVNeElDTEI2Sgoxa3B4M1pjTFZxeldVUllGSEtXaDRRdjhtYk9yb1llQkFnTUJBQUdnZ2dFS01JSUJCZ1lKS29aSWh2Y05BUWtPCk1ZSDRNSUgxTUFrR0ExVWRFd1FDTUFBd0N3WURWUjBQQkFRREFnWGdNQk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUYKQndNQk1JS
EZCZ05WSFJFRWdiMHdnYnFDRlhaaGRXeDBMWE5sY25acFkyVXRNUzB6TVRVMU5JSXJkbUYxYkhRdApjMlZ5ZG1salpTMHhMVE14TlRVMExuWmhkV3gwTFhObGNuWnBZMlV0TVMwek1UVTFOSUl2ZG1GMWJIUXRjMlZ5CmRtbGpaUzB4TFRNeE5UVTBMblpoZFd4MExYTmxjblpwWTJVd
E1TMHpNVFUxTkM1emRtT0NQWFpoZFd4MExYTmwKY25acFkyVXRNUzB6TVRVMU5DNTJZWFZzZEMxelpYSjJhV05sTFRFdE16RTFOVFF1YzNaakxtTnNkWE4wWlhJdQpiRzlqWVd5SEJIOEFBQUV3RFFZSktvWklodmNOQVFFTEJRQURnZ0VCQUVEeUUxNk1GbE1id2F4Z25ZeG1PU3RMC
lh1bE1QVlJJV0hxWElzOEk5cC9SWmhqNzZWRWNzUFVjcmVwWjl3bnNrV1ppYmNiSzF4MnQ5c1oxeDcrMHdDVWoKVFJhZUNzK0ppUGRrbDBnVUNBYUdvUTh2QXNJeGdjMkJCYjhWMlRnTlNPUUxyaEVrS3lRb3B1Qm10R2RYQ01EawpzZUJBVzZjMG9vK1VieDRyZ3YzaThVM2doZ01kN
FRJQWJoeFBoUkV4WU00cWhiejNPQ1ovTUV1VlpoYUxqN3BkCnhZUVJZcWRwdGxZK0Y3RFhZM0FhSXFnbVloTEZ5bXFxR2NkZ3UvZ0pHc3JPZkR2bG5kbk94aS9SVVNsVUp6V2IKOWxyWjFnYVJkbW1HRTNHS2g4Z01kT2daRHk4YTdLV3d4UzhpdXBOaTYvbWVaK25jRGF0aWZNTGhuR
TBrM3JBPQotLS0tLUVORCBDRVJUSUZJQ0FURSBSRVFVRVNULS0tLS0K
  signerName: kubernetes.io/kubelet-serving
  usages:
  - digital signature
  - key encipherment
  - server auth
  username: system:admin
status:
  conditions:
  - lastTransitionTime: "2021-11-10T10:44:41Z"
    lastUpdateTime: "2021-11-10T10:44:41Z"
    message: This CSR was approved by kubectl certificate approve.
    reason: KubectlApprove
    status: "True"
    type: Approved
  - lastTransitionTime: "2021-11-10T10:44:41Z"
    lastUpdateTime: "2021-11-10T10:44:41Z"
    message: subject organization is not system:nodes
    reason: SignerValidationFailure
    status: "True"
    type: Failed
```