### PR TITLE
K8SPXC-1137: fix ProxySQL service update

### DIFF
--- a/pkg/pxc/service.go
+++ b/pkg/pxc/service.go
@@ -260,7 +260,7 @@ func NewServiceProxySQL(cr *api.PerconaXtraDBCluster) *corev1.Service {
 	return obj
 }
 
-func NewServiceHAProxy(cr *api.PerconaXtraDBCluster, owners ...metav1.OwnerReference) *corev1.Service {
+func NewServiceHAProxy(cr *api.PerconaXtraDBCluster) *corev1.Service {
 	svcType := corev1.ServiceTypeClusterIP
 	if cr.Spec.HAProxy != nil && len(cr.Spec.HAProxy.ServiceType) > 0 {
 		svcType = cr.Spec.HAProxy.ServiceType
@@ -289,11 +289,10 @@ func NewServiceHAProxy(cr *api.PerconaXtraDBCluster, owners ...metav1.OwnerRefer
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cr.HaproxyServiceNamespacedName().Name,
-			Namespace:       cr.Namespace,
-			Labels:          serviceLabels,
-			Annotations:     serviceAnnotations,
-			OwnerReferences: owners,
+			Name:        cr.HaproxyServiceNamespacedName().Name,
+			Namespace:   cr.Namespace,
+			Labels:      serviceLabels,
+			Annotations: serviceAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: svcType,
@@ -353,7 +352,7 @@ func NewServiceHAProxy(cr *api.PerconaXtraDBCluster, owners ...metav1.OwnerRefer
 	return obj
 }
 
-func NewServiceHAProxyReplicas(cr *api.PerconaXtraDBCluster, owners ...metav1.OwnerReference) *corev1.Service {
+func NewServiceHAProxyReplicas(cr *api.PerconaXtraDBCluster) *corev1.Service {
 	svcType := corev1.ServiceTypeClusterIP
 	if cr.Spec.HAProxy != nil && len(cr.Spec.HAProxy.ReplicasServiceType) > 0 {
 		svcType = cr.Spec.HAProxy.ReplicasServiceType
@@ -388,11 +387,10 @@ func NewServiceHAProxyReplicas(cr *api.PerconaXtraDBCluster, owners ...metav1.Ow
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            cr.HAProxyReplicasNamespacedName().Name,
-			Namespace:       cr.Namespace,
-			Labels:          serviceLabels,
-			Annotations:     serviceAnnotations,
-			OwnerReferences: owners,
+			Name:        cr.HAProxyReplicasNamespacedName().Name,
+			Namespace:   cr.Namespace,
+			Labels:      serviceLabels,
+			Annotations: serviceAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Type: svcType,


### PR DESCRIPTION
[![K8SPXC-1137](https://badgen.net/badge/JIRA/K8SPXC-1137/green)](https://jira.percona.com/browse/K8SPXC-1137) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-1137

PXC and HAProxy services were updated using `createOrUpdate` method, but not ProxySQL service
This PR removes redundant `createService` calls and removes this method