### PR TITLE
K8SPXC-917 - Update self-healing tests for new PXC version

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -348,6 +348,7 @@ compare_kubectl() {
 		| yq d - '**."kubernetes.io/pvc-protection"' \
 		| yq d - '**.volumeName' \
 		| yq d - '**."volume.beta.kubernetes.io/storage-provisioner"' \
+		| yq d - '**."volume.kubernetes.io/storage-provisioner"' \
 		| yq d - 'spec.volumeMode' \
 		| yq d - 'spec.nodeName' \
 		| yq d - '**."volume.kubernetes.io/selected-node"' \

--- a/e2e-tests/self-healing-chaos/compare/proxy-vars-80.sql
+++ b/e2e-tests/self-healing-chaos/compare/proxy-vars-80.sql
@@ -161,7 +161,7 @@ mysql-query_processor_iterations	0
 mysql-query_retries_on_failure	1
 mysql-reset_connection_algorithm	2
 mysql-server_capabilities	571947
-mysql-server_version	8.0.25
+mysql-server_version	8.0.26
 mysql-servers_stats	true
 mysql-session_idle_ms	1
 mysql-session_idle_show_processlist	true

--- a/e2e-tests/self-healing/compare/proxy-vars-80.sql
+++ b/e2e-tests/self-healing/compare/proxy-vars-80.sql
@@ -143,7 +143,7 @@ mysql-query_processor_iterations	0
 mysql-query_retries_on_failure	1
 mysql-reset_connection_algorithm	2
 mysql-server_capabilities	571947
-mysql-server_version	8.0.25
+mysql-server_version	8.0.26
 mysql-servers_stats	true
 mysql-session_idle_ms	1000
 mysql-session_idle_show_processlist	true


### PR DESCRIPTION
[![K8SPXC-917](https://badgen.net/badge/JIRA/K8SPXC-917/green)](https://jira.percona.com/browse/K8SPXC-917) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Diff in scaling test on minikube:
```
+ diff -u /mnt/jenkins/workspace/pxc-operator-minikube/source/e2e-tests/scaling/compare/pvc_datadir-scaling-pxc-3.yml /tmp/tmp.XwV2SDSmFM/pvc_datadir-scaling-pxc-3.yml
--- /mnt/jenkins/workspace/pxc-operator-minikube/source/e2e-tests/scaling/compare/pvc_datadir-scaling-pxc-3.yml	2022-01-24 08:17:50.000000000 +0000
+++ /tmp/tmp.XwV2SDSmFM/pvc_datadir-scaling-pxc-3.yml	2022-01-24 08:48:39.478565785 +0000
@@ -4,6 +4,7 @@
   annotations:
     pv.kubernetes.io/bind-completed: "yes"
     pv.kubernetes.io/bound-by-controller: "yes"
+    volume.kubernetes.io/storage-provisioner: k8s.io/minikube-hostpath
   labels:
     app.kubernetes.io/component: pxc
     app.kubernetes.io/instance: scaling
```