### PR TITLE
Rename helm delete to uninstall and put timeout to chaos-mesh delete

### DIFF
--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -65,7 +65,7 @@ function main() {
 
 	desc 'starting PMM up'
 	platform=kubernetes
-	helm del --purge monitoring || :
+	helm uninstall monitoring || :
 	if [ ! -z "$OPENSHIFT" ]; then
 		platform=openshift
 		oc create sa pmm-server
@@ -94,7 +94,7 @@ function main() {
 			"spec": {"pmm":{"enabled":false}}
 		}'
 	sleep 120
-	helm delete monitoring
+	helm uninstall monitoring
 	wait_cluster_consistency ${cluster} ${pxc_size} ${proxy_size}
 
 	desc 'write data directly, read from all'

--- a/e2e-tests/demand-backup-encrypted-with-tls/run
+++ b/e2e-tests/demand-backup-encrypted-with-tls/run
@@ -7,48 +7,48 @@ test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
 function jq_filter() {
-    local vault_root=$1
-    jq -r "[ .[] | .=\"'$vault_root/\"+.+\"'\" ] | join(\", \")"
+	local vault_root=$1
+	jq -r "[ .[] | .=\"'$vault_root/\"+.+\"'\" ] | join(\", \")"
 }
 
 main() {
-    create_infra $namespace
+	create_infra $namespace
 
-    vault1="vault-service-1-${RANDOM}"
-    protocol="https"
-    start_vault $vault1 $protocol
-    token1=$(jq -r ".root_token" <"$tmp_dir/$vault1")
-    ip1="$protocol://$vault1.$vault1.svc.cluster.local"
+	vault1="vault-service-1-${RANDOM}"
+	protocol="https"
+	start_vault $vault1 $protocol
+	token1=$(jq -r ".root_token" <"$tmp_dir/$vault1")
+	ip1="$protocol://$vault1.$vault1.svc.cluster.local"
 
-    cluster="some-name"
-    spinup_pxc "$cluster" "$conf_dir/$cluster.yml"
-    keyring_plugin_must_be_in_use "$cluster"
-    table_must_be_encrypted "$cluster" "myApp"
+	cluster="some-name"
+	spinup_pxc "$cluster" "$conf_dir/$cluster.yml"
+	keyring_plugin_must_be_in_use "$cluster"
+	table_must_be_encrypted "$cluster" "myApp"
 
-    run_backup         "$cluster" "on-demand-backup-pvc"
-    run_recovery_check "$cluster" "on-demand-backup-pvc"
-    check_pvc_md5
-    table_must_be_encrypted "$cluster" "myApp"
-    keyring_plugin_must_be_in_use "$cluster"
+	run_backup "$cluster" "on-demand-backup-pvc"
+	run_recovery_check "$cluster" "on-demand-backup-pvc"
+	check_pvc_md5
+	table_must_be_encrypted "$cluster" "myApp"
+	keyring_plugin_must_be_in_use "$cluster"
 
-    if [ -z "$SKIP_BACKUPS_TO_AWS_GCP" ]; then
-        run_backup         "$cluster" "on-demand-backup-aws-s3"
-        run_recovery_check "$cluster" "on-demand-backup-aws-s3"
-        table_must_be_encrypted "$cluster" "myApp"
-        keyring_plugin_must_be_in_use "$cluster"
-    fi
-    
-    mountpt=$(kubectl_bin get -f "$conf_dir/vault-secret.yaml" -o json | egrep -o "secret_mount_point = \w+" | awk -F "=[ ]*" '{print $2}')
-    transition_keys=$(kubectl_bin exec --namespace="$vault1" -it $vault1-0 -- sh -c "
+	if [ -z "$SKIP_BACKUPS_TO_AWS_GCP" ]; then
+		run_backup "$cluster" "on-demand-backup-aws-s3"
+		run_recovery_check "$cluster" "on-demand-backup-aws-s3"
+		table_must_be_encrypted "$cluster" "myApp"
+		keyring_plugin_must_be_in_use "$cluster"
+	fi
+
+	mountpt=$(kubectl_bin get -f "$conf_dir/vault-secret.yaml" -o json | egrep -o "secret_mount_point = \w+" | awk -F "=[ ]*" '{print $2}')
+	transition_keys=$(kubectl_bin exec --namespace="$vault1" -it $vault1-0 -- sh -c "
         VAULT_TOKEN=$token1 vault kv list -format=json $mountpt/backup/" \
-            | jq_filter "$mountpt/backup/")
+		| jq_filter "$mountpt/backup/")
 
-    vault2="vault-service-2-${RANDOM}"
-    start_vault $vault2 $protocol
-    token2=$(jq -r ".root_token" <"$tmp_dir/$vault2")
-    ip2="$protocol://$vault2.$vault2.svc.cluster.local"
+	vault2="vault-service-2-${RANDOM}"
+	start_vault $vault2 $protocol
+	token2=$(jq -r ".root_token" <"$tmp_dir/$vault2")
+	ip2="$protocol://$vault2.$vault2.svc.cluster.local"
 
-    kubectl_bin run -i --tty vault-cp --image=perconalab/vault-cp:latest --restart=Never -- sh -c "
+	kubectl_bin run -i --tty vault-cp --image=perconalab/vault-cp:latest --restart=Never -- sh -c "
         sed -i 's/token=cfg.old_token)/token=cfg.old_token, verify=False)/' /src/vault-cp.py \
         && sed -i 's/token=cfg.new_token)/token=cfg.new_token, verify=False)/' /src/vault-cp.py \
         && echo \"
@@ -61,22 +61,22 @@ secrets = [ $transition_keys ]
     python3 /src/vault-cp.py
     "
 
-    run_recovery_check "$cluster" "on-demand-backup-pvc"
-    table_must_be_encrypted "$cluster" "myApp"
-    keyring_plugin_must_be_in_use "$cluster"
+	run_recovery_check "$cluster" "on-demand-backup-pvc"
+	table_must_be_encrypted "$cluster" "myApp"
+	keyring_plugin_must_be_in_use "$cluster"
 
-    if [ -z "$SKIP_BACKUPS_TO_AWS_GCP" ]; then
-        run_recovery_check "$cluster" "on-demand-backup-aws-s3"
-        table_must_be_encrypted "$cluster" "myApp"
-        keyring_plugin_must_be_in_use "$cluster"
-    fi
+	if [ -z "$SKIP_BACKUPS_TO_AWS_GCP" ]; then
+		run_recovery_check "$cluster" "on-demand-backup-aws-s3"
+		table_must_be_encrypted "$cluster" "myApp"
+		keyring_plugin_must_be_in_use "$cluster"
+	fi
 
-    for i in $vault1 $vault2; do
-        helm uninstall $i || :
-        kubectl_bin delete --grace-period=0 --force=true namespace $i &
-    done
+	for i in $vault1 $vault2; do
+		helm uninstall $i || :
+		kubectl_bin delete --grace-period=0 --force=true namespace $i &
+	done
 
-    destroy $namespace
+	destroy $namespace
 }
 
 main

--- a/e2e-tests/demand-backup-encrypted-with-tls/run
+++ b/e2e-tests/demand-backup-encrypted-with-tls/run
@@ -72,7 +72,7 @@ secrets = [ $transition_keys ]
     fi
 
     for i in $vault1 $vault2; do
-        helm delete $i || :
+        helm uninstall $i || :
         kubectl_bin delete --grace-period=0 --force=true namespace $i &
     done
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -560,7 +560,6 @@ destroy() {
 	kubectl_bin delete pxc-restore --all --all-namespaces || :
 	kubectl_bin delete ValidatingWebhookConfiguration percona-xtradbcluster-webhook || :
 
-	destroy_chaos_mesh
 	kubectl_bin delete -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml 2>/dev/null || :
 	if [ ! -z "$OPENSHIFT" ]; then
 		oc delete --grace-period=0 --force=true project "$namespace" &
@@ -1021,7 +1020,7 @@ start_vault() {
 	fi
 	create_namespace "$name" "skip_clean"
 	deploy_helm "$name"
-	helm delete "$name" || :
+	helm uninstall "$name" || :
 
 	desc "install Vault $name"
 
@@ -1114,7 +1113,7 @@ start_minio() {
 	deploy_helm $namespace
 
 	desc 'install Minio'
-	helm del minio-service || :
+	helm uninstall minio-service || :
 	retry 10 60 helm install \
 		$HELM_ARGS \
 		minio-service \
@@ -1156,14 +1155,14 @@ destroy_chaos_mesh() {
 	local chaos_mesh_ns=$(helm list --all-namespaces --filter chaos-mesh | tail -n1 | awk -F' ' '{print $2}' | sed 's/NAMESPACE//')
 
 	desc 'destroy chaos-mesh'
-	kubectl delete podchaos --all --all-namespaces || :
-	kubectl delete networkchaos --all --all-namespaces || :
+	timeout 30 kubectl delete podchaos --all --all-namespaces || :
+	timeout 30 kubectl delete networkchaos --all --all-namespaces || :
 	if [ -n "${chaos_mesh_ns}" ]; then
 		helm uninstall chaos-mesh --namespace ${chaos_mesh_ns} || :
 	fi
-	kubectl delete crd awschaos.chaos-mesh.org dnschaos.chaos-mesh.org gcpchaos.chaos-mesh.org httpchaos.chaos-mesh.org iochaos.chaos-mesh.org jvmchaos.chaos-mesh.org kernelchaos.chaos-mesh.org networkchaos.chaos-mesh.org podchaos.chaos-mesh.org podhttpchaos.chaos-mesh.org podiochaos.chaos-mesh.org podnetworkchaos.chaos-mesh.org schedules.chaos-mesh.org stresschaos.chaos-mesh.org timechaos.chaos-mesh.org workflownodes.chaos-mesh.org workflows.chaos-mesh.org || :
-	kubectl delete clusterrolebinding chaos-mesh-chaos-controller-manager-cluster-level || :
-	kubectl delete clusterrole chaos-mesh-chaos-controller-manager-cluster-level chaos-mesh-chaos-controller-manager-target-namespace || :
+	timeout 30 kubectl delete crd awschaos.chaos-mesh.org dnschaos.chaos-mesh.org gcpchaos.chaos-mesh.org httpchaos.chaos-mesh.org iochaos.chaos-mesh.org jvmchaos.chaos-mesh.org kernelchaos.chaos-mesh.org networkchaos.chaos-mesh.org podchaos.chaos-mesh.org podhttpchaos.chaos-mesh.org podiochaos.chaos-mesh.org podnetworkchaos.chaos-mesh.org schedules.chaos-mesh.org stresschaos.chaos-mesh.org timechaos.chaos-mesh.org workflownodes.chaos-mesh.org workflows.chaos-mesh.org || :
+	timeout 30 kubectl delete clusterrolebinding chaos-mesh-chaos-controller-manager-cluster-level || :
+	timeout 30 kubectl delete clusterrole chaos-mesh-chaos-controller-manager-cluster-level chaos-mesh-chaos-controller-manager-target-namespace || :
 }
 
 patch_secret() {

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -10,22 +10,21 @@ cluster="monitoring"
 create_infra $namespace
 deploy_helm $namespace
 
-
 desc 'install PMM Server'
 platform=kubernetes
 helm uninstall monitoring || :
 if [ ! -z "$OPENSHIFT" ]; then
-    platform=openshift
-    oc create sa pmm-server
-    oc adm policy add-scc-to-user privileged -z pmm-server
-    if [ -n "$OPERATOR_NS" ]; then
-        oc create clusterrolebinding pmm-pxc-operator-cluster-wide --clusterrole=percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
-        oc patch clusterrole/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]' ${OPERATOR_NS:+-n $OPERATOR_NS}
-    else
-        oc create rolebinding pmm-pxc-operator-namespace-only --role percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
-        oc patch role/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]'
-    fi
-    retry 10 60 helm install monitoring --set platform=$platform --set sa=pmm-server --set supresshttp2=false https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
+	platform=openshift
+	oc create sa pmm-server
+	oc adm policy add-scc-to-user privileged -z pmm-server
+	if [ -n "$OPERATOR_NS" ]; then
+		oc create clusterrolebinding pmm-pxc-operator-cluster-wide --clusterrole=percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
+		oc patch clusterrole/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]' ${OPERATOR_NS:+-n $OPERATOR_NS}
+	else
+		oc create rolebinding pmm-pxc-operator-namespace-only --role percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
+		oc patch role/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]'
+	fi
+	retry 10 60 helm install monitoring --set platform=$platform --set sa=pmm-server --set supresshttp2=false https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
 else
 	helm install monitoring --set platform=$platform https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
 fi
@@ -50,13 +49,13 @@ sleep 90
 
 desc 'check QAN data'
 get_qan20_values $cluster-pxc-0 admin:admin
-if [[ -n "${OPENSHIFT}" ]]; then
-    oc adm policy remove-scc-from-user privileged -z pmm-server
-    if [ -n "$OPERATOR_NS" ]; then
-        oc delete clusterrolebinding pmm-pxc-operator-cluster-wide
-    else
-        oc delete rolebinding pmm-pxc-operator-namespace-only
-    fi
+if [[ -n ${OPENSHIFT} ]]; then
+	oc adm policy remove-scc-from-user privileged -z pmm-server
+	if [ -n "$OPERATOR_NS" ]; then
+		oc delete clusterrolebinding pmm-pxc-operator-cluster-wide
+	else
+		oc delete rolebinding pmm-pxc-operator-namespace-only
+	fi
 fi
 helm uninstall monitoring
 destroy $namespace

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -13,7 +13,7 @@ deploy_helm $namespace
 
 desc 'install PMM Server'
 platform=kubernetes
-helm del --purge monitoring || :
+helm uninstall monitoring || :
 if [ ! -z "$OPENSHIFT" ]; then
     platform=openshift
     oc create sa pmm-server
@@ -58,5 +58,5 @@ if [[ -n "${OPENSHIFT}" ]]; then
         oc delete rolebinding pmm-pxc-operator-namespace-only
     fi
 fi
-helm delete monitoring
+helm uninstall monitoring
 destroy $namespace

--- a/e2e-tests/restore-to-encrypted-cluster/run
+++ b/e2e-tests/restore-to-encrypted-cluster/run
@@ -32,7 +32,7 @@ main() {
         table_must_not_be_encrypted "$cluster" "myApp"
     fi
 
-    helm delete $vault1 || :
+    helm uninstall $vault1 || :
     kubectl_bin delete --grace-period=0 --force=true namespace $vault1 &
     destroy $namespace
 }

--- a/e2e-tests/self-healing-chaos/compare/proxy-vars-80.sql
+++ b/e2e-tests/self-healing-chaos/compare/proxy-vars-80.sql
@@ -161,7 +161,7 @@ mysql-query_processor_iterations	0
 mysql-query_retries_on_failure	1
 mysql-reset_connection_algorithm	2
 mysql-server_capabilities	571947
-mysql-server_version	8.0.23
+mysql-server_version	8.0.25
 mysql-servers_stats	true
 mysql-session_idle_ms	1
 mysql-session_idle_show_processlist	true

--- a/e2e-tests/self-healing/compare/proxy-vars-80.sql
+++ b/e2e-tests/self-healing/compare/proxy-vars-80.sql
@@ -143,7 +143,7 @@ mysql-query_processor_iterations	0
 mysql-query_retries_on_failure	1
 mysql-reset_connection_algorithm	2
 mysql-server_capabilities	571947
-mysql-server_version	8.0.23
+mysql-server_version	8.0.25
 mysql-servers_stats	true
 mysql-session_idle_ms	1000
 mysql-session_idle_show_processlist	true


### PR DESCRIPTION
`--purge` option doesn't exist any more for helm del and delete was renamed to uninstall so better to use it (https://helm.sh/docs/helm/helm_delete/).
Put a timeout to chaos-mesh delete and do not try to remove it on every namespace removal (there's a bug with stall when networkchaos crd is tried to delete).