### PR TITLE
K8SPXC-899: Add HAProxy domain names to ssl-internal certificate

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -372,8 +372,9 @@ compare_kubectl() {
 		| $sed 's#^apiVersion: policy/v1beta1#apiVersion: policy/v1#' \
 		| $sed 's/name: kube-api-access-.*$/name: kube-api-access/' \
 		| $sed 's/namespace\:.*name/name/' \
+		| $sed "s/${namespace}/namespace/g" \
 			>${new_result}
-	# last sed is needed for backup cronjob content
+	# last but one sed is needed for backup cronjob content
 
 	diff -u ${expected_result} ${new_result}
 }

--- a/e2e-tests/init-deploy/compare/certificate_no-proxysql-ssl-internal.yml
+++ b/e2e-tests/init-deploy/compare/certificate_no-proxysql-ssl-internal.yml
@@ -10,7 +10,14 @@ metadata:
 spec:
   commonName: no-proxysql-pxc
   dnsNames:
+    - no-proxysql-pxc
     - '*.no-proxysql-pxc'
+    - no-proxysql-haproxy-replicas.namespace.svc.cluster.local
+    - no-proxysql-haproxy-replicas.namespace
+    - no-proxysql-haproxy-replicas
+    - no-proxysql-haproxy.namespace.svc.cluster.local
+    - no-proxysql-haproxy.namespace
+    - no-proxysql-haproxy
   isCA: true
   issuerRef:
     kind: Issuer

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name-tls-issue-haproxy.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name-tls-issue-haproxy.yml
@@ -29,7 +29,7 @@ spec:
     affinity:
       antiAffinityTopologyKey: "kubernetes.io/hostname"
   proxysql:
-    enabled: true
+    enabled: false
     size: 1
     image: -proxysql
     resources:
@@ -47,7 +47,7 @@ spec:
           requests:
             storage: 2Gi
   haproxy:
-    enabled: false
+    enabled: true
     size: 1
     image: -haproxy
     resources:

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name-tls-issue.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name-tls-issue.yml
@@ -28,10 +28,10 @@ spec:
             storage: 2Gi
     affinity:
       antiAffinityTopologyKey: "kubernetes.io/hostname"
-  proxysql:
+  haproxy:
     enabled: true
     size: 1
-    image: -proxysql
+    image: -haproxy
     resources:
       requests:
         memory: 0.1G
@@ -39,11 +39,6 @@ spec:
       limits:
         memory: 1G
         cpu: 700m
-    volumeSpec:
-      persistentVolumeClaim:
-        resources:
-          requests:
-            storage: 2Gi
     affinity:
       antiAffinityTopologyKey: "kubernetes.io/hostname"
   pmm:

--- a/e2e-tests/tls-issue-cert-manager/run
+++ b/e2e-tests/tls-issue-cert-manager/run
@@ -6,6 +6,18 @@ set -o xtrace
 test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
+check_verify_identity() {
+  local host="$1"
+
+  local command="exit"
+  local args="--ssl-ca=/etc/mysql/ssl-internal/ca.crt --ssl-mode=VERIFY_IDENTITY --protocol=tcp -uroot -proot_password --host=$host"
+
+  [[ ${-/x/} != $- ]] && echo "+ kubectl exec -it $cluster-pxc-0 -- bash -c \"printf '$command\n' | mysql -sN $args\"" >&$BASH_XTRACEFD
+
+  kubectl_bin exec "$cluster-pxc-0" -- \
+    bash -c "printf '%s\n' \"${command}\" | mysql -sN $args"
+}
+
 main() {
   create_infra $namespace
   cluster="some-name-tls-issue"
@@ -27,6 +39,11 @@ main() {
 
   desc 'check if certificate issued'
   compare_kubectl certificate/$cluster-ssl
+
+  desc 'check ssl-internal certificate using PXC'
+  check_verify_identity "$cluster-pxc"
+  desc 'check ssl-internal certificate using HAProxy'
+  check_verify_identity "$cluster-haproxy"
 
   destroy $namespace
 }

--- a/e2e-tests/tls-issue-cert-manager/run
+++ b/e2e-tests/tls-issue-cert-manager/run
@@ -40,6 +40,9 @@ main() {
 	desc 'check if certificate issued'
 	compare_kubectl certificate/$cluster-ssl
 
+	apply_config "$test_dir/conf/$cluster-haproxy.yml"
+	wait_for_running "$cluster-haproxy" 1
+
 	desc 'check ssl-internal certificate using PXC'
 	check_verify_identity "$cluster-pxc"
 	desc 'check ssl-internal certificate using HAProxy'

--- a/e2e-tests/tls-issue-cert-manager/run
+++ b/e2e-tests/tls-issue-cert-manager/run
@@ -7,45 +7,45 @@ test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
 check_verify_identity() {
-  local host="$1"
+	local host="$1"
 
-  local command="exit"
-  local args="--ssl-ca=/etc/mysql/ssl-internal/ca.crt --ssl-mode=VERIFY_IDENTITY --protocol=tcp -uroot -proot_password --host=$host"
+	local command="exit"
+	local args="--ssl-ca=/etc/mysql/ssl-internal/ca.crt --ssl-mode=VERIFY_IDENTITY --protocol=tcp -uroot -proot_password --host=$host"
 
-  [[ ${-/x/} != $- ]] && echo "+ kubectl exec -it $cluster-pxc-0 -- bash -c \"printf '$command\n' | mysql -sN $args\"" >&$BASH_XTRACEFD
+	[[ ${-/x/} != $- ]] && echo "+ kubectl exec -it $cluster-pxc-0 -- bash -c \"printf '$command\n' | mysql -sN $args\"" >&$BASH_XTRACEFD
 
-  kubectl_bin exec "$cluster-pxc-0" -- \
-    bash -c "printf '%s\n' \"${command}\" | mysql -sN $args"
+	kubectl_bin exec "$cluster-pxc-0" -- \
+		bash -c "printf '%s\n' \"${command}\" | mysql -sN $args"
 }
 
 main() {
-  create_infra $namespace
-  cluster="some-name-tls-issue"
+	create_infra $namespace
+	cluster="some-name-tls-issue"
 
-  desc 'deploy cert manager'
-  deploy_cert_manager
+	desc 'deploy cert manager'
+	deploy_cert_manager
 
-  desc 'create pxc cluster'
-  spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml" 3 10 "$conf_dir/secrets_without_tls.yml" "$test_dir/conf/client.yml"
+	desc 'create pxc cluster'
+	spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml" 3 10 "$conf_dir/secrets_without_tls.yml" "$test_dir/conf/client.yml"
 
-  desc 'check if certificates issued with certmanager'
-  tlsSecretsShouldExist "$cluster-ssl"
+	desc 'check if certificates issued with certmanager'
+	tlsSecretsShouldExist "$cluster-ssl"
 
-  desc 'check if CA issuer created'
-  compare_kubectl issuer/$cluster-pxc-ca-issuer
+	desc 'check if CA issuer created'
+	compare_kubectl issuer/$cluster-pxc-ca-issuer
 
-  desc 'check if issuer created'
-  compare_kubectl issuer/$cluster-pxc-issuer
+	desc 'check if issuer created'
+	compare_kubectl issuer/$cluster-pxc-issuer
 
-  desc 'check if certificate issued'
-  compare_kubectl certificate/$cluster-ssl
+	desc 'check if certificate issued'
+	compare_kubectl certificate/$cluster-ssl
 
-  desc 'check ssl-internal certificate using PXC'
-  check_verify_identity "$cluster-pxc"
-  desc 'check ssl-internal certificate using HAProxy'
-  check_verify_identity "$cluster-haproxy"
+	desc 'check ssl-internal certificate using PXC'
+	check_verify_identity "$cluster-pxc"
+	desc 'check ssl-internal certificate using HAProxy'
+	check_verify_identity "$cluster-haproxy"
 
-  destroy $namespace
+	destroy $namespace
 }
 
 main

--- a/pkg/controller/pxc/tls.go
+++ b/pkg/controller/pxc/tls.go
@@ -149,7 +149,14 @@ func (r *ReconcilePerconaXtraDBCluster) createSSLByCertManager(cr *api.PerconaXt
 			SecretName: cr.Spec.PXC.SSLInternalSecretName,
 			CommonName: cr.Name + "-pxc",
 			DNSNames: []string{
+				cr.Name + "-pxc",
 				"*." + cr.Name + "-pxc",
+				cr.Name + "-haproxy-replicas." + cr.Namespace + ".svc.cluster.local",
+				cr.Name + "-haproxy-replicas." + cr.Namespace,
+				cr.Name + "-haproxy-replicas",
+				cr.Name + "-haproxy." + cr.Namespace + ".svc.cluster.local",
+				cr.Name + "-haproxy." + cr.Namespace,
+				cr.Name + "-haproxy",
 			},
 			IsCA: true,
 			IssuerRef: cmmeta.ObjectReference{


### PR DESCRIPTION
[![K8SPXC-899](https://badgen.net/badge/JIRA/K8SPXC-899/green)](https://jira.percona.com/browse/K8SPXC-899) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-899

Also add pxc domain name from CN to the ssl-internal certificate, because running with `--ssl-mode=VERIFY_IDENTITY` doesn't work without it