### PR TITLE
K8SPXC-1142: Don't use unready service for users management

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -884,6 +884,11 @@ kubectl_bin() {
 			break
 		fi
 	done
+	if [[ ${exit_status} > 0 ]]; then
+		set +e
+		kubectl get pods
+		set -e
+	fi
 	cat "$LAST_OUT"
 	cat "$LAST_ERR" >&2
 	rm "$LAST_OUT" "$LAST_ERR"

--- a/e2e-tests/pitr/run
+++ b/e2e-tests/pitr/run
@@ -60,6 +60,7 @@ write_test_data() {
 		'INSERT test.test (id) VALUES (100500); INSERT test.test (id) VALUES (100501); INSERT test.test (id) VALUES (100502);' \
 		"-h $proxy -uroot -proot_password"
 	sleep 30
+	wait_for_running "$cluster-pxc" 3
 	for i in $(seq 0 $((size - 1))); do
 		compare_mysql_cmd "select-3" "SELECT * from test.test;" "-h $cluster-pxc-$i.$cluster-pxc -uroot -proot_password"
 	done

--- a/pkg/controller/pxc/users.go
+++ b/pkg/controller/pxc/users.go
@@ -257,8 +257,10 @@ func (r *ReconcilePerconaXtraDBCluster) manageOperatorAdminUser(cr *api.PerconaX
 		return errors.Wrap(err, "generate password")
 	}
 	addr := cr.Name + "-pxc." + cr.Namespace
-	if cr.CompareVersionWith("1.6.0") >= 0 {
+	if cr.CompareVersionWith("1.6.0") >= 0 && cr.CompareVersionWith("1.12.0") < 0 {
 		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+	} else if cr.CompareVersionWith("1.12.0") >= 0 {
+		addr = cr.Name + "-pxc." + cr.Namespace + ":33062"
 	}
 	um, err := users.NewManager(addr, users.Root, string(secrets.Data[users.Root]), cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
 	if err != nil {
@@ -313,7 +315,11 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(cr *api.PerconaXtraDBC
 		return errors.Wrap(err, "check if congfig has proxy_protocol_networks key")
 	}
 	if hasKey {
-		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+		if cr.CompareVersionWith("1.12.0") >= 0 {
+			addr = cr.Name + "-pxc." + cr.Namespace + ":33062"
+		} else {
+			addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+		}
 	}
 
 	um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
@@ -453,16 +459,20 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUser(cr *api.PerconaXt
 					pxcUser = users.Operator
 					pxcPass = string(internalSecrets.Data[users.Operator])
 				}
-			
+
 				addr := cr.Name + "-pxc-unready." + cr.Namespace + ":3306"
 				hasKey, err := cr.ConfigHasKey("mysqld", "proxy_protocol_networks")
 				if err != nil {
 					return errors.Wrap(err, "check if congfig has proxy_protocol_networks key")
 				}
 				if hasKey {
-					addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+					if cr.CompareVersionWith("1.12.0") >= 0 {
+						addr = cr.Name + "-pxc." + cr.Namespace + ":33062"
+					} else {
+						addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+					}
 				}
-			
+
 				um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
 				if err != nil {
 					return errors.Wrap(err, "new users manager for grant")
@@ -567,7 +577,11 @@ func (r *ReconcilePerconaXtraDBCluster) updateXtrabackupUserGrant(cr *api.Percon
 		return errors.Wrap(err, "check if congfig has proxy_protocol_networks key")
 	}
 	if hasKey {
-		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+		if cr.CompareVersionWith("1.12.0") >= 0 {
+			addr = cr.Name + "-pxc." + cr.Namespace + ":33062"
+		} else {
+			addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+		}
 	}
 
 	um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
@@ -664,8 +678,10 @@ func (r *ReconcilePerconaXtraDBCluster) manageReplicationUser(cr *api.PerconaXtr
 	}
 
 	addr := cr.Name + "-pxc." + cr.Namespace
-	if cr.CompareVersionWith("1.6.0") >= 0 {
+	if cr.CompareVersionWith("1.6.0") >= 0 && cr.CompareVersionWith("1.12.0") < 0 {
 		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+	} else if cr.CompareVersionWith("1.12.0") >= 0 {
+		addr = cr.Name + "-pxc." + cr.Namespace + ":33062"
 	}
 
 	pxcUser := "root"
@@ -830,9 +846,12 @@ func (r *ReconcilePerconaXtraDBCluster) updateUserPass(cr *api.PerconaXtraDBClus
 	}
 
 	addr := cr.Name + "-pxc." + cr.Namespace
-	if cr.CompareVersionWith("1.6.0") >= 0 {
+	if cr.CompareVersionWith("1.6.0") >= 0 && cr.CompareVersionWith("1.12.0") < 0 {
 		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+	} else if cr.CompareVersionWith("1.12.0") >= 0 {
+		addr = cr.Name + "-pxc." + cr.Namespace + ":33062"
 	}
+
 	um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
 	if err != nil {
 		return errors.Wrap(err, "new users manager")


### PR DESCRIPTION
[![K8SPXC-1142](https://badgen.net/badge/JIRA/K8SPXC-1142/green)](https://jira.percona.com/browse/K8SPXC-1142) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

