### PR TITLE
K8SPXC-1036 improve liveness/readiness checks

### DIFF
--- a/build/liveness-check.sh
+++ b/build/liveness-check.sh
@@ -33,7 +33,7 @@ else
 	MYSQL_CMDLINE="/usr/bin/timeout $TIMEOUT mysql -nNE --connect-timeout=$TIMEOUT ${EXTRA_ARGS}"
 fi
 
-STATUS=$(MYSQL_PWD="${MYSQL_PASSWORD}" $MYSQL_CMDLINE -e 'SHOW GLOBAL STATUS LIKE "wsrep_cluster_status";' | sed -n -e '3p')
+STATUS=$(MYSQL_PWD="${MYSQL_PASSWORD}" $MYSQL_CMDLINE --init-command="SET SESSION wsrep_sync_wait=0;" -e 'SHOW GLOBAL STATUS LIKE "wsrep_cluster_status";' | sed -n -e '3p')
 set -x
 
 if [[ -n ${STATUS} && ${STATUS} == 'Primary' ]]; then

--- a/build/readiness-check.sh
+++ b/build/readiness-check.sh
@@ -31,7 +31,7 @@ else
     MYSQL_CMDLINE="/usr/bin/timeout $TIMEOUT mysql -nNE --connect-timeout=$TIMEOUT ${EXTRA_ARGS}"
 fi
 
-WSREP_STATUS=($(MYSQL_PWD="${MYSQL_PASSWORD}" $MYSQL_CMDLINE -e "SHOW GLOBAL STATUS LIKE 'wsrep_%';"  \
+WSREP_STATUS=($(MYSQL_PWD="${MYSQL_PASSWORD}" $MYSQL_CMDLINE --init-command="SET SESSION wsrep_sync_wait=0;" -e "SHOW GLOBAL STATUS LIKE 'wsrep_%';"  \
     | grep -A 1 -E 'wsrep_local_state$|wsrep_cluster_status$' \
     | sed -n -e '2p'  -e '5p' | tr '\n' ' '))
 set -x


### PR DESCRIPTION
    * set 'wsrep_sync_wait = 0' for liveness/readiness checks
      not to block checks in case of DDL during the backup