### PR TITLE
K8SPXC-926: increase `MaxConcurrentReconciles`

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -84,7 +84,7 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("perconaxtradbcluster-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("perconaxtradbcluster-controller", mgr, controller.Options{MaxConcurrentReconciles: 20, Reconciler: r})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://jira.percona.com/browse/K8SPXC-926

If we use an operator for two or more clusters, and one of them is stuck, we can't update the other clusters. That's why we need concurrent reconciles