### PR TITLE
K8SPXC-750: ProxySQL can't connect to PXC if allowUnsafeConfigurations is true

### DIFF
--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -239,6 +239,16 @@ func (c *Proxy) SidecarContainers(spec *api.PodSpec, secrets string, cr *api.Per
 			},
 		},
 	}
+	if cr.Spec.AllowUnsafeConfig && (cr.Spec.TLS == nil || cr.Spec.TLS.IssuerConf == nil) {
+		pxcMonit.Env = append(pxcMonit.Env, corev1.EnvVar{
+			Name:  "SSL_DIR",
+			Value: "/dev/null",
+		})
+		proxysqlMonit.Env = append(proxysqlMonit.Env, corev1.EnvVar{
+			Name:  "SSL_DIR",
+			Value: "/dev/null",
+		})
+	}
 	if cr.CompareVersionWith("1.9.0") >= 0 {
 		fvar := true
 		envFrom := corev1.EnvFromSource{


### PR DESCRIPTION
https://jira.percona.com/browse/K8SPXC-750

Provide `SSL_DIR` with `/dev/null` value to proxysql sidecars if `allowUnsafeConfigurations` is true. Sidecar containers will try to find certificates by this path and fail, which will lead to setting `use_ssl` to 0