### PR TITLE
K8SPXC-985: Remove binlog filter

### DIFF
--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -420,10 +420,6 @@ func (r *Recoverer) setBinlogs() error {
 		}
 		binlogGTIDSet := string(content)
 		log.Println("checking current file", " name ", binlog, " gtid ", binlogGTIDSet)
-		if sourceID != strings.Split(binlogGTIDSet, ":")[0] {
-			log.Println("Source id is not equal to binlog source id")
-			continue
-		}
 
 		if len(r.gtid) > 0 && r.recoverType == Transaction {
 			subResult, err := r.db.SubtractGTIDSet(binlogGTIDSet, r.gtid)


### PR DESCRIPTION
[![K8SPXC-985](https://badgen.net/badge/JIRA/K8SPXC-985/green)](https://jira.percona.com/browse/K8SPXC-985) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We were trying to filter binlogs while applying to make storing binlogs
from multiple clusters in the same bucket possible. The filter is
implemented with the assumption that we can't have a different GTID from
the source cluster that we created the full backup from. This was wrong.
There are multiple ways that can lead GTID to change and making the
cluster that collects binlogs a replica of another is one of them.

We'll recommend users to use a separate storage/bucket/directory to
store the binlogs and remove the filter from PITR recoverer. All the
binlogs will be applied one by one.