### PR TITLE
CLOUD-666 - Replace yq v3 with yq v4 for e2e tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,7 @@ pipeline {
                     curl -s -L https://github.com/mitchellh/golicense/releases/latest/download/golicense_0.2.0_linux_x86_64.tar.gz \
                         | sudo tar -C /usr/local/bin --wildcards -zxvpf -
 
-                    sudo sh -c "curl -s -L https://github.com/mikefarah/yq/releases/download/3.3.2/yq_linux_amd64 > /usr/local/bin/yq"
+                    sudo sh -c "curl -s -L https://github.com/mikefarah/yq/releases/download/4.27.2/yq_linux_amd64 > /usr/local/bin/yq"
                     sudo chmod +x /usr/local/bin/yq
                 '''
                 withCredentials([file(credentialsId: 'cloud-secret-file', variable: 'CLOUD_SECRET_FILE')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,7 @@ pipeline {
                     curl -s -L https://github.com/mitchellh/golicense/releases/latest/download/golicense_0.2.0_linux_x86_64.tar.gz \
                         | sudo tar -C /usr/local/bin --wildcards -zxvpf -
 
-                    sudo sh -c "curl -s -L https://github.com/mikefarah/yq/releases/download/4.27.2/yq_linux_amd64 > /usr/local/bin/yq"
+                    sudo sh -c "curl -s -L https://github.com/mikefarah/yq/releases/download/v4.27.2/yq_linux_amd64 > /usr/local/bin/yq"
                     sudo chmod +x /usr/local/bin/yq
                 '''
                 withCredentials([file(credentialsId: 'cloud-secret-file', variable: 'CLOUD_SECRET_FILE')]) {

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -16647,87 +16647,87 @@ spec:
     listKind: PerconaXtraDBClusterBackupList
     plural: perconaxtradbclusterbackups
     shortNames:
-    - pxc-backup
-    - pxc-backups
+      - pxc-backup
+      - pxc-backups
     singular: perconaxtradbclusterbackup
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Cluster name
-      jsonPath: .spec.pxcCluster
-      name: Cluster
-      type: string
-    - description: Storage name from pxc spec
-      jsonPath: .status.storageName
-      name: Storage
-      type: string
-    - description: Backup destination
-      jsonPath: .status.destination
-      name: Destination
-      type: string
-    - description: Job status
-      jsonPath: .status.state
-      name: Status
-      type: string
-    - description: Completed time
-      jsonPath: .status.completed
-      name: Completed
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          priorityClassName:
-            type: string
-          schedulerName:
-            type: string
-          spec:
-            properties:
-              pxcCluster:
-                type: string
-              storageName:
-                type: string
-            type: object
-          status:
-            properties:
-              completed:
-                format: date-time
-                type: string
-              destination:
-                type: string
-              lastscheduled:
-                format: date-time
-                type: string
-              s3:
-                properties:
-                  bucket:
-                    type: string
-                  credentialsSecret:
-                    type: string
-                  endpointUrl:
-                    type: string
-                  region:
-                    type: string
-                type: object
-              state:
-                type: string
-              storageName:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Cluster name
+          jsonPath: .spec.pxcCluster
+          name: Cluster
+          type: string
+        - description: Storage name from pxc spec
+          jsonPath: .status.storageName
+          name: Storage
+          type: string
+        - description: Backup destination
+          jsonPath: .status.destination
+          name: Destination
+          type: string
+        - description: Job status
+          jsonPath: .status.state
+          name: Status
+          type: string
+        - description: Completed time
+          jsonPath: .status.completed
+          name: Completed
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            priorityClassName:
+              type: string
+            schedulerName:
+              type: string
+            spec:
+              properties:
+                pxcCluster:
+                  type: string
+                storageName:
+                  type: string
+              type: object
+            status:
+              properties:
+                completed:
+                  format: date-time
+                  type: string
+                destination:
+                  type: string
+                lastscheduled:
+                  format: date-time
+                  type: string
+                s3:
+                  properties:
+                    bucket:
+                      type: string
+                    credentialsSecret:
+                      type: string
+                    endpointUrl:
+                      type: string
+                    region:
+                      type: string
+                  type: object
+                state:
+                  type: string
+                storageName:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -16749,123 +16749,123 @@ spec:
     listKind: PerconaXtraDBClusterRestoreList
     plural: perconaxtradbclusterrestores
     shortNames:
-    - pxc-restore
-    - pxc-restores
+      - pxc-restore
+      - pxc-restores
     singular: perconaxtradbclusterrestore
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Cluster name
-      jsonPath: .spec.pxcCluster
-      name: Cluster
-      type: string
-    - description: Job status
-      jsonPath: .status.state
-      name: Status
-      type: string
-    - description: Completed time
-      jsonPath: .status.completed
-      name: Completed
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              backupName:
-                type: string
-              backupSource:
-                properties:
-                  completed:
-                    format: date-time
-                    type: string
-                  destination:
-                    type: string
-                  lastscheduled:
-                    format: date-time
-                    type: string
-                  s3:
-                    properties:
-                      bucket:
-                        type: string
-                      credentialsSecret:
-                        type: string
-                      endpointUrl:
-                        type: string
-                      region:
-                        type: string
-                    type: object
-                  state:
-                    type: string
-                  storageName:
-                    type: string
-                type: object
-              pitr:
-                properties:
-                  backupSource:
-                    properties:
-                      completed:
-                        format: date-time
-                        type: string
-                      destination:
-                        type: string
-                      lastscheduled:
-                        format: date-time
-                        type: string
-                      s3:
-                        properties:
-                          bucket:
-                            type: string
-                          credentialsSecret:
-                            type: string
-                          endpointUrl:
-                            type: string
-                          region:
-                            type: string
-                        type: object
-                      state:
-                        type: string
-                      storageName:
-                        type: string
-                    type: object
-                  date:
-                    type: string
-                  gtid:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              pxcCluster:
-                type: string
-            type: object
-          status:
-            properties:
-              comments:
-                type: string
-              completed:
-                format: date-time
-                type: string
-              lastscheduled:
-                format: date-time
-                type: string
-              state:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Cluster name
+          jsonPath: .spec.pxcCluster
+          name: Cluster
+          type: string
+        - description: Job status
+          jsonPath: .status.state
+          name: Status
+          type: string
+        - description: Completed time
+          jsonPath: .status.completed
+          name: Completed
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                backupName:
+                  type: string
+                backupSource:
+                  properties:
+                    completed:
+                      format: date-time
+                      type: string
+                    destination:
+                      type: string
+                    lastscheduled:
+                      format: date-time
+                      type: string
+                    s3:
+                      properties:
+                        bucket:
+                          type: string
+                        credentialsSecret:
+                          type: string
+                        endpointUrl:
+                          type: string
+                        region:
+                          type: string
+                      type: object
+                    state:
+                      type: string
+                    storageName:
+                      type: string
+                  type: object
+                pitr:
+                  properties:
+                    backupSource:
+                      properties:
+                        completed:
+                          format: date-time
+                          type: string
+                        destination:
+                          type: string
+                        lastscheduled:
+                          format: date-time
+                          type: string
+                        s3:
+                          properties:
+                            bucket:
+                              type: string
+                            credentialsSecret:
+                              type: string
+                            endpointUrl:
+                              type: string
+                            region:
+                              type: string
+                          type: object
+                        state:
+                          type: string
+                        storageName:
+                          type: string
+                      type: object
+                    date:
+                      type: string
+                    gtid:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                pxcCluster:
+                  type: string
+              type: object
+            status:
+              properties:
+                comments:
+                  type: string
+                completed:
+                  format: date-time
+                  type: string
+                lastscheduled:
+                  format: date-time
+                  type: string
+                state:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -16878,114 +16878,114 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: percona-xtradb-cluster-operator
 rules:
-- apiGroups:
-  - pxc.percona.com
-  resources:
-  - perconaxtradbclusters
-  - perconaxtradbclusters/status
-  - perconaxtradbclusterbackups
-  - perconaxtradbclusterbackups/status
-  - perconaxtradbclusterrestores
-  - perconaxtradbclusterrestores/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - pods/exec
-  - pods/log
-  - configmaps
-  - services
-  - persistentvolumeclaims
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - certmanager.k8s.io
-  - cert-manager.io
-  resources:
-  - issuers
-  - certificates
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
+  - apiGroups:
+      - pxc.percona.com
+    resources:
+      - perconaxtradbclusters
+      - perconaxtradbclusters/status
+      - perconaxtradbclusterbackups
+      - perconaxtradbclusterbackups/status
+      - perconaxtradbclusterrestores
+      - perconaxtradbclusterrestores/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/exec
+      - pods/log
+      - configmaps
+      - services
+      - persistentvolumeclaims
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - certmanager.k8s.io
+      - cert-manager.io
+    resources:
+      - issuers
+      - certificates
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -16997,8 +16997,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-account-percona-xtradb-cluster-operator
 subjects:
-- kind: ServiceAccount
-  name: percona-xtradb-cluster-operator
+  - kind: ServiceAccount
+    name: percona-xtradb-cluster-operator
 roleRef:
   kind: Role
   name: percona-xtradb-cluster-operator
@@ -17030,39 +17030,39 @@ spec:
     spec:
       terminationGracePeriodSeconds: 600
       containers:
-      - command:
-        - percona-xtradb-cluster-operator
-        env:
-        - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: OPERATOR_NAME
-          value: percona-xtradb-cluster-operator
-        image: perconalab/percona-xtradb-cluster-operator:main
-        imagePullPolicy: Always
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /metrics
-            port: metrics
-            scheme: HTTP
-        resources:
-          limits:
-            cpu: 200m
-            memory: 500Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
-        name: percona-xtradb-cluster-operator
-        ports:
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
+        - command:
+            - percona-xtradb-cluster-operator
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: percona-xtradb-cluster-operator
+          image: perconalab/percona-xtradb-cluster-operator:main
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /metrics
+              port: metrics
+              scheme: HTTP
+          resources:
+            limits:
+              cpu: 200m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
+          name: percona-xtradb-cluster-operator
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
       serviceAccountName: percona-xtradb-cluster-operator

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -16647,87 +16647,87 @@ spec:
     listKind: PerconaXtraDBClusterBackupList
     plural: perconaxtradbclusterbackups
     shortNames:
-    - pxc-backup
-    - pxc-backups
+      - pxc-backup
+      - pxc-backups
     singular: perconaxtradbclusterbackup
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Cluster name
-      jsonPath: .spec.pxcCluster
-      name: Cluster
-      type: string
-    - description: Storage name from pxc spec
-      jsonPath: .status.storageName
-      name: Storage
-      type: string
-    - description: Backup destination
-      jsonPath: .status.destination
-      name: Destination
-      type: string
-    - description: Job status
-      jsonPath: .status.state
-      name: Status
-      type: string
-    - description: Completed time
-      jsonPath: .status.completed
-      name: Completed
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          priorityClassName:
-            type: string
-          schedulerName:
-            type: string
-          spec:
-            properties:
-              pxcCluster:
-                type: string
-              storageName:
-                type: string
-            type: object
-          status:
-            properties:
-              completed:
-                format: date-time
-                type: string
-              destination:
-                type: string
-              lastscheduled:
-                format: date-time
-                type: string
-              s3:
-                properties:
-                  bucket:
-                    type: string
-                  credentialsSecret:
-                    type: string
-                  endpointUrl:
-                    type: string
-                  region:
-                    type: string
-                type: object
-              state:
-                type: string
-              storageName:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Cluster name
+          jsonPath: .spec.pxcCluster
+          name: Cluster
+          type: string
+        - description: Storage name from pxc spec
+          jsonPath: .status.storageName
+          name: Storage
+          type: string
+        - description: Backup destination
+          jsonPath: .status.destination
+          name: Destination
+          type: string
+        - description: Job status
+          jsonPath: .status.state
+          name: Status
+          type: string
+        - description: Completed time
+          jsonPath: .status.completed
+          name: Completed
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            priorityClassName:
+              type: string
+            schedulerName:
+              type: string
+            spec:
+              properties:
+                pxcCluster:
+                  type: string
+                storageName:
+                  type: string
+              type: object
+            status:
+              properties:
+                completed:
+                  format: date-time
+                  type: string
+                destination:
+                  type: string
+                lastscheduled:
+                  format: date-time
+                  type: string
+                s3:
+                  properties:
+                    bucket:
+                      type: string
+                    credentialsSecret:
+                      type: string
+                    endpointUrl:
+                      type: string
+                    region:
+                      type: string
+                  type: object
+                state:
+                  type: string
+                storageName:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -16749,123 +16749,123 @@ spec:
     listKind: PerconaXtraDBClusterRestoreList
     plural: perconaxtradbclusterrestores
     shortNames:
-    - pxc-restore
-    - pxc-restores
+      - pxc-restore
+      - pxc-restores
     singular: perconaxtradbclusterrestore
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Cluster name
-      jsonPath: .spec.pxcCluster
-      name: Cluster
-      type: string
-    - description: Job status
-      jsonPath: .status.state
-      name: Status
-      type: string
-    - description: Completed time
-      jsonPath: .status.completed
-      name: Completed
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              backupName:
-                type: string
-              backupSource:
-                properties:
-                  completed:
-                    format: date-time
-                    type: string
-                  destination:
-                    type: string
-                  lastscheduled:
-                    format: date-time
-                    type: string
-                  s3:
-                    properties:
-                      bucket:
-                        type: string
-                      credentialsSecret:
-                        type: string
-                      endpointUrl:
-                        type: string
-                      region:
-                        type: string
-                    type: object
-                  state:
-                    type: string
-                  storageName:
-                    type: string
-                type: object
-              pitr:
-                properties:
-                  backupSource:
-                    properties:
-                      completed:
-                        format: date-time
-                        type: string
-                      destination:
-                        type: string
-                      lastscheduled:
-                        format: date-time
-                        type: string
-                      s3:
-                        properties:
-                          bucket:
-                            type: string
-                          credentialsSecret:
-                            type: string
-                          endpointUrl:
-                            type: string
-                          region:
-                            type: string
-                        type: object
-                      state:
-                        type: string
-                      storageName:
-                        type: string
-                    type: object
-                  date:
-                    type: string
-                  gtid:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              pxcCluster:
-                type: string
-            type: object
-          status:
-            properties:
-              comments:
-                type: string
-              completed:
-                format: date-time
-                type: string
-              lastscheduled:
-                format: date-time
-                type: string
-              state:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Cluster name
+          jsonPath: .spec.pxcCluster
+          name: Cluster
+          type: string
+        - description: Job status
+          jsonPath: .status.state
+          name: Status
+          type: string
+        - description: Completed time
+          jsonPath: .status.completed
+          name: Completed
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                backupName:
+                  type: string
+                backupSource:
+                  properties:
+                    completed:
+                      format: date-time
+                      type: string
+                    destination:
+                      type: string
+                    lastscheduled:
+                      format: date-time
+                      type: string
+                    s3:
+                      properties:
+                        bucket:
+                          type: string
+                        credentialsSecret:
+                          type: string
+                        endpointUrl:
+                          type: string
+                        region:
+                          type: string
+                      type: object
+                    state:
+                      type: string
+                    storageName:
+                      type: string
+                  type: object
+                pitr:
+                  properties:
+                    backupSource:
+                      properties:
+                        completed:
+                          format: date-time
+                          type: string
+                        destination:
+                          type: string
+                        lastscheduled:
+                          format: date-time
+                          type: string
+                        s3:
+                          properties:
+                            bucket:
+                              type: string
+                            credentialsSecret:
+                              type: string
+                            endpointUrl:
+                              type: string
+                            region:
+                              type: string
+                          type: object
+                        state:
+                          type: string
+                        storageName:
+                          type: string
+                      type: object
+                    date:
+                      type: string
+                    gtid:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                pxcCluster:
+                  type: string
+              type: object
+            status:
+              properties:
+                comments:
+                  type: string
+                completed:
+                  format: date-time
+                  type: string
+                lastscheduled:
+                  format: date-time
+                  type: string
+                state:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -16647,87 +16647,87 @@ spec:
     listKind: PerconaXtraDBClusterBackupList
     plural: perconaxtradbclusterbackups
     shortNames:
-    - pxc-backup
-    - pxc-backups
+      - pxc-backup
+      - pxc-backups
     singular: perconaxtradbclusterbackup
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Cluster name
-      jsonPath: .spec.pxcCluster
-      name: Cluster
-      type: string
-    - description: Storage name from pxc spec
-      jsonPath: .status.storageName
-      name: Storage
-      type: string
-    - description: Backup destination
-      jsonPath: .status.destination
-      name: Destination
-      type: string
-    - description: Job status
-      jsonPath: .status.state
-      name: Status
-      type: string
-    - description: Completed time
-      jsonPath: .status.completed
-      name: Completed
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          priorityClassName:
-            type: string
-          schedulerName:
-            type: string
-          spec:
-            properties:
-              pxcCluster:
-                type: string
-              storageName:
-                type: string
-            type: object
-          status:
-            properties:
-              completed:
-                format: date-time
-                type: string
-              destination:
-                type: string
-              lastscheduled:
-                format: date-time
-                type: string
-              s3:
-                properties:
-                  bucket:
-                    type: string
-                  credentialsSecret:
-                    type: string
-                  endpointUrl:
-                    type: string
-                  region:
-                    type: string
-                type: object
-              state:
-                type: string
-              storageName:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Cluster name
+          jsonPath: .spec.pxcCluster
+          name: Cluster
+          type: string
+        - description: Storage name from pxc spec
+          jsonPath: .status.storageName
+          name: Storage
+          type: string
+        - description: Backup destination
+          jsonPath: .status.destination
+          name: Destination
+          type: string
+        - description: Job status
+          jsonPath: .status.state
+          name: Status
+          type: string
+        - description: Completed time
+          jsonPath: .status.completed
+          name: Completed
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            priorityClassName:
+              type: string
+            schedulerName:
+              type: string
+            spec:
+              properties:
+                pxcCluster:
+                  type: string
+                storageName:
+                  type: string
+              type: object
+            status:
+              properties:
+                completed:
+                  format: date-time
+                  type: string
+                destination:
+                  type: string
+                lastscheduled:
+                  format: date-time
+                  type: string
+                s3:
+                  properties:
+                    bucket:
+                      type: string
+                    credentialsSecret:
+                      type: string
+                    endpointUrl:
+                      type: string
+                    region:
+                      type: string
+                  type: object
+                state:
+                  type: string
+                storageName:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -16749,123 +16749,123 @@ spec:
     listKind: PerconaXtraDBClusterRestoreList
     plural: perconaxtradbclusterrestores
     shortNames:
-    - pxc-restore
-    - pxc-restores
+      - pxc-restore
+      - pxc-restores
     singular: perconaxtradbclusterrestore
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Cluster name
-      jsonPath: .spec.pxcCluster
-      name: Cluster
-      type: string
-    - description: Job status
-      jsonPath: .status.state
-      name: Status
-      type: string
-    - description: Completed time
-      jsonPath: .status.completed
-      name: Completed
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              backupName:
-                type: string
-              backupSource:
-                properties:
-                  completed:
-                    format: date-time
-                    type: string
-                  destination:
-                    type: string
-                  lastscheduled:
-                    format: date-time
-                    type: string
-                  s3:
-                    properties:
-                      bucket:
-                        type: string
-                      credentialsSecret:
-                        type: string
-                      endpointUrl:
-                        type: string
-                      region:
-                        type: string
-                    type: object
-                  state:
-                    type: string
-                  storageName:
-                    type: string
-                type: object
-              pitr:
-                properties:
-                  backupSource:
-                    properties:
-                      completed:
-                        format: date-time
-                        type: string
-                      destination:
-                        type: string
-                      lastscheduled:
-                        format: date-time
-                        type: string
-                      s3:
-                        properties:
-                          bucket:
-                            type: string
-                          credentialsSecret:
-                            type: string
-                          endpointUrl:
-                            type: string
-                          region:
-                            type: string
-                        type: object
-                      state:
-                        type: string
-                      storageName:
-                        type: string
-                    type: object
-                  date:
-                    type: string
-                  gtid:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              pxcCluster:
-                type: string
-            type: object
-          status:
-            properties:
-              comments:
-                type: string
-              completed:
-                format: date-time
-                type: string
-              lastscheduled:
-                format: date-time
-                type: string
-              state:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Cluster name
+          jsonPath: .spec.pxcCluster
+          name: Cluster
+          type: string
+        - description: Job status
+          jsonPath: .status.state
+          name: Status
+          type: string
+        - description: Completed time
+          jsonPath: .status.completed
+          name: Completed
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                backupName:
+                  type: string
+                backupSource:
+                  properties:
+                    completed:
+                      format: date-time
+                      type: string
+                    destination:
+                      type: string
+                    lastscheduled:
+                      format: date-time
+                      type: string
+                    s3:
+                      properties:
+                        bucket:
+                          type: string
+                        credentialsSecret:
+                          type: string
+                        endpointUrl:
+                          type: string
+                        region:
+                          type: string
+                      type: object
+                    state:
+                      type: string
+                    storageName:
+                      type: string
+                  type: object
+                pitr:
+                  properties:
+                    backupSource:
+                      properties:
+                        completed:
+                          format: date-time
+                          type: string
+                        destination:
+                          type: string
+                        lastscheduled:
+                          format: date-time
+                          type: string
+                        s3:
+                          properties:
+                            bucket:
+                              type: string
+                            credentialsSecret:
+                              type: string
+                            endpointUrl:
+                              type: string
+                            region:
+                              type: string
+                          type: object
+                        state:
+                          type: string
+                        storageName:
+                          type: string
+                      type: object
+                    date:
+                      type: string
+                    gtid:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                pxcCluster:
+                  type: string
+              type: object
+            status:
+              properties:
+                comments:
+                  type: string
+                completed:
+                  format: date-time
+                  type: string
+                lastscheduled:
+                  format: date-time
+                  type: string
+                state:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""
@@ -16878,126 +16878,126 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: percona-xtradb-cluster-operator
 rules:
-- apiGroups:
-  - pxc.percona.com
-  resources:
-  - perconaxtradbclusters
-  - perconaxtradbclusters/status
-  - perconaxtradbclusterbackups
-  - perconaxtradbclusterbackups/status
-  - perconaxtradbclusterrestores
-  - perconaxtradbclusterrestores/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - pods/exec
-  - pods/log
-  - configmaps
-  - services
-  - persistentvolumeclaims
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - certmanager.k8s.io
-  - cert-manager.io
-  resources:
-  - issuers
-  - certificates
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
+  - apiGroups:
+      - pxc.percona.com
+    resources:
+      - perconaxtradbclusters
+      - perconaxtradbclusters/status
+      - perconaxtradbclusterbackups
+      - perconaxtradbclusterbackups/status
+      - perconaxtradbclusterrestores
+      - perconaxtradbclusterrestores/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/exec
+      - pods/log
+      - configmaps
+      - services
+      - persistentvolumeclaims
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - certmanager.k8s.io
+      - cert-manager.io
+    resources:
+      - issuers
+      - certificates
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -17009,9 +17009,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-account-percona-xtradb-cluster-operator
 subjects:
-- kind: ServiceAccount
-  name: percona-xtradb-cluster-operator
-  namespace: "pxc-operator"
+  - kind: ServiceAccount
+    name: percona-xtradb-cluster-operator
+    namespace: "pxc-operator"
 roleRef:
   kind: ClusterRole
   name: percona-xtradb-cluster-operator
@@ -17043,38 +17043,38 @@ spec:
     spec:
       terminationGracePeriodSeconds: 600
       containers:
-      - command:
-        - percona-xtradb-cluster-operator
-        env:
-        - name: WATCH_NAMESPACE
-          value: ""
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: OPERATOR_NAME
-          value: percona-xtradb-cluster-operator
-        image: perconalab/percona-xtradb-cluster-operator:main
-        imagePullPolicy: Always
-        resources:
-          limits:
-            cpu: 200m
-            memory: 500Mi
-          requests:
-            cpu: 100m
-            memory: 20Mi
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /metrics
-            port: metrics
-            scheme: HTTP
-        name: percona-xtradb-cluster-operator
-        ports:
-        - containerPort: 8080
-          name: metrics
-          protocol: TCP
+        - command:
+            - percona-xtradb-cluster-operator
+          env:
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: percona-xtradb-cluster-operator
+          image: perconalab/percona-xtradb-cluster-operator:main
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 200m
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /metrics
+              port: metrics
+              scheme: HTTP
+          name: percona-xtradb-cluster-operator
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
       serviceAccountName: percona-xtradb-cluster-operator
 ---
 apiVersion: v1

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -11,7 +11,7 @@ Run the following commands to install the required components:
 ```
 sudo yum -y install epel-release https://repo.percona.com/yum/percona-release-latest.noarch.rpm
 sudo yum -y install coreutils sed jq curl docker percona-xtrabackup-24
-sudo curl -s -L https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 -o /usr/bin/yq
+sudo curl -s -L https://github.com/mikefarah/yq/releases/download/4.27.2/yq_linux_amd64 -o /usr/bin/yq
 sudo chmod a+x /usr/bin/yq
 curl -s -L https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz \
     | tar -C /usr/bin --strip-components 1 --wildcards -zxvpf - '*/oc' '*/kubectl'
@@ -25,9 +25,7 @@ curl https://sdk.cloud.google.com | bash
 Install [Docker](https://docs.docker.com/docker-for-mac/install/), and run the following commands for the other required components:
 
 ```
-brew install coreutils gnu-sed jq kubernetes-cli openshift-cli kubernetes-helm percona-xtrabackup
-brew install yq@3
-brew link yq@3
+brew install coreutils gnu-sed jq yq kubernetes-cli openshift-cli kubernetes-helm percona-xtrabackup
 curl https://sdk.cloud.google.com | bash
 ```
 

--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -42,7 +42,7 @@ function start_cluster() {
 function main() {
 	create_infra "${namespace}"
 
-	cluster="$(yq r ${deploy_dir}/cr.yaml 'metadata.name')"
+	cluster="$(yq eval '.metadata.name' ${deploy_dir}/cr.yaml)"
 
 	kubectl_bin apply -f ${deploy_dir}/secrets.yaml
 	kubectl_bin apply -f ${conf_dir}/client.yml
@@ -121,7 +121,7 @@ function main() {
 
 	kubectl_bin delete -f ${deploy_dir}/cr.yaml
 
-	cluster="$(yq r ${deploy_dir}/cr-minimal.yaml 'metadata.name')"
+	cluster="$(yq eval '.metadata.name' ${deploy_dir}/cr-minimal.yaml)"
 	kubectl_bin apply -f ${deploy_dir}/cr-minimal.yaml
 
 	pxc_size=$(kubectl_bin get pxc/${cluster} -o jsonpath={.spec.pxc.size})

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -347,9 +347,10 @@ compare_kubectl() {
 			del(.. | select(has("uid")).uid) |
 			del(.metadata.resourceVersion) |
 			del(.spec.template.spec.containers[].env[] | select(.name == "CLUSTER_HASH")) |
+			del(.spec.template.spec.containers[].env[] | select(.name == "S3_BUCKET_PATH")) |
+			del(.spec.template.spec.containers[].env[] | select(.name == "S3_BUCKET_URL")) |
 			del(.metadata.selfLink) |
 			del(.metadata.deletionTimestamp) |
-			del(.metadata.annotations."k8s.v1.cni.cncf.io*") |
 			del(.metadata.annotations."kubernetes.io/psp") |
 			del(.metadata.annotations."cloud.google.com/neg") |
 			del(.. | select(has("image")).image) |
@@ -383,13 +384,10 @@ compare_kubectl() {
 			del(.. | select(has("preemptionPolicy")).preemptionPolicy) |
 			del(.spec.ipFamilies) |
 			del(.spec.ipFamilyPolicy) |
-			del(.. | select(has("kubernetes.io/hostname"))."kubernetes.io/hostname")' - \
-		| $sed 's#^apiVersion: policy/v1beta1#apiVersion: policy/v1#' \
-		| $sed 's/name: kube-api-access-.*$/name: kube-api-access/' \
-		| $sed 's/namespace\:.*name/name/' \
-		| $sed "s/${namespace}/namespace/g" \
-			>${new_result}
-	# last but one sed is needed for backup cronjob content
+			(.. | select(. == "policy/v1beta1")) = "policy/v1" |
+			del(.. | select(has("kubernetes.io/hostname"))."kubernetes.io/hostname") |
+			(.. | select(tag == "!!str")) |= sub("init-deploy-[0-9]*", "namespace") |
+			del(.. | select(.[] == "percona-xtradb-cluster-operator-workload-token*"))' - >${new_result}
 
 	diff -u ${expected_result} ${new_result}
 }

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -388,6 +388,7 @@ compare_kubectl() {
 			del(.. | select(has("kubernetes.io/hostname"))."kubernetes.io/hostname") |
 			(.. | select(tag == "!!str")) |= sub("'$namespace'", "namespace") |
 			(.. | select(tag == "!!str")) |= sub("kube-api-access-.*", "kube-api-access") |
+			del(.metadata.annotations."k8s.v1.cni.cncf.io*") |
 			del(.. | select(.[] == "percona-xtradb-cluster-operator-workload-token*"))' - >${new_result}
 
 	diff -u ${expected_result} ${new_result}

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -340,52 +340,50 @@ compare_kubectl() {
 	fi
 
 	kubectl_bin get -o yaml ${resource} \
-		| yq d - 'metadata.managedFields' \
-		| yq d - '**.creationTimestamp' \
-		| yq d - '**.namespace' \
-		| yq d - '**.uid' \
-		| yq d - 'metadata.resourceVersion' \
-		| yq d - '**.env.(name==CLUSTER_HASH)' \
-		| yq d - 'metadata.selfLink' \
-		| yq d - 'metadata.deletionTimestamp' \
-		| yq d - 'metadata.annotations."k8s.v1.cni.cncf.io*"' \
-		| yq d - 'metadata.annotations."kubernetes.io/psp"' \
-		| yq d - 'metadata.annotations."cloud.google.com/neg"' \
-		| yq d - '**.(name==percona-xtradb-cluster-operator-workload-token*)' \
-		| yq d - '**.creationTimestamp' \
-		| yq d - '**.image' \
-		| yq d - '**.clusterIP' \
-		| yq d - '**.clusterIPs' \
-		| yq d - '**.dataSource' \
-		| yq d - '**.procMount' \
-		| yq d - '**.storageClassName' \
-		| yq d - '**.finalizers' \
-		| yq d - '**."kubernetes.io/pvc-protection"' \
-		| yq d - '**.volumeName' \
-		| yq d - '**."volume.beta.kubernetes.io/storage-provisioner"' \
-		| yq d - '**."volume.kubernetes.io/storage-provisioner"' \
-		| yq d - 'spec.volumeMode' \
-		| yq d - 'spec.nodeName' \
-		| yq d - '**."volume.kubernetes.io/selected-node"' \
-		| yq d - '**."percona.com/*"' \
-		| yq d - '**.(volumeMode==Filesystem).volumeMode' \
-		| yq d - '**.healthCheckNodePort' \
-		| yq d - '**.nodePort' \
-		| yq d - '**.imagePullSecrets' \
-		| yq d - '**.enableServiceLinks' \
-		| yq d - 'status' \
-		| yq d - '**.(name==NAMESPACE)' \
-		| yq d - '**.(name==suffix)' \
-		| yq d - '**.(name==S3_BUCKET_PATH)' \
-		| yq d - '**.(name==S3_BUCKET_URL)' \
-		| yq d - 'spec.volumeClaimTemplates.*.apiVersion' \
-		| yq d - 'spec.volumeClaimTemplates.*.kind' \
-		| yq d - 'metadata.ownerReferences.*.apiVersion' \
-		| yq d - '**.controller-uid' \
-		| yq d - '**.preemptionPolicy' \
-		| yq d - 'spec.ipFamilies' \
-		| yq d - 'spec.ipFamilyPolicy' \
-		| yq d - '**."kubernetes.io/hostname"' \
+		| yq eval '
+			del(.metadata.managedFields) |
+			del(.. | select(has("creationTimestamp")).creationTimestamp) |
+			del(.. | select(has("namespace")).namespace) |
+			del(.. | select(has("uid")).uid) |
+			del(.metadata.resourceVersion) |
+			del(.spec.template.spec.containers[].env[] | select(.name == "CLUSTER_HASH")) |
+			del(.metadata.selfLink) |
+			del(.metadata.deletionTimestamp) |
+			del(.metadata.annotations."k8s.v1.cni.cncf.io*") |
+			del(.metadata.annotations."kubernetes.io/psp") |
+			del(.metadata.annotations."cloud.google.com/neg") |
+			del(.. | select(has("image")).image) |
+			del(.. | select(has("clusterIP")).clusterIP) |
+			del(.. | select(has("clusterIPs")).clusterIPs) |
+			del(.. | select(has("dataSource")).dataSource) |
+			del(.. | select(has("procMount")).procMount) |
+			del(.. | select(has("storageClassName")).storageClassName) |
+			del(.. | select(has("finalizers")).finalizers) |
+			del(.. | select(has("kubernetes.io/pvc-protection"))."kubernetes.io/pvc-protection") |
+			del(.. | select(has("volumeName")).volumeName) |
+			del(.. | select(has("volume.beta.kubernetes.io/storage-provisioner"))."volume.beta.kubernetes.io/storage-provisioner") |
+			del(.. | select(has("volume.kubernetes.io/storage-provisioner"))."volume.kubernetes.io/storage-provisioner") |
+			del(.spec.volumeMode) |
+			del(.spec.nodeName) |
+			del(.. | select(has("volume.kubernetes.io/selected-node"))."volume.kubernetes.io/selected-node") |
+			del(.. | select(has("percona.com/last-config-hash"))."percona.com/last-config-hash") |
+			del(.. | select(has("percona.com/configuration-hash"))."percona.com/configuration-hash") |
+			del(.. | select(has("percona.com/ssl-hash"))."percona.com/ssl-hash") |
+			del(.. | select(has("percona.com/ssl-internal-hash"))."percona.com/ssl-internal-hash") |
+			del(.spec.volumeClaimTemplates[].spec.volumeMode | select(. == "Filesystem")) |
+			del(.. | select(has("healthCheckNodePort")).healthCheckNodePort) |
+			del(.. | select(has("nodePort")).nodePort) |
+			del(.. | select(has("imagePullSecrets")).imagePullSecrets) |
+			del(.. | select(has("enableServiceLinks")).enableServiceLinks) |
+			del(.status) |
+			del(.spec.volumeClaimTemplates[].apiVersion) |
+			del(.spec.volumeClaimTemplates[].kind) |
+			del(.metadata.ownerReferences[].apiVersion) |
+			del(.. | select(has("controller-uid")).controller-uid) |
+			del(.. | select(has("preemptionPolicy")).preemptionPolicy) |
+			del(.spec.ipFamilies) |
+			del(.spec.ipFamilyPolicy) |
+			del(.. | select(has("kubernetes.io/hostname"))."kubernetes.io/hostname")' - \
 		| $sed 's#^apiVersion: policy/v1beta1#apiVersion: policy/v1#' \
 		| $sed 's/name: kube-api-access-.*$/name: kube-api-access/' \
 		| $sed 's/namespace\:.*name/name/' \
@@ -743,8 +741,9 @@ apply_config() {
 			| kubectl_bin apply -f -
 	else
 		cat_config "$1" \
-			| yq d - 'spec.backup.schedule.[1]' \
-			| yq d - 'spec.backup.schedule.[2]' \
+			| yq eval '
+                del(.spec.backup.schedule.[1]) |
+                del(.spec.backup.schedule.[2])' - \
 			| kubectl_bin apply -f -
 	fi
 }
@@ -1319,30 +1318,36 @@ function prepare_cr_yaml() {
 	# spinup function expects images to have suffix like "-pxc"
 	# to replace them with images from environment variables
 	curl -s "https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/${git_tag}/deploy/cr.yaml" \
-		| yq w - "metadata.name" "${cluster}" \
-		| yq w - "spec.secretsName" "my-cluster-secrets" \
-		| yq w - "spec.vaultSecretName" "some-name-vault" \
-		| yq w - "spec.sslSecretName" "some-name-ssl" \
-		| yq w - "spec.sslInternalSecretName" "some-name-ssl-internal" \
-		| yq w - "spec.upgradeOptions.apply" "disabled" \
-		| yq w - "spec.pxc.size" "${cluster_size}" \
-		| yq w - "spec.proxysql.size" "${cluster_size}" \
-		| yq w - "spec.haproxy.size" "${cluster_size}" \
-		| yq w - "spec.pxc.image" -- "-pxc" \
-		| yq w - "spec.proxysql.image" -- "-proxysql" \
-		| yq w - "spec.haproxy.image" -- "-haproxy" \
-		| yq w - "spec.backup.image" -- "-backup" \
-		| yq w - "spec.backup.storages.minio.s3.credentialsSecret" "minio-secret" \
-		| yq w - "spec.backup.storages.minio.s3.region" "us-east-1" \
-		| yq w - "spec.backup.storages.minio.s3.bucket" "operator-testing" \
-		| yq w - "spec.backup.storages.minio.s3.endpointUrl" "http://minio-service:9000/" \
-		| yq w - "spec.backup.storages.minio.type" "s3" >"${cr_yaml}"
+		| yq eval "
+			.metadata.name = \"${cluster}\" |
+			.spec.secretsName = \"my-cluster-secrets\" |
+			.spec.vaultSecretName = \"some-name-vault\" |
+			.spec.sslSecretName = \"some-name-ssl\" |
+			.spec.sslInternalSecretName = \"some-name-ssl-internal\" |
+			.spec.upgradeOptions.apply = \"disabled\" |
+			.spec.pxc.size = ${cluster_size} |
+			.spec.proxysql.size = ${cluster_size} |
+			.spec.haproxy.size = ${cluster_size} |
+			.spec.pxc.image = \"-pxc\" |
+			.spec.proxysql.image = \"-proxysql\" |
+			.spec.haproxy.image = \"-haproxy\" |
+			.spec.backup.image = \"-backup\" |
+			.spec.backup.storages.minio.s3.credentialsSecret = \"minio-secret\" |
+			.spec.backup.storages.minio.s3.region = \"us-east-1\" |
+			.spec.backup.storages.minio.s3.bucket = \"operator-testing\" |
+			.spec.backup.storages.minio.s3.endpointUrl = \"http://minio-service:9000/\" |
+			.spec.backup.storages.minio.type = \"s3\"
+		" - >"${cr_yaml}"
 	if [[ ${proxy} == "haproxy" ]]; then
-		yq w -i "${cr_yaml}" "spec.haproxy.enabled" "true"
-		yq w -i "${cr_yaml}" "spec.proxysql.enabled" "false"
+		yq -i eval '
+			.spec.haproxy.enabled = true |
+			.spec.proxysql.enabled = false
+		' "${cr_yaml}"
 	else
-		yq w -i "${cr_yaml}" "spec.haproxy.enabled" "false"
-		yq w -i "${cr_yaml}" "spec.proxysql.enabled" "true"
+		yq -i eval '
+			.spec.haproxy.enabled = false |
+			.spec.proxysql.enabled = true
+		' "${cr_yaml}"
 	fi
 }
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -742,8 +742,8 @@ apply_config() {
 	else
 		cat_config "$1" \
 			| yq eval '
-                del(.spec.backup.schedule.[1]) |
-                del(.spec.backup.schedule.[2])' - \
+				del(.spec.backup.schedule.[1]) |
+				del(.spec.backup.schedule.[2])' - \
 			| kubectl_bin apply -f -
 	fi
 }

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -386,7 +386,8 @@ compare_kubectl() {
 			del(.spec.ipFamilyPolicy) |
 			(.. | select(. == "policy/v1beta1")) = "policy/v1" |
 			del(.. | select(has("kubernetes.io/hostname"))."kubernetes.io/hostname") |
-			(.. | select(tag == "!!str")) |= sub("init-deploy-[0-9]*", "namespace") |
+			(.. | select(tag == "!!str")) |= sub("'$namespace'", "namespace") |
+			(.. | select(tag == "!!str")) |= sub("kube-api-access-.*", "kube-api-access") |
 			del(.. | select(.[] == "percona-xtradb-cluster-operator-workload-token*"))' - >${new_result}
 
 	diff -u ${expected_result} ${new_result}

--- a/e2e-tests/manifest
+++ b/e2e-tests/manifest
@@ -14,53 +14,36 @@ controller-gen crd:allowDangerousTypes=true,maxDescLen=0 paths=./pkg/apis/... ou
 
 crd_ver=${1}
 if [ "${crd_ver}" == "" ]; then
-	crd_ver=$(yq r -d0 "deploy/crd.yaml" "spec.versions[-1].name")
+	crd_ver=$(yq eval "select(document_index == 0) | .spec.versions[-1].name" "deploy/crd.yaml")
 fi
 
 wip_crd=$(mktemp)
-yq r -d0 "deploy/crd.yaml" \
-	| yq d - "spec.versions(name==${crd_ver})" \
-	| yq w - "spec.versions[*].storage" false \
-		>"$wip_crd"
+yq eval 'select(document_index == 0) |
+	del(.spec.versions[] |
+	select(.name == "v1-12-0")) |
+	.spec.versions[].storage = false' "deploy/crd.yaml" >"$wip_crd"
 
-yq w -i "$wip_crd" "spec.versions[+].name" "${crd_ver}"
+yq -i eval "(.spec.versions += {\"name\": \"${crd_ver}\"})" "$wip_crd"
 
 sed '/.*- protocol/d; s/.*- containerPort/&\n&/; s/- containerPort/- protocol/' \
 	deploy/crds/pxc.percona.com_perconaxtradbclusters.yaml \
-	| yq r - "spec.versions[0]" \
-	| yq d - "name" \
+	| yq eval ".spec.versions[0] | del(.name)" - \
 	| sed 's/^/      /g' \
 		>>"$wip_crd"
 
 # deploy/crd.yaml
 crd_file=$(mktemp)
-yq r "$wip_crd" >"$crd_file"
-
-cat "deploy/crds/pxc.percona.com_perconaxtradbclusterbackups.yaml" >>"$crd_file"
-cat "deploy/crds/pxc.percona.com_perconaxtradbclusterrestores.yaml" >>"$crd_file"
-
+yq eval "$wip_crd" "deploy/crds/pxc.percona.com_perconaxtradbclusterbackups.yaml" "deploy/crds/pxc.percona.com_perconaxtradbclusterrestores.yaml" >"$crd_file"
 mv "$crd_file" "deploy/crd.yaml"
 
 # deploy/bundle.yaml
 bundle_file=$(mktemp)
-
-cat "deploy/crd.yaml" >"$bundle_file"
-echo "---" >>"$bundle_file"
-cat "deploy/rbac.yaml" >>"$bundle_file"
-echo "---" >>"$bundle_file"
-cat "deploy/operator.yaml" >>"$bundle_file"
-
+yq eval "deploy/crd.yaml" "deploy/rbac.yaml" "deploy/operator.yaml" >"$bundle_file"
 mv "$bundle_file" "deploy/bundle.yaml"
 
 # deploy/cw-bundle.yaml
 cw_bundle_file=$(mktemp)
-
-cat "deploy/crd.yaml" >"$cw_bundle_file"
-echo "---" >> "$cw_bundle_file"
-cat "deploy/cw-rbac.yaml" >>"$cw_bundle_file"
-echo "---" >>"$cw_bundle_file"
-cat "deploy/cw-operator.yaml" >>"$cw_bundle_file"
-
+yq "deploy/crd.yaml" "deploy/cw-rbac.yaml" "deploy/cw-operator.yaml" >"$cw_bundle_file"
 mv "$cw_bundle_file" "deploy/cw-bundle.yaml"
 
 rm -rf ./deploy/crds

--- a/e2e-tests/manifest
+++ b/e2e-tests/manifest
@@ -43,7 +43,7 @@ mv "$bundle_file" "deploy/bundle.yaml"
 
 # deploy/cw-bundle.yaml
 cw_bundle_file=$(mktemp)
-yq "deploy/crd.yaml" "deploy/cw-rbac.yaml" "deploy/cw-operator.yaml" >"$cw_bundle_file"
+yq eval "deploy/crd.yaml" "deploy/cw-rbac.yaml" "deploy/cw-operator.yaml" >"$cw_bundle_file"
 mv "$cw_bundle_file" "deploy/cw-bundle.yaml"
 
 rm -rf ./deploy/crds

--- a/e2e-tests/operator-self-healing-chaos/run
+++ b/e2e-tests/operator-self-healing-chaos/run
@@ -12,9 +12,10 @@ fail_pod() {
 	local restart_count_before=$(kubectl_bin get pod ${init_pod} --namespace="${OPERATOR_NS:-$namespace}" -ojsonpath='{.status.containerStatuses[0].restartCount}')
 
 	cat $conf_dir/chaos-pod-failure.yml \
-		| yq w - "metadata.name" "chaos-operator-pod-failure" \
-		| yq d - "spec.selector.pods.test-namespace" \
-		| yq w - "spec.selector.pods.$test_namespace[0]" "$init_pod" \
+		| yq eval "
+			.metadata.name = \"chaos-operator-pod-failure\" |
+			del(.spec.selector.pods.test-namespace) |
+			.spec.selector.pods.$test_namespace[0] = \"$init_pod\"" - \
 		| kubectl_bin apply --namespace $test_namespace -f-
 	sleep 10
 
@@ -49,9 +50,10 @@ network_loss() {
 	local pod=$(get_operator_pod)
 
 	cat $conf_dir/chaos-network-loss.yml \
-		| yq w - "metadata.name" "chaos-operator-network" \
-		| yq d - "spec.selector.pods.test-namespace" \
-		| yq w - "spec.selector.pods.$test_namespace[0]" "$init_pod" \
+		| yq eval "
+			.metadata.name = \"chaos-operator-network\" |
+			del(.spec.selector.pods.test-namespace) |
+			.spec.selector.pods.$test_namespace[0] = \"$pod\"" - \
 		| kubectl_bin apply --namespace $test_namespace -f-
 	sleep 10
 
@@ -74,9 +76,10 @@ kill_pod() {
 	local init_pod=$(get_operator_pod)
 
 	cat $conf_dir/chaos-pod-kill.yml \
-		| yq w - "metadata.name" "chaos-operator-pod-kill" \
-		| yq d - "spec.selector.pods.test-namespace" \
-		| yq w - "spec.selector.pods.$test_namespace[0]" "$init_pod" \
+		| yq eval "
+			.metadata.name = \"chaos-operator-pod-kill\" |
+			del(.spec.selector.pods.test-namespace) |
+			.spec.selector.pods.$test_namespace[0] = \"$init_pod\"" - \
 		| kubectl_bin apply --namespace $test_namespace -f-
 	sleep 10
 

--- a/e2e-tests/self-healing-advanced-chaos/run
+++ b/e2e-tests/self-healing-advanced-chaos/run
@@ -22,12 +22,13 @@ crash_cluster_with_kubectl() {
 
 crash_cluster_with_chaos_mesh() {
 	cat $conf_dir/chaos-pod-kill.yml \
-		| yq w - "metadata.name" "chaos-cluster-kill" \
-		| yq w - "spec.mode" "all" \
-		| yq d - "spec.selector.pods.test-namespace" \
-		| yq w - "spec.selector.pods.$namespace[0]" "$cluster-pxc-0" \
-		| yq w - "spec.selector.pods.$namespace[1]" "$cluster-pxc-1" \
-		| yq w - "spec.selector.pods.$namespace[2]" "$cluster-pxc-2" \
+		| yq eval "
+			.metadata.name = \"chaos-cluster-kill\" |
+			.spec.mode = \"all\" |
+			del(.spec.selector.pods.test-namespace) |
+			.spec.selector.pods.$namespace[0] = \"$cluster-pxc-0\" |
+			.spec.selector.pods.$namespace[1] = \"$cluster-pxc-1\" |
+			.spec.selector.pods.$namespace[2] = \"$cluster-pxc-2\"" - \
 		| kubectl_bin apply -f-
 
 	sleep 60

--- a/e2e-tests/self-healing-chaos/compare/proxy-vars-80.sql
+++ b/e2e-tests/self-healing-chaos/compare/proxy-vars-80.sql
@@ -40,7 +40,7 @@ admin-stats_system_memory	60
 admin-telnet_admin_ifaces	(null)
 admin-telnet_stats_ifaces	(null)
 admin-vacuum_stats	true
-admin-version	2.3.2-percona-1.1
+admin-version	2.4.2-percona-1.1
 admin-web_enabled	false
 admin-web_port	6080
 admin-web_verbosity	0
@@ -49,14 +49,13 @@ mysql-auditlog_filename
 mysql-auditlog_filesize	104857600
 mysql-aurora_max_lag_ms_only_read_from_replicas	2
 mysql-auto_increment_delay_multiplex	5
+mysql-auto_increment_delay_multiplex_timeout_ms	10000
 mysql-autocommit_false_is_transaction	false
 mysql-autocommit_false_not_reusable	false
 mysql-automatic_detect_sqli	false
 mysql-binlog_reader_connect_retry_msec	3000
-mysql-client_found_rows	true
 mysql-client_host_cache_size	0
 mysql-client_host_error_counts	0
-mysql-client_multi_statements	true
 mysql-client_session_track_gtid	true
 mysql-commands_stats	true
 mysql-connect_retries_delay	1
@@ -94,7 +93,7 @@ mysql-have_ssl	true
 mysql-hostgroup_manager_verbose	1
 mysql-init_connect	
 mysql-interfaces	0.0.0.0:3306;0.0.0.0:33062
-mysql-keep_multiplexing_variables	tx_isolation,version
+mysql-keep_multiplexing_variables	tx_isolation,transaction_isolation,version
 mysql-kill_backend_connection_when_disconnect	true
 mysql-ldap_user_variable	
 mysql-log_mysql_warnings_enabled	false
@@ -131,6 +130,7 @@ mysql-monitor_read_only_interval	1000
 mysql-monitor_read_only_max_timeout_count	3
 mysql-monitor_read_only_timeout	800
 mysql-monitor_replication_lag_count	1
+mysql-monitor_replication_lag_group_by_host	false
 mysql-monitor_replication_lag_interval	10000
 mysql-monitor_replication_lag_timeout	1000
 mysql-monitor_replication_lag_use_percona_heartbeat	
@@ -150,6 +150,8 @@ mysql-query_cache_size_MB	256
 mysql-query_cache_stores_empty_result	true
 mysql-query_digests	true
 mysql-query_digests_grouping_limit	3
+mysql-query_digests_groups_grouping_limit	0
+mysql-query_digests_keep_comment	false
 mysql-query_digests_lowercase	false
 mysql-query_digests_max_digest_length	2048
 mysql-query_digests_max_query_length	65000
@@ -187,6 +189,7 @@ mysql-threshold_resultset_size	4194304
 mysql-throttle_connections_per_sec_to_hostgroup	1000000
 mysql-throttle_max_bytes_per_second_to_client	0
 mysql-throttle_ratio_server_to_client	0
+mysql-unshun_algorithm	0
 mysql-use_tcp_keepalive	false
 mysql-verbose_query_error	false
 mysql-wait_timeout	28800000

--- a/e2e-tests/self-healing-chaos/compare/proxy-vars-80.sql
+++ b/e2e-tests/self-healing-chaos/compare/proxy-vars-80.sql
@@ -40,7 +40,7 @@ admin-stats_system_memory	60
 admin-telnet_admin_ifaces	(null)
 admin-telnet_stats_ifaces	(null)
 admin-vacuum_stats	true
-admin-version	2.4.2-percona-1.1
+admin-version	2.4.3-percona-1.1
 admin-web_enabled	false
 admin-web_port	6080
 admin-web_verbosity	0

--- a/e2e-tests/self-healing-chaos/run
+++ b/e2e-tests/self-healing-chaos/run
@@ -11,9 +11,10 @@ kill_pod() {
 	local pod=$1
 
 	cat $conf_dir/chaos-pod-kill.yml \
-		| yq w - "metadata.name" "chaos-pod-kill" \
-		| yq d - "spec.selector.pods.test-namespace" \
-		| yq w - "spec.selector.pods.$namespace[0]" "$pod" \
+		| yq eval "
+			.metadata.name = \"chaos-pod-kill\" |
+			del(.spec.selector.pods.test-namespace) |
+			.spec.selector.pods.$namespace[0] = \"$pod\"" - \
 		| kubectl_bin apply -f-
 	sleep 5
 
@@ -29,9 +30,10 @@ fail_pod() {
 
 	# run chaos for Pod
 	cat $conf_dir/chaos-pod-failure.yml \
-		| yq w - "metadata.name" "chaos-pod-failure" \
-		| yq d - "spec.selector.pods.test-namespace" \
-		| yq w - "spec.selector.pods.$namespace[0]" "$pod" \
+		| yq eval "
+			.metadata.name = \"chaos-pod-failure\" |
+			del(.spec.selector.pods.test-namespace) |
+			.spec.selector.pods.$namespace[0] = \"$pod\"" - \
 		| kubectl_bin apply -f-
 	sleep 10
 
@@ -56,9 +58,10 @@ network_loss() {
 
 	# run chaos for Pod
 	cat $conf_dir/chaos-network-loss.yml \
-		| yq w - "metadata.name" "chaos-pod-network-loss" \
-		| yq d - "spec.selector.pods.test-namespace" \
-		| yq w - "spec.selector.pods.$namespace[0]" "$pod" \
+		| yq eval "
+			.metadata.name = \"chaos-pod-network-loss\" |
+			del(.spec.selector.pods.test-namespace) |
+			.spec.selector.pods.$namespace[0] = \"$pod\"" - \
 		| kubectl_bin apply -f-
 	sleep 10
 

--- a/e2e-tests/self-healing/compare/proxy-vars-80.sql
+++ b/e2e-tests/self-healing/compare/proxy-vars-80.sql
@@ -40,7 +40,7 @@ admin-stats_system_memory	60
 admin-telnet_admin_ifaces	(null)
 admin-telnet_stats_ifaces	(null)
 admin-vacuum_stats	true
-admin-version	2.4.2-percona-1.1
+admin-version	2.4.3-percona-1.1
 admin-web_enabled	false
 admin-web_port	6080
 admin-web_verbosity	0

--- a/e2e-tests/self-healing/compare/proxy-vars-80.sql
+++ b/e2e-tests/self-healing/compare/proxy-vars-80.sql
@@ -1,21 +1,31 @@
 admin-admin_credentials	proxyadmin:admin_password
+admin-checksum_admin_variables	false
+admin-checksum_ldap_variables	false
 admin-checksum_mysql_query_rules	true
 admin-checksum_mysql_servers	true
 admin-checksum_mysql_users	true
+admin-checksum_mysql_variables	false
+admin-cluster_admin_variables_diffs_before_sync	3
+admin-cluster_admin_variables_save_to_disk	true
 admin-cluster_check_interval_ms	200
 admin-cluster_check_status_frequency	100
+admin-cluster_ldap_variables_diffs_before_sync	3
+admin-cluster_ldap_variables_save_to_disk	true
 admin-cluster_mysql_query_rules_diffs_before_sync	1
 admin-cluster_mysql_query_rules_save_to_disk	true
 admin-cluster_mysql_servers_diffs_before_sync	1
 admin-cluster_mysql_servers_save_to_disk	true
 admin-cluster_mysql_users_diffs_before_sync	1
 admin-cluster_mysql_users_save_to_disk	true
+admin-cluster_mysql_variables_diffs_before_sync	3
+admin-cluster_mysql_variables_save_to_disk	true
 admin-cluster_password	admin_password
 admin-cluster_proxysql_servers_diffs_before_sync	1
 admin-cluster_proxysql_servers_save_to_disk	true
 admin-cluster_username	proxyadmin
 admin-hash_passwords	true
 admin-mysql_ifaces	0.0.0.0:6032
+admin-prometheus_memory_metrics_interval	61
 admin-read_only	false
 admin-refresh_interval	2000
 admin-restapi_enabled	false
@@ -30,20 +40,22 @@ admin-stats_system_memory	60
 admin-telnet_admin_ifaces	(null)
 admin-telnet_stats_ifaces	(null)
 admin-vacuum_stats	true
-admin-version	2.0.18-percona-1.1
+admin-version	2.4.2-percona-1.1
 admin-web_enabled	false
 admin-web_port	6080
+admin-web_verbosity	0
 mysql-add_ldap_user_comment	
 mysql-auditlog_filename	
 mysql-auditlog_filesize	104857600
 mysql-aurora_max_lag_ms_only_read_from_replicas	2
 mysql-auto_increment_delay_multiplex	5
+mysql-auto_increment_delay_multiplex_timeout_ms	10000
 mysql-autocommit_false_is_transaction	false
 mysql-autocommit_false_not_reusable	false
-mysql-automatic_detect_sqli	0
+mysql-automatic_detect_sqli	false
 mysql-binlog_reader_connect_retry_msec	3000
-mysql-client_found_rows	true
-mysql-client_multi_statements	true
+mysql-client_host_cache_size	0
+mysql-client_host_error_counts	0
 mysql-client_session_track_gtid	true
 mysql-commands_stats	true
 mysql-connect_retries_delay	1
@@ -64,14 +76,16 @@ mysql-default_reconnect	true
 mysql-default_schema	information_schema
 mysql-default_session_track_gtids	OFF
 mysql-default_tx_isolation	READ-COMMITTED
+mysql-enable_client_deprecate_eof	true
+mysql-enable_load_data_local_infile	false
+mysql-enable_server_deprecate_eof	true
 mysql-enforce_autocommit_on_reads	false
 mysql-eventslog_default_log	0
 mysql-eventslog_filename	
 mysql-eventslog_filesize	104857600
 mysql-eventslog_format	1
-mysql-firewall_whitelist_enabled	0
+mysql-firewall_whitelist_enabled	false
 mysql-firewall_whitelist_errormsg	Firewall blocked this query
-mysql-forward_autocommit	false
 mysql-free_connections_pct	10
 mysql-handle_unknown_charset	1
 mysql-have_compress	true
@@ -79,9 +93,10 @@ mysql-have_ssl	true
 mysql-hostgroup_manager_verbose	1
 mysql-init_connect	
 mysql-interfaces	0.0.0.0:3306;0.0.0.0:33062
-mysql-keep_multiplexing_variables	tx_isolation,version
+mysql-keep_multiplexing_variables	tx_isolation,transaction_isolation,version
 mysql-kill_backend_connection_when_disconnect	true
 mysql-ldap_user_variable	
+mysql-log_mysql_warnings_enabled	false
 mysql-log_unhealthy_connections	true
 mysql-long_query_time	1000
 mysql-max_allowed_packet	67108864
@@ -103,6 +118,7 @@ mysql-monitor_groupreplication_healthcheck_interval	5000
 mysql-monitor_groupreplication_healthcheck_max_timeout_count	3
 mysql-monitor_groupreplication_healthcheck_timeout	800
 mysql-monitor_groupreplication_max_transactions_behind_count	3
+mysql-monitor_groupreplication_max_transactions_behind_for_read_only	1
 mysql-monitor_history	60000
 mysql-monitor_password	monitor
 mysql-monitor_ping_interval	10000
@@ -114,6 +130,7 @@ mysql-monitor_read_only_interval	1000
 mysql-monitor_read_only_max_timeout_count	3
 mysql-monitor_read_only_timeout	800
 mysql-monitor_replication_lag_count	1
+mysql-monitor_replication_lag_group_by_host	false
 mysql-monitor_replication_lag_interval	10000
 mysql-monitor_replication_lag_timeout	1000
 mysql-monitor_replication_lag_use_percona_heartbeat	
@@ -132,6 +149,9 @@ mysql-poll_timeout_on_failure	100
 mysql-query_cache_size_MB	256
 mysql-query_cache_stores_empty_result	true
 mysql-query_digests	true
+mysql-query_digests_grouping_limit	3
+mysql-query_digests_groups_grouping_limit	0
+mysql-query_digests_keep_comment	false
 mysql-query_digests_lowercase	false
 mysql-query_digests_max_digest_length	2048
 mysql-query_digests_max_query_length	65000
@@ -145,7 +165,7 @@ mysql-reset_connection_algorithm	2
 mysql-server_capabilities	571947
 mysql-server_version	8.0.28
 mysql-servers_stats	true
-mysql-session_idle_ms	1000
+mysql-session_idle_ms	1
 mysql-session_idle_show_processlist	true
 mysql-sessions_sort	true
 mysql-set_query_lock_on_hostgroup	1
@@ -153,8 +173,11 @@ mysql-show_processlist_extended	0
 mysql-shun_on_failures	5
 mysql-shun_recovery_time_sec	10
 mysql-ssl_p2s_ca	/etc/proxysql/ssl-internal/ca.crt
+mysql-ssl_p2s_capath	
 mysql-ssl_p2s_cert	/etc/proxysql/ssl-internal/tls.crt
 mysql-ssl_p2s_cipher	ECDHE-RSA-AES128-GCM-SHA256
+mysql-ssl_p2s_crl	
+mysql-ssl_p2s_crlpath	
 mysql-ssl_p2s_key	/etc/proxysql/ssl-internal/tls.key
 mysql-stacksize	1048576
 mysql-stats_time_backend_query	false
@@ -166,6 +189,7 @@ mysql-threshold_resultset_size	4194304
 mysql-throttle_connections_per_sec_to_hostgroup	1000000
 mysql-throttle_max_bytes_per_second_to_client	0
 mysql-throttle_ratio_server_to_client	0
-mysql-use_tcp_keepalive	0
+mysql-unshun_algorithm	0
+mysql-use_tcp_keepalive	false
 mysql-verbose_query_error	false
 mysql-wait_timeout	28800000

--- a/e2e-tests/smart-update/run
+++ b/e2e-tests/smart-update/run
@@ -12,10 +12,10 @@ CLUSTER="smart-update"
 CLUSTER_SIZE=3
 PROXY_SIZE=2
 
-if [[ "${TARGET_IMAGE_PXC}" == *"percona-xtradb-cluster-operator"* ]]; then
-    PXC_VER=$(echo -n "${TARGET_IMAGE_PXC}" | $sed -r 's/.*([0-9].[0-9])$/\1/')
+if [[ ${TARGET_IMAGE_PXC} == *"percona-xtradb-cluster-operator"* ]]; then
+	PXC_VER=$(echo -n "${TARGET_IMAGE_PXC}" | $sed -r 's/.*([0-9].[0-9])$/\1/')
 else
-    PXC_VER=$(echo -n "${TARGET_IMAGE_PXC}" | $sed -r 's/.*:([0-9]+\.[0-9]+).*$/\1/')
+	PXC_VER=$(echo -n "${TARGET_IMAGE_PXC}" | $sed -r 's/.*:([0-9]+\.[0-9]+).*$/\1/')
 fi
 TARGET_IMAGE_PXC_VS="perconalab/percona-xtradb-cluster-operator:main-pxc${PXC_VER}"
 VS_URL="http://version-service"
@@ -23,188 +23,187 @@ VS_PORT="11000"
 VS_ENDPOINT="${VS_URL}:${VS_PORT}"
 
 function get_pod_names_images {
-    local cluster=${1}
-    local type=${2:-pxc}
+	local cluster=${1}
+	local type=${2:-pxc}
 
-    echo -e $(kubectl_bin get pods -l "app.kubernetes.io/instance=${cluster},app.kubernetes.io/component=${type}" \
-                                   -o jsonpath="{range .items[*]}{.metadata.name}{\",\"}{.spec.containers[?(@.name == \"${type}\")].image}{\"\n\"}{end}")
+	echo -e $(kubectl_bin get pods -l "app.kubernetes.io/instance=${cluster},app.kubernetes.io/component=${type}" \
+		-o jsonpath="{range .items[*]}{.metadata.name}{\",\"}{.spec.containers[?(@.name == \"${type}\")].image}{\"\n\"}{end}")
 }
 
 function check_last_pod_to_update {
-    local cluster=${1}
-    local initial_primary=${2}
-    local pxc_size=${3}
-    local target_image=${4}
+	local cluster=${1}
+	local initial_primary=${2}
+	local pxc_size=${3}
+	local target_image=${4}
 
-    set +x
-    echo -n "Waiting for the last pod to update"
-    until [[ "$(kubectl_bin get pxc "${cluster}" -o jsonpath='{.status.state}')" == "ready" ]]; do
-        echo -n "."
-        updated_pods_count=0
-        for entry in $(get_pod_names_images "${cluster}"); do
-            if [[ -n "$(echo ${entry} | grep ${target_image})" ]]; then
-                ((updated_pods_count+=1))
-            fi
-        done
+	set +x
+	echo -n "Waiting for the last pod to update"
+	until [[ "$(kubectl_bin get pxc "${cluster}" -o jsonpath='{.status.state}')" == "ready" ]]; do
+		echo -n "."
+		updated_pods_count=0
+		for entry in $(get_pod_names_images "${cluster}"); do
+			if [[ -n "$(echo ${entry} | grep ${target_image})" ]]; then
+				((updated_pods_count += 1))
+			fi
+		done
 
-        if [[ ${updated_pods_count} == $((pxc_size-1)) ]]; then
-            if [[ -n $(get_pod_names_images "${cluster}" | grep "${initial_primary}" | grep "${IMAGE_PXC}") ]]; then
-                echo
-                echo "${initial_primary} is REALLY the last one to update"
-                break
-            else
-                echo "${initial_primary} is not the last one to update. Exiting..."
-                exit 1
-            fi
-        fi
-        sleep 1
-    done
-    set -x
+		if [[ ${updated_pods_count} == $((pxc_size - 1)) ]]; then
+			if [[ -n $(get_pod_names_images "${cluster}" | grep "${initial_primary}" | grep "${IMAGE_PXC}") ]]; then
+				echo
+				echo "${initial_primary} is REALLY the last one to update"
+				break
+			else
+				echo "${initial_primary} is not the last one to update. Exiting..."
+				exit 1
+			fi
+		fi
+		sleep 1
+	done
+	set -x
 }
 
 function deploy_version_service {
-    desc 'install version service'
-    kubectl_bin create configmap versions \
-      --from-file "${test_dir}/conf/operator.9.9.9.pxc-operator.dep.json" \
-      --from-file "${test_dir}/conf/operator.9.9.9.pxc-operator.json"
-    kubectl_bin apply -f "${test_dir}/conf/vs.yml"
-    sleep 10
+	desc 'install version service'
+	kubectl_bin create configmap versions \
+		--from-file "${test_dir}/conf/operator.9.9.9.pxc-operator.dep.json" \
+		--from-file "${test_dir}/conf/operator.9.9.9.pxc-operator.json"
+	kubectl_bin apply -f "${test_dir}/conf/vs.yml"
+	sleep 10
 }
 
-
 function main() {
-    create_infra "${namespace}"
-    deploy_version_service
-    deploy_cert_manager
-    IMAGE_PXC=$(kubectl_bin exec -ti "$(get_operator_pod)" ${OPERATOR_NS:+-n $OPERATOR_NS} -- curl -s "${VS_URL}.${namespace}.svc.cluster.local:${VS_PORT}/versions/v1/pxc-operator/9.9.9" | jq -r '.versions[].matrix.pxc[].imagePath' | grep ":${PXC_VER}"| sort -V | tail -n3 | head -n1)
+	create_infra "${namespace}"
+	deploy_version_service
+	deploy_cert_manager
+	IMAGE_PXC=$(kubectl_bin exec -ti "$(get_operator_pod)" ${OPERATOR_NS:+-n $OPERATOR_NS} -- curl -s "${VS_URL}.${namespace}.svc.cluster.local:${VS_PORT}/versions/v1/pxc-operator/9.9.9" | jq -r '.versions[].matrix.pxc[].imagePath' | grep ":${PXC_VER}" | sort -V | tail -n3 | head -n1)
 
-    kubectl_bin patch crd perconaxtradbclusters.pxc.percona.com --type='json' -p '[{"op":"add","path":"/spec/versions/-", "value":{"name": "v9-9-9","schema": {"openAPIV3Schema": {"properties": {"spec": {"type": "object","x-kubernetes-preserve-unknown-fields": true},"status": {"type": "object", "x-kubernetes-preserve-unknown-fields": true}}, "type": "object" }}, "served": true, "storage": false, "subresources": { "status": {}}}}]'
+	kubectl_bin patch crd perconaxtradbclusters.pxc.percona.com --type='json' -p '[{"op":"add","path":"/spec/versions/-", "value":{"name": "v9-9-9","schema": {"openAPIV3Schema": {"properties": {"spec": {"type": "object","x-kubernetes-preserve-unknown-fields": true},"status": {"type": "object", "x-kubernetes-preserve-unknown-fields": true}}, "type": "object" }}, "served": true, "storage": false, "subresources": { "status": {}}}}]'
 
-    ##################################################
-    desc 'Updating ProxySQL PXC cluster'
-    cp -f "${test_dir}/conf/${CLUSTER}.yml" "${tmp_dir}/${CLUSTER}.yml"
-    yq w -i "${tmp_dir}/${CLUSTER}.yml" "spec.initImage" "${IMAGE}"
-    spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}.yml"
+	##################################################
+	desc 'Updating ProxySQL PXC cluster'
+	cp -f "${test_dir}/conf/${CLUSTER}.yml" "${tmp_dir}/${CLUSTER}.yml"
+	yq -i eval ".spec.initImage = \"${IMAGE}\"" "${tmp_dir}/${CLUSTER}.yml"
+	spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}.yml"
 
-    initial_primary=$(get_proxy_primary "-h127.0.0.1 -P6032 -uproxyadmin -padmin_password" "$(get_proxy ${CLUSTER})-0")
-    kubectl_bin patch pxc/"${CLUSTER}" --type=merge -p '{"spec":{"pxc":{"image":"'"${TARGET_IMAGE_PXC}"'"}}}'
-    sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
+	initial_primary=$(get_proxy_primary "-h127.0.0.1 -P6032 -uproxyadmin -padmin_password" "$(get_proxy ${CLUSTER})-0")
+	kubectl_bin patch pxc/"${CLUSTER}" --type=merge -p '{"spec":{"pxc":{"image":"'"${TARGET_IMAGE_PXC}"'"}}}'
+	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
 
-    check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC}"
-    wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
-    for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
-        compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
-    done
+	check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC}"
+	wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
+	for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
+		compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
+	done
 
-    kubectl_bin delete -f "${test_dir}/conf/${CLUSTER}.yml"
-    kubectl_bin delete pvc --all
+	kubectl_bin delete -f "${test_dir}/conf/${CLUSTER}.yml"
+	kubectl_bin delete pvc --all
 
-    ##################################################
-    desc 'Updating HAProxy PXC cluster'
-    cp -f "${test_dir}/conf/${CLUSTER}-haproxy.yml" "${tmp_dir}/${CLUSTER}-haproxy.yml"
-    yq w -i "${tmp_dir}/${CLUSTER}-haproxy.yml" "spec.initImage" "${IMAGE}"
-    spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-haproxy.yml"
+	##################################################
+	desc 'Updating HAProxy PXC cluster'
+	cp -f "${test_dir}/conf/${CLUSTER}-haproxy.yml" "${tmp_dir}/${CLUSTER}-haproxy.yml"
+	yq -i eval ".spec.initImage = \"${IMAGE}\"" "${tmp_dir}/${CLUSTER}-haproxy.yml"
+	spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-haproxy.yml"
 
-    initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
-    kubectl_bin patch pxc/${CLUSTER} --type=merge -p '{"spec":{"pxc":{"image":"'"${TARGET_IMAGE_PXC}"'"}}}'
-    sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
+	initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
+	kubectl_bin patch pxc/${CLUSTER} --type=merge -p '{"spec":{"pxc":{"image":"'"${TARGET_IMAGE_PXC}"'"}}}'
+	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
 
-    check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC}"
-    wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
-    for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
-        compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
-    done
+	check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC}"
+	wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
+	for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
+		compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
+	done
 
-    kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-haproxy.yml"
-    kubectl_bin delete pvc --all
+	kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-haproxy.yml"
+	kubectl_bin delete pvc --all
 
-    ##################################################
-    desc 'Updating PXC cluster with version service available but disabled'
-    cp -f "${test_dir}/conf/${CLUSTER}-version-service-reachable.yml" "${tmp_dir}/${CLUSTER}-version-service-reachable.yml"
-    yq w -i "${tmp_dir}/${CLUSTER}-version-service-reachable.yml" "spec.initImage" "${IMAGE}"
-    spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-version-service-reachable.yml"
+	##################################################
+	desc 'Updating PXC cluster with version service available but disabled'
+	cp -f "${test_dir}/conf/${CLUSTER}-version-service-reachable.yml" "${tmp_dir}/${CLUSTER}-version-service-reachable.yml"
+	yq -i eval ".spec.initImage = \"${IMAGE}\"" "${tmp_dir}/${CLUSTER}-version-service-reachable.yml"
+	spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-version-service-reachable.yml"
 
-    initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
-    kubectl_bin patch pxc/${CLUSTER} --type=merge -p '{"spec":{"pxc":{"image":"'"${TARGET_IMAGE_PXC}"'"}}}'
-    sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
+	initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
+	kubectl_bin patch pxc/${CLUSTER} --type=merge -p '{"spec":{"pxc":{"image":"'"${TARGET_IMAGE_PXC}"'"}}}'
+	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
 
-    check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC}"
-    wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
-    for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
-        compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
-    done
+	check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC}"
+	wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
+	for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
+		compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
+	done
 
-    kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-version-service-reachable.yml"
-    kubectl_bin delete pvc --all
+	kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-version-service-reachable.yml"
+	kubectl_bin delete pvc --all
 
-    ##################################################
-    desc 'PXC cluster with version service offline'
-    cp -f "${test_dir}/conf/${CLUSTER}-version-service-unreachable.yml" "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
-    yq w -i "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml" "spec.initImage" "${IMAGE}"
-    spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
+	##################################################
+	desc 'PXC cluster with version service offline'
+	cp -f "${test_dir}/conf/${CLUSTER}-version-service-unreachable.yml" "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
+	yq -i eval ".spec.initImage = \"${IMAGE}\"" "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
+	spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
 
-    wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
-    if [[ "$(kubectl_bin get pxc/${CLUSTER} -o jsonpath='{.spec.pxc.image}')" != "${IMAGE_PXC}" ]]; then
-        echo "ERROR: PXC image has been changed. Exiting..."
-        exit 1
-    fi
+	wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
+	if [[ "$(kubectl_bin get pxc/${CLUSTER} -o jsonpath='{.spec.pxc.image}')" != "${IMAGE_PXC}" ]]; then
+		echo "ERROR: PXC image has been changed. Exiting..."
+		exit 1
+	fi
 
-    ##################################################
-    desc 'PXC cluster update with recommended image by version service'
-    vs_image="recommended"
-    initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
+	##################################################
+	desc 'PXC cluster update with recommended image by version service'
+	vs_image="recommended"
+	initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
 
-    kubectl_bin patch pxc/"${CLUSTER}" --type=merge -p '{"spec":{"upgradeOptions":{"versionServiceEndpoint":"'${VS_ENDPOINT}'","apply":"'${vs_image}'","schedule": "* * * * *"}}}'
-    sleep 55
+	kubectl_bin patch pxc/"${CLUSTER}" --type=merge -p '{"spec":{"upgradeOptions":{"versionServiceEndpoint":"'${VS_ENDPOINT}'","apply":"'${vs_image}'","schedule": "* * * * *"}}}'
+	sleep 55
 
-    check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC_VS}"
-    wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
-    for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
-        compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
-    done
+	check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC_VS}"
+	wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
+	for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
+		compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
+	done
 
-    kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
-    kubectl_bin delete pvc --all
+	kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
+	kubectl_bin delete pvc --all
 
-    ##################################################
-    desc 'PXC cluster update with the latest image by version service'
-    spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
-    vs_image="latest"
-    initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
+	##################################################
+	desc 'PXC cluster update with the latest image by version service'
+	spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
+	vs_image="latest"
+	initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
 
-    kubectl_bin patch pxc/"${CLUSTER}" --type=merge -p '{"spec":{"upgradeOptions":{"versionServiceEndpoint":"'${VS_ENDPOINT}'","apply":"'${vs_image}'","schedule": "* * * * *"}}}'
-    sleep 55
+	kubectl_bin patch pxc/"${CLUSTER}" --type=merge -p '{"spec":{"upgradeOptions":{"versionServiceEndpoint":"'${VS_ENDPOINT}'","apply":"'${vs_image}'","schedule": "* * * * *"}}}'
+	sleep 55
 
-    check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC_VS}"
-    wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
-    for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
-        compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
-    done
+	check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "${TARGET_IMAGE_PXC_VS}"
+	wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
+	for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
+		compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
+	done
 
-    kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
-    kubectl_bin delete pvc --all
+	kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
+	kubectl_bin delete pvc --all
 
-    ##################################################
-    desc 'PXC cluster update with explicitly specified image inside version service'
-    spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
-    vs_image=$(kubectl_bin exec -ti "$(get_operator_pod)" ${OPERATOR_NS:+-n $OPERATOR_NS} -- curl -s "${VS_URL}.${namespace}.svc.cluster.local:${VS_PORT}/versions/v1/pxc-operator/9.9.9" | jq -r '.versions[].matrix.pxc[].imagePath' | grep ":${PXC_VER}"| sort -V | tail -n2 | head -n1)
-    initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
+	##################################################
+	desc 'PXC cluster update with explicitly specified image inside version service'
+	spinup_pxc "${CLUSTER}" "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
+	vs_image=$(kubectl_bin exec -ti "$(get_operator_pod)" ${OPERATOR_NS:+-n $OPERATOR_NS} -- curl -s "${VS_URL}.${namespace}.svc.cluster.local:${VS_PORT}/versions/v1/pxc-operator/9.9.9" | jq -r '.versions[].matrix.pxc[].imagePath' | grep ":${PXC_VER}" | sort -V | tail -n2 | head -n1)
+	initial_primary=$(run_mysql 'SELECT @@hostname hostname;' "-h ${CLUSTER}-haproxy -uroot -proot_password")
 
-    kubectl_bin patch pxc/"${CLUSTER}" --type=merge -p '{"spec":{"upgradeOptions":{"versionServiceEndpoint":"'${VS_ENDPOINT}'","apply":"'${vs_image}'","schedule": "* * * * *"}}}'
-    sleep 55
+	kubectl_bin patch pxc/"${CLUSTER}" --type=merge -p '{"spec":{"upgradeOptions":{"versionServiceEndpoint":"'${VS_ENDPOINT}'","apply":"'${vs_image}'","schedule": "* * * * *"}}}'
+	sleep 55
 
-    check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "percona/percona-xtradb-cluster:${vs_image}"
-    wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
-    for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
-        compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
-    done
+	check_last_pod_to_update "${CLUSTER}" "${initial_primary}" "${CLUSTER_SIZE}" "percona/percona-xtradb-cluster:${vs_image}"
+	wait_cluster_consistency "${CLUSTER}" "${CLUSTER_SIZE}" "${PROXY_SIZE}"
+	for i in $(seq 0 $((CLUSTER_SIZE - 1))); do
+		compare_mysql_cmd "select-1" "SELECT * from myApp.myApp;" "-h ${CLUSTER}-pxc-${i}.${CLUSTER}-pxc -uroot -proot_password"
+	done
 
-    kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
-    kubectl_bin delete pvc --all
+	kubectl_bin delete -f "${tmp_dir}/${CLUSTER}-version-service-unreachable.yml"
+	kubectl_bin delete pvc --all
 
-    desc 'cleanup'
-    kubectl_bin delete -f "${test_dir}/conf/vs.yml"
-    destroy "${namespace}"
+	desc 'cleanup'
+	kubectl_bin delete -f "${test_dir}/conf/vs.yml"
+	destroy "${namespace}"
 }
 
 main

--- a/e2e-tests/validation-hook/run
+++ b/e2e-tests/validation-hook/run
@@ -53,7 +53,7 @@ fi
 
 sleep 1
 
-if ! output=$(kubectl 2>&1 get pxc/simple-pxc -o yaml | yq r - spec.pxc.size); then
+if ! output=$(kubectl 2>&1 get pxc/simple-pxc -o yaml | yq eval ".spec.pxc.size" -); then
 	echo "ERROR: ${output}"
 elif ((output != replicas_num)); then
 	echo "ERROR: pxc did  ${output}"


### PR DESCRIPTION
[![CLOUD-666](https://badgen.net/badge/JIRA/CLOUD-666/green)](https://jira.percona.com/browse/CLOUD-666) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This should replace `yq v3` (which is not supported any more and doesn't have builds in some platforms) with `yq v4` for our E2E tests.