### PR TITLE
K8SPXC-1138 decrease the value for timeout in readiness/liveness

### DIFF
--- a/build/liveness-check.sh
+++ b/build/liveness-check.sh
@@ -20,7 +20,7 @@ MYSQL_PASSWORD="${mysql_pass:-$MONITOR_PASSWORD}"
 DEFAULTS_EXTRA_FILE=${DEFAULTS_EXTRA_FILE:-/etc/my.cnf}
 NODE_IP=$(hostname -I | awk ' { print $1 } ')
 #Timeout exists for instances where mysqld may be hung
-TIMEOUT=$((${LIVENESS_CHECK_TIMEOUTD:-5}-1))
+TIMEOUT=$((${LIVENESS_CHECK_TIMEOUTD:-5} - 1))
 
 EXTRA_ARGS=""
 if [[ -n $MYSQL_USERNAME ]]; then

--- a/build/liveness-check.sh
+++ b/build/liveness-check.sh
@@ -20,7 +20,7 @@ MYSQL_PASSWORD="${mysql_pass:-$MONITOR_PASSWORD}"
 DEFAULTS_EXTRA_FILE=${DEFAULTS_EXTRA_FILE:-/etc/my.cnf}
 NODE_IP=$(hostname -I | awk ' { print $1 } ')
 #Timeout exists for instances where mysqld may be hung
-TIMEOUT=$((${LIVENESS_CHECK_TIMEOUTD:-5} - 1))
+TIMEOUT=$((${LIVENESS_CHECK_TIMEOUT:-5} - 1))
 
 EXTRA_ARGS=""
 if [[ -n $MYSQL_USERNAME ]]; then

--- a/build/liveness-check.sh
+++ b/build/liveness-check.sh
@@ -20,7 +20,7 @@ MYSQL_PASSWORD="${mysql_pass:-$MONITOR_PASSWORD}"
 DEFAULTS_EXTRA_FILE=${DEFAULTS_EXTRA_FILE:-/etc/my.cnf}
 NODE_IP=$(hostname -I | awk ' { print $1 } ')
 #Timeout exists for instances where mysqld may be hung
-TIMEOUT=${LIVENESS_CHECK_TIMEOUT:-5}
+TIMEOUT=$((${LIVENESS_CHECK_TIMEOUTD:-5}-1))
 
 EXTRA_ARGS=""
 if [[ -n $MYSQL_USERNAME ]]; then

--- a/build/readiness-check.sh
+++ b/build/readiness-check.sh
@@ -18,7 +18,7 @@ AVAILABLE_WHEN_DONOR=${AVAILABLE_WHEN_DONOR:-1}
 NODE_IP=$(hostname -I | awk ' { print $1 } ')
 
 #Timeout exists for instances where mysqld may be hung
-TIMEOUT=$((${READINESS_CHECK_TIMEOUT:-10}-1))
+TIMEOUT=$((${READINESS_CHECK_TIMEOUT:-10} - 1))
 
 EXTRA_ARGS=""
 if [[ -n "$MYSQL_USERNAME" ]]; then

--- a/build/readiness-check.sh
+++ b/build/readiness-check.sh
@@ -18,7 +18,7 @@ AVAILABLE_WHEN_DONOR=${AVAILABLE_WHEN_DONOR:-1}
 NODE_IP=$(hostname -I | awk ' { print $1 } ')
 
 #Timeout exists for instances where mysqld may be hung
-TIMEOUT=${READINESS_CHECK_TIMEOUT:-10}
+TIMEOUT=$((${READINESS_CHECK_TIMEOUT:-10}-1))
 
 EXTRA_ARGS=""
 if [[ -n "$MYSQL_USERNAME" ]]; then


### PR DESCRIPTION
[![K8SPXC-1138](https://badgen.net/badge/JIRA/K8SPXC-1138/green)](https://jira.percona.com/browse/K8SPXC-1138) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* we need to use argument for a timeout command in
      readiness/liveness scripts a little bit less to avoid
      killing them by k8s