### PR TITLE
K8SPXC-1056 - Comment delete-s3-backup finalizer in the example backup.yaml

### DIFF
--- a/deploy/backup/backup.yaml
+++ b/deploy/backup/backup.yaml
@@ -1,8 +1,8 @@
 apiVersion: pxc.percona.com/v1
 kind: PerconaXtraDBClusterBackup
 metadata:
-  finalizers:
-    - delete-s3-backup
+#  finalizers:
+#    - delete-s3-backup
   name: backup1
 spec:
   pxcCluster: cluster1


### PR DESCRIPTION
[![K8SPXC-1056](https://badgen.net/badge/JIRA/K8SPXC-1056/green)](https://jira.percona.com/browse/K8SPXC-1056) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

In the example we have `fs-pvc` as storage for backup, but enable `delete-s3-backup` finalizer.