### PR TITLE
K8SPXC-1005: add pitr support for azure backups

### DIFF
--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"fmt"
 	"io"
@@ -16,7 +17,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/minio/minio-go/v7"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 
 	"github.com/percona/percona-xtradb-cluster-operator/cmd/pitr/pxc"
 	"github.com/percona/percona-xtradb-cluster-operator/cmd/pitr/storage"

--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/minio/minio-go/v7"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -119,10 +120,10 @@ func (c *Collector) Run(ctx context.Context) error {
 func (c *Collector) lastGTIDSet(ctx context.Context, sourceID string) (string, error) {
 	// get last binlog set stored on S3
 	lastSetObject, err := c.storage.GetObject(ctx, lastSetFilePrefix+sourceID)
-	if err == storage.ErrBlobNotFound {
-		return "", nil
-	}
 	if err != nil {
+		if bloberror.HasCode(errors.Cause(err), bloberror.BlobNotFound) {
+			return "", nil
+		}
 		return "", errors.Wrap(err, "get last set content")
 	}
 	lastSet, err := ioutil.ReadAll(lastSetObject)

--- a/cmd/pitr/main.go
+++ b/cmd/pitr/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -17,18 +19,19 @@ func main() {
 	if len(os.Args) > 1 {
 		command = os.Args[1]
 	}
+	ctx := context.Background()
 	switch command {
 	case "collect":
-		runCollector()
+		runCollector(ctx)
 	case "recover":
-		runRecoverer()
+		runRecoverer(ctx)
 	default:
 		fmt.Fprintf(os.Stderr, "ERROR: unknown command \"%s\".\nCommands:\n  collect - collect binlogs\n  recover - recover from binlogs\n", command)
 		os.Exit(1)
 	}
 }
 
-func runCollector() {
+func runCollector(ctx context.Context) {
 	config, err := getCollectorConfig()
 	if err != nil {
 		log.Fatalln("ERROR: get config:", err)
@@ -39,26 +42,32 @@ func runCollector() {
 	}
 	log.Println("run binlog collector")
 	for {
-		err := c.Run()
+		err := c.Run(ctx)
 		if err != nil {
 			log.Println("ERROR:", err)
 		}
 
-		time.Sleep(time.Duration(config.CollectSpanSec) * time.Second)
+		t := time.NewTimer(time.Duration(config.CollectSpanSec) * time.Second)
+		select {
+		case <-ctx.Done():
+			log.Fatalln("ERROR:", ctx.Err().Error())
+		case <-t.C:
+			break	
+		}
 	}
 }
 
-func runRecoverer() {
+func runRecoverer(ctx context.Context) {
 	config, err := getRecovererConfig()
 	if err != nil {
 		log.Fatalln("ERROR: get recoverer config:", err)
 	}
-	c, err := recoverer.New(config)
+	c, err := recoverer.New(ctx, config)
 	if err != nil {
 		log.Fatalln("ERROR: new recoverer controller:", err)
 	}
 	log.Println("run recover")
-	err = c.Run()
+	err = c.Run(ctx)
 	if err != nil {
 		log.Fatalln("ERROR: recover:", err)
 	}
@@ -67,6 +76,18 @@ func runRecoverer() {
 func getCollectorConfig() (collector.Config, error) {
 	cfg := collector.Config{}
 	err := env.Parse(&cfg)
+	switch cfg.StorageType {
+	case "s3":
+		if err := env.Parse(&cfg.BackupStorageS3); err != nil {
+			return cfg, err
+		}
+	case "azure":
+		if err := env.Parse(&cfg.BackupStorageAzure); err != nil {
+			return cfg, err
+		}
+	default:
+		return cfg, errors.New("unknown STORAGE_TYPE")
+	}
 
 	return cfg, err
 
@@ -77,11 +98,23 @@ func getRecovererConfig() (recoverer.Config, error) {
 	if err := env.Parse(&cfg); err != nil {
 		return cfg, err
 	}
-	if err := env.Parse(&cfg.BackupStorage); err != nil {
-		return cfg, err
-	}
-	if err := env.Parse(&cfg.BinlogStorage); err != nil {
-		return cfg, err
+	switch cfg.StorageType {
+	case "s3":
+		if err := env.Parse(&cfg.BackupStorageS3); err != nil {
+			return cfg, err
+		}
+		if err := env.Parse(&cfg.BinlogStorageS3); err != nil {
+			return cfg, err
+		}
+	case "azure":
+		if err := env.Parse(&cfg.BackupStorageAzure); err != nil {
+			return cfg, err
+		}
+		if err := env.Parse(&cfg.BinlogStorageAzure); err != nil {
+			return cfg, err
+		}
+	default:
+		return cfg, errors.New("unknown STORAGE_TYPE")
 	}
 
 	return cfg, nil

--- a/cmd/pitr/main.go
+++ b/cmd/pitr/main.go
@@ -52,7 +52,7 @@ func runCollector(ctx context.Context) {
 		case <-ctx.Done():
 			log.Fatalln("ERROR:", ctx.Err().Error())
 		case <-t.C:
-			break	
+			break
 		}
 	}
 }

--- a/cmd/pitr/main.go
+++ b/cmd/pitr/main.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/percona/percona-xtradb-cluster-operator/cmd/pitr/collector"
@@ -19,7 +21,8 @@ func main() {
 	if len(os.Args) > 1 {
 		command = os.Args[1]
 	}
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, os.Interrupt)
+	defer stop()
 	switch command {
 	case "collect":
 		runCollector(ctx)

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -2,6 +2,7 @@ package recoverer
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"log"
@@ -37,15 +38,57 @@ type Recoverer struct {
 }
 
 type Config struct {
-	PXCServiceName string `env:"PXC_SERVICE,required"`
-	PXCUser        string `env:"PXC_USER,required"`
-	PXCPass        string `env:"PXC_PASS,required"`
-	BackupStorage  BackupS3
-	RecoverTime    string `env:"PITR_DATE"`
-	RecoverType    string `env:"PITR_RECOVERY_TYPE,required"`
-	GTID           string `env:"PITR_GTID"`
-	VerifyTLS      bool   `env:"VERIFY_TLS" envDefault:"true"`
-	BinlogStorage  BinlogS3
+	PXCServiceName     string `env:"PXC_SERVICE,required"`
+	PXCUser            string `env:"PXC_USER,required"`
+	PXCPass            string `env:"PXC_PASS,required"`
+	BackupStorageS3    BackupS3
+	BackupStorageAzure BackupAzure
+	RecoverTime        string `env:"PITR_DATE"`
+	RecoverType        string `env:"PITR_RECOVERY_TYPE,required"`
+	GTID               string `env:"PITR_GTID"`
+	VerifyTLS          bool   `env:"VERIFY_TLS" envDefault:"true"`
+	StorageType        string `env:"STORAGE_TYPE,required"`
+	BinlogStorageS3    BinlogS3
+	BinlogStorageAzure BinlogAzure
+}
+
+func (c Config) storages() (storage.Storage, storage.Storage, error) {
+	var binlogStorage, defaultStorage storage.Storage
+	switch c.StorageType {
+	case "s3":
+		bucket, prefix, err := getBucketAndPrefix(c.BinlogStorageS3.BucketURL)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "get bucket and prefix")
+		}
+		binlogStorage, err = storage.NewS3(c.BinlogStorageS3.Endpoint, c.BinlogStorageS3.AccessKeyID, c.BinlogStorageS3.AccessKey, bucket, prefix, c.BinlogStorageS3.Region, c.VerifyTLS)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "new s3 storage")
+		}
+
+		bucket, prefix, err = getBucketAndPrefix(c.BackupStorageS3.BackupDest)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "get bucket and prefix")
+		}
+		prefix = prefix[:len(prefix)-1]
+		defaultStorage, err = storage.NewS3(c.BackupStorageS3.Endpoint, c.BackupStorageS3.AccessKeyID, c.BackupStorageS3.AccessKey, bucket, prefix+".sst_info/", c.BackupStorageS3.Region, c.VerifyTLS)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "new storage manager")
+		}
+	case "azure":
+		var err error
+		container, prefix := getContainerAndPrefix(c.BinlogStorageAzure.ContainerPath)
+		binlogStorage, err = storage.NewAzure(c.BinlogStorageAzure.AccountName, c.BinlogStorageAzure.AccountKey, c.BinlogStorageAzure.Endpoint, container, prefix+"/")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "new azure storage")
+		}
+		defaultStorage, err = storage.NewAzure(c.BackupStorageAzure.AccountName, c.BackupStorageAzure.AccountKey, c.BackupStorageAzure.Endpoint, c.BackupStorageAzure.ContainerName, c.BackupStorageAzure.BackupDest+".sst_info/")
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "new azure storage")
+		}
+	default:
+		return nil, nil, errors.New("unknown STORAGE_TYPE")
+	}
+	return binlogStorage, defaultStorage, nil
 }
 
 type BackupS3 struct {
@@ -56,6 +99,15 @@ type BackupS3 struct {
 	BackupDest  string `env:"S3_BUCKET_URL,required"`
 }
 
+type BackupAzure struct {
+	Endpoint      string `env:"AZURE_ENDPOINT,required"`
+	ContainerName string `env:"AZURE_CONTAINER_NAME,required"`
+	StorageClass  string `env:"AZURE_STORAGE_CLASS"`
+	AccountName   string `env:"AZURE_STORAGE_ACCOUNT,required"`
+	AccountKey    string `env:"AZURE_ACCESS_KEY,required"`
+	BackupDest    string `env:"BACKUP_PATH,required"`
+}
+
 type BinlogS3 struct {
 	Endpoint    string `env:"BINLOG_S3_ENDPOINT" envDefault:"s3.amazonaws.com"`
 	AccessKeyID string `env:"BINLOG_ACCESS_KEY_ID,required"`
@@ -64,30 +116,34 @@ type BinlogS3 struct {
 	BucketURL   string `env:"BINLOG_S3_BUCKET_URL,required"`
 }
 
+type BinlogAzure struct {
+	Endpoint      string `env:"BINLOG_AZURE_ENDPOINT,required"`
+	ContainerPath string `env:"BINLOG_AZURE_CONTAINER_NAME,required"`
+	StorageClass  string `env:"BINLOG_AZURE_STORAGE_CLASS"`
+	AccountName   string `env:"BINLOG_AZURE_STORAGE_ACCOUNT,required"`
+	AccountKey    string `env:"BINLOG_AZURE_ACCESS_KEY,required"`
+}
+
 func (c *Config) Verify() {
-	if len(c.BackupStorage.Endpoint) == 0 {
-		c.BackupStorage.Endpoint = "s3.amazonaws.com"
+	if len(c.BackupStorageS3.Endpoint) == 0 {
+		c.BackupStorageS3.Endpoint = "s3.amazonaws.com"
 	}
-	if len(c.BinlogStorage.Endpoint) == 0 {
-		c.BinlogStorage.Endpoint = "s3.amazonaws.com"
+	if len(c.BinlogStorageS3.Endpoint) == 0 {
+		c.BinlogStorageS3.Endpoint = "s3.amazonaws.com"
 	}
 }
 
 type RecoverType string
 
-func New(c Config) (*Recoverer, error) {
+func New(ctx context.Context, c Config) (*Recoverer, error) {
 	c.Verify()
-	bucket, prefix, err := getBucketAndPrefix(c.BinlogStorage.BucketURL)
+
+	binlogStorage, storage, err := c.storages()
 	if err != nil {
-		return nil, errors.Wrap(err, "get bucket and prefix")
+		return nil, errors.Wrap(err, "new binlog storage manager")
 	}
 
-	s3, err := storage.NewS3(strings.TrimPrefix(strings.TrimPrefix(c.BinlogStorage.Endpoint, "https://"), "http://"), c.BinlogStorage.AccessKeyID, c.BinlogStorage.AccessKey, bucket, prefix, c.BinlogStorage.Region, strings.HasPrefix(c.BinlogStorage.Endpoint, "https"), c.VerifyTLS)
-	if err != nil {
-		return nil, errors.Wrap(err, "new storage manager")
-	}
-
-	startGTID, err := getStartGTIDSet(c.BackupStorage, c.VerifyTLS)
+	startGTID, err := getStartGTIDSet(ctx, storage)
 	if err != nil {
 		return nil, errors.Wrap(err, "get start GTID")
 	}
@@ -117,7 +173,7 @@ func New(c Config) (*Recoverer, error) {
 	}
 
 	return &Recoverer{
-		storage:        s3,
+		storage:        binlogStorage,
 		recoverTime:    c.RecoverTime,
 		pxcUser:        c.PXCUser,
 		pxcPass:        c.PXCPass,
@@ -127,6 +183,11 @@ func New(c Config) (*Recoverer, error) {
 		gtid:           c.GTID,
 		verifyTLS:      c.VerifyTLS,
 	}, nil
+}
+
+func getContainerAndPrefix(s string) (string, string) {
+	container, prefix, _ := strings.Cut(s, "/")
+	return container, prefix
 }
 
 func getBucketAndPrefix(bucketURL string) (bucket string, prefix string, err error) {
@@ -155,48 +216,35 @@ func getBucketAndPrefix(bucketURL string) (bucket string, prefix string, err err
 	return bucket, prefix, err
 }
 
-func getStartGTIDSet(c BackupS3, verifyTLS bool) (string, error) {
-	bucketArr := strings.Split(c.BackupDest, "/")
-	if len(bucketArr) < 2 {
-		return "", errors.New("parsing bucket")
-	}
-
-	prefix := strings.TrimPrefix(c.BackupDest, bucketArr[0]+"/")
-	backupPrefix := prefix + "/"
-	sstPrefix := prefix + ".sst_info/"
-
-	s3, err := storage.NewS3(strings.TrimPrefix(strings.TrimPrefix(c.Endpoint, "https://"), "http://"), c.AccessKeyID, c.AccessKey, bucketArr[0], sstPrefix, c.Region, strings.HasPrefix(c.Endpoint, "https"), verifyTLS)
+func getStartGTIDSet(ctx context.Context, s storage.Storage) (string, error) {
+	sstInfo, err := s.ListObjects(ctx, "sst_info")
 	if err != nil {
-		return "", errors.Wrap(err, "new storage manager")
-	}
-	sstInfo, err := s3.ListObjects("sst_info")
-	if err != nil {
-		return "", errors.Wrapf(err, "list %s info fies", prefix)
+		return "", errors.Wrapf(err, "list objects")
 	}
 	if len(sstInfo) == 0 {
 		return "", errors.New("no info files in sst dir")
 	}
 	sort.Strings(sstInfo)
 
-	sstInfoObj, err := s3.GetObject(sstInfo[0])
+	sstInfoObj, err := s.GetObject(ctx, sstInfo[0])
 	if err != nil {
-		return "", errors.Wrapf(err, "get %s info", prefix)
+		return "", errors.Wrapf(err, "get object")
 	}
+	defer sstInfoObj.Close()
 
-	s3.SetPrefix(backupPrefix)
-
-	xtrabackupInfo, err := s3.ListObjects("xtrabackup_info")
+	s.SetPrefix(strings.TrimSuffix(s.GetPrefix(), ".sst_info/") + "/")
+	xtrabackupInfo, err := s.ListObjects(ctx, "xtrabackup_info")
 	if err != nil {
-		return "", errors.Wrapf(err, "list %s info fies", prefix)
+		return "", errors.Wrapf(err, "list objects")
 	}
 	if len(xtrabackupInfo) == 0 {
 		return "", errors.New("no info files in backup")
 	}
 	sort.Strings(xtrabackupInfo)
 
-	xtrabackupInfoObj, err := s3.GetObject(xtrabackupInfo[0])
+	xtrabackupInfoObj, err := s.GetObject(ctx, xtrabackupInfo[0])
 	if err != nil {
-		return "", errors.Wrapf(err, "get %s info", prefix)
+		return "", errors.Wrapf(err, "get object")
 	}
 
 	lastGTID, err := getLastBackupGTID(sstInfoObj, xtrabackupInfoObj)
@@ -214,7 +262,7 @@ const (
 	Skip        RecoverType = "skip"        // skip transactions
 )
 
-func (r *Recoverer) Run() error {
+func (r *Recoverer) Run(ctx context.Context) error {
 	host, err := pxc.GetPXCFirstHost(r.pxcServiceName)
 	if err != nil {
 		return errors.Wrap(err, "get host")
@@ -224,7 +272,7 @@ func (r *Recoverer) Run() error {
 		return errors.Wrapf(err, "new manager with host %s", host)
 	}
 
-	err = r.setBinlogs()
+	err = r.setBinlogs(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get binlog list")
 	}
@@ -248,7 +296,7 @@ func (r *Recoverer) Run() error {
 		return errors.New("wrong recover type")
 	}
 
-	err = r.recover()
+	err = r.recover(ctx)
 	if err != nil {
 		return errors.Wrap(err, "recover")
 	}
@@ -256,7 +304,7 @@ func (r *Recoverer) Run() error {
 	return nil
 }
 
-func (r *Recoverer) recover() (err error) {
+func (r *Recoverer) recover(ctx context.Context) (err error) {
 	err = r.db.DropCollectorFunctions()
 	if err != nil {
 		return errors.Wrap(err, "drop collector funcs")
@@ -278,7 +326,7 @@ func (r *Recoverer) recover() (err error) {
 			}
 		}
 
-		binlogObj, err := r.storage.GetObject(binlog)
+		binlogObj, err := r.storage.GetObject(ctx, binlog)
 		if err != nil {
 			return errors.Wrap(err, "get obj")
 		}
@@ -289,7 +337,7 @@ func (r *Recoverer) recover() (err error) {
 		}
 
 		cmdString := "mysqlbinlog --disable-log-bin" + r.recoverFlag + " - | mysql -h" + r.db.GetHost() + " -u" + r.pxcUser
-		cmd := exec.Command("sh", "-c", cmdString)
+		cmd := exec.CommandContext(ctx, "sh", "-c", cmdString)
 
 		cmd.Stdin = binlogObj
 		var outb, errb bytes.Buffer
@@ -386,7 +434,7 @@ func getDecompressedContent(infoObj io.Reader, filename string) ([]byte, error) 
 	cmd.Stderr = &errb
 	err := cmd.Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "xbsream cmd run. stderr: %s, stdout: %s", &errb, &outb)
+		return nil, errors.Wrapf(err, "xbstream cmd run. stderr: %s, stdout: %s", &errb, &outb)
 	}
 	if errb.Len() > 0 {
 		return nil, errors.Errorf("run xbstream error: %s", &errb)
@@ -400,8 +448,8 @@ func getDecompressedContent(infoObj io.Reader, filename string) ([]byte, error) 
 	return decContent, nil
 }
 
-func (r *Recoverer) setBinlogs() error {
-	list, err := r.storage.ListObjects("binlog_")
+func (r *Recoverer) setBinlogs(ctx context.Context) error {
+	list, err := r.storage.ListObjects(ctx, "binlog_")
 	if err != nil {
 		return errors.Wrap(err, "list objects with prefix 'binlog_'")
 	}
@@ -413,7 +461,7 @@ func (r *Recoverer) setBinlogs() error {
 		if strings.Contains(binlog, "-gtid-set") {
 			continue
 		}
-		infoObj, err := r.storage.GetObject(binlog + "-gtid-set")
+		infoObj, err := r.storage.GetObject(ctx, binlog+"-gtid-set")
 		if err != nil {
 			log.Println("Can't get binlog object with gtid set. Name:", binlog, "error", err)
 			continue

--- a/cmd/pitr/storage/storage.go
+++ b/cmd/pitr/storage/storage.go
@@ -127,14 +127,9 @@ func NewAzure(storageAccount, accessKey, endpoint, container, prefix string) (*A
 	}, nil
 }
 
-var ErrBlobNotFound = errors.New("blob not found")
-
 func (a *Azure) GetObject(ctx context.Context, name string) (io.ReadCloser, error) {
 	resp, err := a.client.DownloadStream(ctx, a.container, a.prefix+name, &azblob.DownloadStreamOptions{})
 	if err != nil {
-		if strings.Contains(err.Error(), "BlobNotFound") {
-			return nil, ErrBlobNotFound
-		}
 		return nil, errors.Wrapf(err, "download stream: %s", a.prefix+name)
 	}
 	return resp.Body, nil

--- a/cmd/pitr/storage/storage.go
+++ b/cmd/pitr/storage/storage.go
@@ -3,31 +3,37 @@ package storage
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/pkg/errors"
 )
 
 type Storage interface {
-	GetObject(objectName string) (io.Reader, error)
-	PutObject(name string, data io.Reader, size int64) error
-	ListObjects(prefix string) ([]string, error)
+	GetObject(ctx context.Context, objectName string) (io.ReadCloser, error)
+	PutObject(ctx context.Context, name string, data io.Reader, size int64) error
+	ListObjects(ctx context.Context, prefix string) ([]string, error)
+	SetPrefix(prefix string)
+	GetPrefix() string
 }
 
 // S3 is a type for working with S3 storages
 type S3 struct {
-	minioClient *minio.Client   // minio client for work with storage
-	ctx         context.Context // context for client operations
-	bucketName  string          // S3 bucket name where binlogs will be stored
-	prefix      string          // prefix for S3 requests
+	client     *minio.Client // minio client for work with storage
+	bucketName string        // S3 bucket name where binlogs will be stored
+	prefix     string        // prefix for S3 requests
 }
 
 // NewS3 return new Manager, useSSL using ssl for connection with storage
-func NewS3(endpoint, accessKeyID, secretAccessKey, bucketName, prefix, region string, useSSL, verifyTLS bool) (*S3, error) {
+func NewS3(endpoint, accessKeyID, secretAccessKey, bucketName, prefix, region string, verifyTLS bool) (*S3, error) {
+	useSSL := strings.Contains(endpoint, "https")
+	endpoint = strings.TrimPrefix(strings.TrimPrefix(endpoint, "https://"), "http://")
 	transport := http.DefaultTransport
 	transport.(*http.Transport).TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: !verifyTLS,
@@ -43,45 +49,40 @@ func NewS3(endpoint, accessKeyID, secretAccessKey, bucketName, prefix, region st
 	}
 
 	return &S3{
-		minioClient: minioClient,
-		ctx:         context.TODO(),
-		bucketName:  bucketName,
-		prefix:      prefix,
+		client:     minioClient,
+		bucketName: bucketName,
+		prefix:     prefix,
 	}, nil
 }
 
-func (s *S3) SetPrefix(prefix string) {
-	s.prefix = prefix
-}
-
 // GetObject return content by given object name
-func (s *S3) GetObject(objectName string) (io.Reader, error) {
-	oldObj, err := s.minioClient.GetObject(s.ctx, s.bucketName, s.prefix+objectName, minio.GetObjectOptions{})
+func (s *S3) GetObject(ctx context.Context, objectName string) (io.ReadCloser, error) {
+	oldObj, err := s.client.GetObject(ctx, s.bucketName, s.prefix+objectName, minio.GetObjectOptions{})
 	if err != nil {
-		return nil, errors.Wrap(err, "get object")
+		return nil, errors.Wrapf(err, "get object %s", s.prefix+objectName)
 	}
 
 	return oldObj, nil
 }
 
 // PutObject puts new object to storage with given name and content
-func (s *S3) PutObject(name string, data io.Reader, size int64) error {
-	_, err := s.minioClient.PutObject(s.ctx, s.bucketName, s.prefix+name, data, size, minio.PutObjectOptions{})
+func (s *S3) PutObject(ctx context.Context, name string, data io.Reader, size int64) error {
+	_, err := s.client.PutObject(ctx, s.bucketName, s.prefix+name, data, size, minio.PutObjectOptions{})
 	if err != nil {
-		return errors.Wrap(err, "put object")
+		return errors.Wrapf(err, "put object %s", s.prefix+name)
 	}
 
 	return nil
 }
 
-func (s *S3) ListObjects(prefix string) ([]string, error) {
+func (s *S3) ListObjects(ctx context.Context, prefix string) ([]string, error) {
 	opts := minio.ListObjectsOptions{
 		UseV1:  true,
 		Prefix: s.prefix + prefix,
 	}
 	list := []string{}
 
-	for object := range s.minioClient.ListObjects(s.ctx, s.bucketName, opts) {
+	for object := range s.client.ListObjects(ctx, s.bucketName, opts) {
 		if object.Err != nil {
 			return nil, errors.Wrapf(object.Err, "list object %s", object.Key)
 		}
@@ -89,4 +90,91 @@ func (s *S3) ListObjects(prefix string) ([]string, error) {
 	}
 
 	return list, nil
+}
+
+func (s *S3) SetPrefix(prefix string) {
+	s.prefix = prefix
+}
+
+func (s *S3) GetPrefix() string {
+	return s.prefix
+}
+
+// Azure is a type for working with Azure Blob storages
+type Azure struct {
+	client    *azblob.Client // azure client for work with storage
+	container string
+	prefix    string
+}
+
+func NewAzure(storageAccount, accessKey, endpoint, container, prefix string) (*Azure, error) {
+	credential, err := azblob.NewSharedKeyCredential(storageAccount, accessKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "new credentials")
+	}
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("https://%s.blob.core.windows.net/", storageAccount)
+	}
+	cli, err := azblob.NewClientWithSharedKeyCredential(endpoint, credential, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "new client")
+	}
+
+	return &Azure{
+		client:    cli,
+		container: container,
+		prefix:    prefix,
+	}, nil
+}
+
+var ErrBlobNotFound = errors.New("blob not found")
+
+func (a *Azure) GetObject(ctx context.Context, name string) (io.ReadCloser, error) {
+	resp, err := a.client.DownloadStream(ctx, a.container, a.prefix+name, &azblob.DownloadStreamOptions{})
+	if err != nil {
+		if strings.Contains(err.Error(), "BlobNotFound") {
+			return nil, ErrBlobNotFound
+		}
+		return nil, errors.Wrapf(err, "download stream: %s", a.prefix+name)
+	}
+	return resp.Body, nil
+}
+
+func (a *Azure) PutObject(ctx context.Context, name string, data io.Reader, _ int64) error {
+	_, err := a.client.UploadStream(ctx, a.container, a.prefix+name, data, nil)
+	if err != nil {
+		return errors.Wrapf(err, "upload stream: %s", a.prefix+name)
+	}
+	return nil
+}
+
+func (a *Azure) ListObjects(ctx context.Context, prefix string) ([]string, error) {
+	listPrefix := a.prefix + prefix
+	pg := a.client.NewListBlobsFlatPager(a.container, &container.ListBlobsFlatOptions{
+		Prefix: &listPrefix,
+	})
+	var blobs []string
+	for pg.More() {
+		resp, err := pg.NextPage(ctx)
+		if err != nil {
+			return nil, errors.Wrapf(err, "next page: %s", prefix)
+		}
+		if resp.Segment != nil {
+			for _, item := range resp.Segment.BlobItems {
+				if item != nil && item.Name != nil {
+					name := strings.TrimPrefix(*item.Name, a.prefix)
+					blobs = append(blobs, name)
+				}
+			}
+		}
+	}
+	return blobs, nil
+}
+
+func (a *Azure) SetPrefix(prefix string) {
+	a.prefix = prefix
+}
+
+func (a *Azure) GetPrefix() string {
+	return a.prefix
 }

--- a/e2e-tests/pitr/conf/pitr.yml
+++ b/e2e-tests/pitr/conf/pitr.yml
@@ -67,7 +67,7 @@ spec:
         type: filesystem
         volume:
           persistentVolumeClaim:
-            accessModes: [ "ReadWriteOnce" ]
+            accessModes: ["ReadWriteOnce"]
             resources:
               requests:
                 storage: 1Gi
@@ -105,3 +105,13 @@ spec:
           region: us-east-1
           bucket: operator-testing/binlog-cluster1
           endpointUrl: https://storage.googleapis.com
+      azure-blob:
+        type: azure
+        azure:
+          credentialsSecret: azure-secret
+          container: operator-testing
+      azure-blob-binlogs:
+        type: azure
+        azure:
+          credentialsSecret: azure-secret
+          container: operator-testing/binlogs

--- a/pkg/apis/pxc/v1/pxc_prestore_types.go
+++ b/pkg/apis/pxc/v1/pxc_prestore_types.go
@@ -73,8 +73,8 @@ func (cr *PerconaXtraDBClusterRestore) CheckNsetDefaults() error {
 	if cr.Spec.PXCCluster == "" {
 		return errors.New("pxcCluster can't be empty")
 	}
-	if cr.Spec.PITR != nil && cr.Spec.PITR.BackupSource != nil && cr.Spec.PITR.BackupSource.StorageName == "" && cr.Spec.PITR.BackupSource.S3 == nil {
-		return errors.New("PITR.BackupSource.StorageName and PITR.BackupSource.S3 can't be empty simultaneously")
+	if cr.Spec.PITR != nil && cr.Spec.PITR.BackupSource != nil && cr.Spec.PITR.BackupSource.StorageName == "" && cr.Spec.PITR.BackupSource.S3 == nil && cr.Spec.PITR.BackupSource.Azure == nil {
+		return errors.New("PITR.BackupSource.StorageName, PITR.BackupSource.S3 and PITR.BackupSource.Azure can't be empty simultaneously")
 	}
 	if cr.Spec.BackupName == "" && cr.Spec.BackupSource == nil {
 		return errors.New("backupName and BackupSource can't be empty simultaneously")

--- a/pkg/pxc/app/deployment/binlog-collector.go
+++ b/pkg/pxc/app/deployment/binlog-collector.go
@@ -36,6 +36,9 @@ func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster) (appsv1.Deployme
 		labels[key] = value
 	}
 	envs, err := getStorageEnvs(cr)
+	if err != nil {
+		return appsv1.Deployment{}, errors.Wrap(err, "get storage envs")
+	}
 	envs = append(envs, []corev1.EnvVar{
 		{
 			Name:  "PXC_SERVICE",

--- a/pkg/pxc/app/deployment/binlog-collector.go
+++ b/pkg/pxc/app/deployment/binlog-collector.go
@@ -9,13 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/pkg/errors"
+
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
-	"github.com/pkg/errors"
 )
 
 func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster) (appsv1.Deployment, error) {
-	storage := cr.Spec.Backup.Storages[cr.Spec.Backup.PITR.StorageName]
 	binlogCollectorName := GetBinlogCollectorDeploymentName(cr)
 	pxcUser := "xtrabackup"
 	sleepTime := fmt.Sprintf("%.2f", cr.Spec.Backup.PITR.TimeBetweenUploads)
@@ -35,26 +35,8 @@ func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster) (appsv1.Deployme
 	for key, value := range cr.Spec.Backup.Storages[cr.Spec.Backup.PITR.StorageName].Labels {
 		labels[key] = value
 	}
-	if storage.S3 == nil {
-		return appsv1.Deployment{}, errors.New("s3 storage is not specified")
-	}
-	envs := []corev1.EnvVar{
-		{
-			Name: "SECRET_ACCESS_KEY",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(storage.S3.CredentialsSecret, "AWS_SECRET_ACCESS_KEY"),
-			},
-		},
-		{
-			Name: "ACCESS_KEY_ID",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(storage.S3.CredentialsSecret, "AWS_ACCESS_KEY_ID"),
-			},
-		},
-		{
-			Name:  "S3_BUCKET_URL",
-			Value: storage.S3.Bucket,
-		},
+	envs, err := getStorageEnvs(cr)
+	envs = append(envs, []corev1.EnvVar{
 		{
 			Name:  "PXC_SERVICE",
 			Value: cr.Name + "-pxc",
@@ -70,10 +52,6 @@ func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster) (appsv1.Deployme
 			},
 		},
 		{
-			Name:  "DEFAULT_REGION",
-			Value: cr.Spec.Backup.Storages[cr.Spec.Backup.PITR.StorageName].S3.Region,
-		},
-		{
 			Name:  "COLLECT_SPAN_SEC",
 			Value: sleepTime,
 		},
@@ -81,13 +59,7 @@ func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster) (appsv1.Deployme
 			Name:  "BUFFER_SIZE",
 			Value: strconv.FormatInt(bufferSize, 10),
 		},
-	}
-	if len(storage.S3.EndpointURL) > 0 {
-		envs = append(envs, corev1.EnvVar{
-			Name:  "ENDPOINT",
-			Value: storage.S3.EndpointURL,
-		})
-	}
+	}...)
 	container := corev1.Container{
 		Name:            "pitr",
 		Image:           cr.Spec.Backup.Image,
@@ -144,6 +116,85 @@ func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster) (appsv1.Deployme
 			},
 		},
 	}, nil
+}
+
+func getStorageEnvs(cr *api.PerconaXtraDBCluster) ([]corev1.EnvVar, error) {
+	storage := cr.Spec.Backup.Storages[cr.Spec.Backup.PITR.StorageName]
+	switch storage.Type {
+	case api.BackupStorageS3:
+		if storage.S3 == nil {
+			return nil, errors.New("s3 storage is not specified")
+		}
+		envs := []corev1.EnvVar{
+			{
+				Name: "SECRET_ACCESS_KEY",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: app.SecretKeySelector(storage.S3.CredentialsSecret, "AWS_SECRET_ACCESS_KEY"),
+				},
+			},
+			{
+				Name: "ACCESS_KEY_ID",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: app.SecretKeySelector(storage.S3.CredentialsSecret, "AWS_ACCESS_KEY_ID"),
+				},
+			},
+			{
+				Name:  "S3_BUCKET_URL",
+				Value: storage.S3.Bucket,
+			},
+			{
+				Name:  "DEFAULT_REGION",
+				Value: storage.S3.Region,
+			},
+			{
+				Name:  "STORAGE_TYPE",
+				Value: "s3",
+			},
+		}
+		if len(storage.S3.EndpointURL) > 0 {
+			envs = append(envs, corev1.EnvVar{
+				Name:  "ENDPOINT",
+				Value: storage.S3.EndpointURL,
+			})
+		}
+		return envs, nil
+	case api.BackupStorageAzure:
+		if storage.Azure == nil {
+			return nil, errors.New("azure storage is not specified")
+		}
+		return []corev1.EnvVar{
+			{
+				Name: "AZURE_STORAGE_ACCOUNT",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: app.SecretKeySelector(storage.Azure.CredentialsSecret, "AZURE_STORAGE_ACCOUNT_NAME"),
+				},
+			},
+			{
+				Name: "AZURE_ACCESS_KEY",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: app.SecretKeySelector(storage.Azure.CredentialsSecret, "AZURE_STORAGE_ACCOUNT_KEY"),
+				},
+			},
+			{
+				Name:  "AZURE_STORAGE_CLASS",
+				Value: storage.Azure.StorageClass,
+			},
+			{
+				Name:  "AZURE_CONTAINER_NAME",
+				Value: storage.Azure.ContainerName,
+			},
+			{
+				Name:  "AZURE_ENDPOINT",
+				Value: storage.Azure.Endpoint,
+			},
+			{
+				Name:  "STORAGE_TYPE",
+				Value: "azure",
+			},
+		}, nil
+	default:
+		return nil, errors.Errorf("%s storage has unsupported type %s", cr.Spec.Backup.PITR.StorageName, storage.Type)
+	}
 }
 
 func GetBinlogCollectorDeploymentName(cr *api.PerconaXtraDBCluster) string {


### PR DESCRIPTION
[![K8SPXC-1005](https://badgen.net/badge/JIRA/K8SPXC-1005/green)](https://jira.percona.com/browse/K8SPXC-1005) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-1005

Changes in `cmd/pitr`:

- Added `ctx` which can be cancelled via SIGTERM
- Use `ctx` in all functions instead of `context.TODO()`
- Added azure client which implements `Storage` interface
- Added azure env vars to `recoverer` and `collector` configs
- Added `STORAGE_TYPE` env var to determine which storage type is used

It's possible to specify binlog storage path in `container` field like `<container-name>/<prefix>`

Changes in operator:
- Added `STORAGE_TYPE` env var to restore jobs and to binlog collector deployment
