### PR TITLE
K8SPXC-1005: fix azure binlog storage

### DIFF
--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -82,7 +82,10 @@ func New(c Config) (*Collector, error) {
 		}
 	case "azure":
 		container, prefix, _ := strings.Cut(c.BackupStorageAzure.ContainerPath, "/")
-		s, err = storage.NewAzure(c.BackupStorageAzure.AccountName, c.BackupStorageAzure.AccountKey, c.BackupStorageAzure.Endpoint, container, prefix+"/")
+		if prefix != "" {
+			prefix += "/"
+		}
+		s, err = storage.NewAzure(c.BackupStorageAzure.AccountName, c.BackupStorageAzure.AccountKey, c.BackupStorageAzure.Endpoint, container, prefix)
 		if err != nil {
 			return nil, errors.Wrap(err, "new azure storage")
 		}

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -77,7 +77,7 @@ func (c Config) storages() (storage.Storage, storage.Storage, error) {
 	case "azure":
 		var err error
 		container, prefix := getContainerAndPrefix(c.BinlogStorageAzure.ContainerPath)
-		binlogStorage, err = storage.NewAzure(c.BinlogStorageAzure.AccountName, c.BinlogStorageAzure.AccountKey, c.BinlogStorageAzure.Endpoint, container, prefix+"/")
+		binlogStorage, err = storage.NewAzure(c.BinlogStorageAzure.AccountName, c.BinlogStorageAzure.AccountKey, c.BinlogStorageAzure.Endpoint, container, prefix)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "new azure storage")
 		}
@@ -187,6 +187,9 @@ func New(ctx context.Context, c Config) (*Recoverer, error) {
 
 func getContainerAndPrefix(s string) (string, string) {
 	container, prefix, _ := strings.Cut(s, "/")
+	if prefix != "" {
+		prefix += "/"
+	}
 	return container, prefix
 }
 


### PR DESCRIPTION
https://jira.percona.com/browse/K8SPXC-1005

PITR was failing when azure binlog storage's `container`  field contained only the container name, without subdirs