### PR TITLE
K8SPXC-960 Clarify that both backup and binlogs should use s3 storage…

### DIFF
--- a/source/backups.rst
+++ b/source/backups.rst
@@ -175,8 +175,11 @@ under the ``backup`` section of the `deploy/cr.yaml <https://github.com/percona/
 
 * ``enabled`` key should be set to ``true``,
 * ``storageName`` key should point to the name of the storage already configured
-  in the ``storages`` subsection (currently, only s3-compatible storages are
-  supported),
+  in the ``storages`` subsection
+  
+  .. note:: Both binlog and full backup should use s3-compatible storage to make
+     point-in-time recovery work!
+     
 * ``timeBetweenUploads`` key specifies the number of seconds between running the
   binlog uploader.
 


### PR DESCRIPTION
[![K8SPXC-960](https://badgen.net/badge/JIRA/K8SPXC-960/green)](https://jira.percona.com/browse/K8SPXC-960) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… type to make PITR work