### PR TITLE
K8SPXC-1113: dual passwords (#1268)

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -896,11 +896,6 @@ kubectl_bin() {
 			break
 		fi
 	done
-	if [[ ${exit_status} > 0 ]]; then
-		set +e
-		kubectl get pods
-		set -e
-	fi
 	cat "$LAST_OUT"
 	cat "$LAST_ERR" >&2
 	rm "$LAST_OUT" "$LAST_ERR"

--- a/e2e-tests/users/conf/some-name.yml
+++ b/e2e-tests/users/conf/some-name.yml
@@ -42,7 +42,7 @@ spec:
       maxUnavailable: 2
   proxysql:
     enabled: false
-    size: 1
+    size: 2
     image: -proxysql
     resources:
       requests:

--- a/e2e-tests/users/run
+++ b/e2e-tests/users/run
@@ -6,6 +6,51 @@ set -o xtrace
 test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
+is_password_updated() {
+	local username=$1
+	local uri=$2
+	run_mysql "SELECT User_attributes FROM mysql.user WHERE user='${username}'" "${uri}" | grep additional_password
+}
+
+is_old_password_discarded() {
+	local username=$1
+	local uri=$2
+	run_mysql "SELECT User_attributes FROM mysql.user WHERE user='${username}'" "${uri}" | grep NULL
+}
+
+wait_for_password_propagation() {
+	local secret=$1
+	local user=$2
+	local max_retry="${3:-240}"
+	local root_pass=$(getSecretData "${secret}" "root")
+
+	if [[ $IMAGE_PXC =~ 5\.7 ]]; then
+		echo "Skipping dual password feature doesn't work for 5.7. PXC 5.7 doesn't support it!"
+		return
+	fi
+	retry=0
+	until is_password_updated "${user}" "-h ${cluster}-pxc -uroot -p'${root_pass}'"; do
+		echo "waiting for password update"
+		sleep 1
+		let retry+=1
+		if [[ $retry -ge $max_retry ]]; then
+			echo max retry count $retry reached. something went wrong with operator or kubernetes cluster
+			exit 1
+		fi
+	done
+
+	retry=0
+	until is_old_password_discarded "${user}" "-h ${cluster}-pxc -uroot -p'${root_pass}'"; do
+		echo "waiting for password propagation"
+		sleep 1
+		let retry+=1
+		if [[ $retry -ge $max_retry ]]; then
+			echo max retry count $retry reached. something went wrong with operator or kubernetes cluster
+			exit 1
+		fi
+	done
+}
+
 create_infra $namespace
 
 desc 'create PXC cluster'
@@ -33,41 +78,44 @@ compare_mysql_cmd_local "select-2" "SHOW TABLES;" "-h127.0.0.1 -P6032 -uproxyadm
 compare_mysql_cmd_local "select-2" "SHOW TABLES;" "-h127.0.0.1 -P6032 -uproxyadmin -p'$newpass'" "$cluster-proxysql-2" "" 'proxysql'
 
 desc 'test xtrabackup'
-kubectl_bin patch pxc some-name --type=merge -p="{\"spec\":{\"proxysql\":{\"size\":1}}}"
+kubectl_bin patch pxc some-name --type=merge -p="{\"spec\":{\"proxysql\":{\"size\":2}}}"
 patch_secret "my-cluster-secrets" "xtrabackup" "$newpassencrypted"
-sleep 30
+sleep 15
 wait_cluster_consistency "$cluster" 3 2
 compare_mysql_cmd_local "select-3" "SHOW DATABASES;" "-h 127.0.0.1 -uxtrabackup -p'$newpass'" "$cluster-pxc-0" "" 'pxc'
 
 desc 'test clustercheck'
 patch_secret "my-cluster-secrets" "clustercheck" "$newpassencrypted"
-sleep 30
+sleep 15
 wait_cluster_consistency "$cluster" 3 2
 compare_mysql_cmd_local "select-5" "SHOW DATABASES;" "-h 127.0.0.1 -uclustercheck -p'$newpass'" "$cluster-pxc-0" "" 'pxc'
 
 desc 'test monitor'
 patch_secret "my-cluster-secrets" "monitor" "$newpassencrypted"
-sleep 30
+wait_for_password_propagation "my-cluster-secrets" "monitor"
 wait_cluster_consistency "$cluster" 3 2
+sleep 10 # give some time for proxy-admin --syncusers
 compare_mysql_cmd "select-4" "SHOW TABLES;" "-h $cluster-proxysql -umonitor -p'$newpass'"
 
 desc 'test operator'
 patch_secret "my-cluster-secrets" "operator" "$newpassencrypted"
-sleep 30
+sleep 15
 wait_cluster_consistency "$cluster" 3 2
+sleep 10 # give some time for proxy-admin --syncusers
 compare_mysql_cmd "select-4" "SHOW TABLES;" "-h $cluster-proxysql -uoperator -p'$newpass'"
 
 desc 'change secret name'
 kubectl_bin patch pxc $cluster --type merge --patch '{"spec": {"secretsName":"my-cluster-secrets-2"}}'
 sleep 30
 wait_cluster_consistency "$cluster" 3 2
-newpass="test-password2"
-newpassencrypted=$(echo -n "$newpass" | base64)
 
 desc 'test new operator'
+newpass="test-password2"
+newpassencrypted=$(echo -n "$newpass" | base64)
 patch_secret "my-cluster-secrets-2" "operator" "$newpassencrypted"
-sleep 30
+sleep 15
 wait_cluster_consistency "$cluster" 3 2
+sleep 10 # give some time for proxy-admin --syncusers
 compare_mysql_cmd "select-4" "SHOW TABLES;" "-h $cluster-proxysql -uoperator -p'$newpass'"
 
 newpass=$(getSecretData "my-cluster-secrets-2" "root")

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
 	go.uber.org/zap v1.23.0
+	golang.org/x/sync v0.1.0
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3
 	k8s.io/client-go v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -618,6 +618,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -292,14 +292,12 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 
 	userReconcileResult := &ReconcileUsersResult{}
 
-	if o.CompareVersionWith("1.5.0") >= 0 {
-		urr, err := r.reconcileUsers(o)
-		if err != nil {
-			return rr, errors.Wrap(err, "reconcile users")
-		}
-		if urr != nil {
-			userReconcileResult = urr
-		}
+	urr, err := r.reconcileUsers(o)
+	if err != nil {
+		return rr, errors.Wrap(err, "reconcile users")
+	}
+	if urr != nil {
+		userReconcileResult = urr
 	}
 
 	r.resyncPXCUsersWithProxySQL(o)

--- a/pkg/controller/pxc/users.go
+++ b/pkg/controller/pxc/users.go
@@ -10,18 +10,24 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app/statefulset"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 )
 
+var mysql80 = version.Must(version.NewVersion("8.0.0"))
+
 // https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_system-user
 var privSystemUserAddedIn = version.Must(version.NewVersion("8.0.16"))
+
+var PassNotPropagatedError = errors.New("password not yet propagated")
 
 type userUpdateActions struct {
 	restartPXC            bool
@@ -36,6 +42,8 @@ type ReconcileUsersResult struct {
 }
 
 func (r *ReconcilePerconaXtraDBCluster) reconcileUsers(cr *api.PerconaXtraDBCluster) (*ReconcileUsersResult, error) {
+	logger := r.logger(cr.Name, cr.Namespace)
+
 	secrets := corev1.Secret{}
 	err := r.client.Get(context.TODO(),
 		types.NamespacedName{
@@ -77,13 +85,34 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileUsers(cr *api.PerconaXtraDBClus
 		return nil, nil
 	}
 
-	if cr.Status.Status != api.AppStateReady {
-		return nil, nil
+	mysqlVersion := cr.Status.PXC.Version
+	if mysqlVersion == "" {
+		var err error
+		mysqlVersion, err = r.mysqlVersion(cr, statefulset.NewNode(cr))
+		if err != nil {
+			if errors.Is(err, versionNotReadyErr) {
+				return nil, nil
+			}
+			return nil, errors.Wrap(err, "retrieving pxc version")
+		}
 	}
 
-	actions, err := r.updateUsers(cr, &secrets, &internalSecrets)
+	ver, err := version.NewVersion(mysqlVersion)
 	if err != nil {
-		return nil, errors.Wrap(err, "manage sys users")
+		return nil, errors.Wrap(err, "invalid pxc version")
+	}
+
+	var actions *userUpdateActions
+	if ver.GreaterThanOrEqual(mysql80) {
+		actions, err = r.updateUsers(cr, &secrets, &internalSecrets)
+		if err != nil {
+			return nil, errors.Wrap(err, "manage sys users")
+		}
+	} else {
+		actions, err = r.updateUsersWithoutDP(cr, &secrets, &internalSecrets)
+		if err != nil {
+			return nil, errors.Wrap(err, "manage sys users")
+		}
 	}
 
 	newSysData, err := json.Marshal(secrets.Data)
@@ -97,9 +126,11 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileUsers(cr *api.PerconaXtraDBClus
 	}
 
 	if actions.restartProxy {
+		logger.Info("Proxy pods will be restarted", "last-applied-secret", newSecretDataHash)
 		result.proxysqlAnnotations = map[string]string{"last-applied-secret": newSecretDataHash}
 	}
 	if actions.restartPXC {
+		logger.Info("PXC pods will be restarted", "last-applied-secret", newSecretDataHash)
 		result.pxcAnnotations = map[string]string{"last-applied-secret": newSecretDataHash}
 	}
 
@@ -129,6 +160,9 @@ func (r *ReconcilePerconaXtraDBCluster) updateUsers(cr *api.PerconaXtraDBCluster
 			}
 		case users.Monitor:
 			if err := r.handleMonitorUser(cr, secrets, internalSecrets, res); err != nil {
+				if errors.Is(err, PassNotPropagatedError) {
+					continue
+				}
 				return res, err
 			}
 		case users.Clustercheck:
@@ -166,13 +200,32 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUser(cr *api.PerconaXtraDBClus
 		Hosts: []string{"localhost", "%"},
 	}
 
-	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	passDiscarded, err := r.isOldPasswordDiscarded(cr, internalSecrets, user)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && passDiscarded {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && !passDiscarded {
+		err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+		if err != nil {
+			return errors.Wrap(err, "discard old pass")
+		}
+		logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+
 		return nil
 	}
 
 	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
-	err := r.updateUserPass(cr, secrets, internalSecrets, user)
+	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update root users pass")
 	}
@@ -183,12 +236,19 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUser(cr *api.PerconaXtraDBClus
 		return errors.Wrap(err, "sync users")
 	}
 
+	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
-	err = r.client.Update(context.TODO(), internalSecrets)
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
 	if err != nil {
 		return errors.Wrap(err, "update internal secrets root user password")
 	}
 	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "discard old password")
+	}
+	logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
 
 	return nil
 }
@@ -196,42 +256,66 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUser(cr *api.PerconaXtraDBClus
 func (r *ReconcilePerconaXtraDBCluster) handleOperatorUser(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
 	logger := r.logger(cr.Name, cr.Namespace)
 
-	if cr.Status.PXC.Ready == 0 {
-		return nil
-	}
-
 	user := &users.SysUser{
 		Name:  users.Operator,
 		Pass:  string(secrets.Data[users.Operator]),
 		Hosts: []string{"%"},
 	}
 
-	// Regardless of password change, always ensure that operator user is there with the right privileges
-	err := r.manageOperatorAdminUser(cr, secrets, internalSecrets)
-	if err != nil {
-		return errors.Wrap(err, "manage operator admin user")
+	if cr.Status.PXC.Ready > 0 {
+		err := r.manageOperatorAdminUser(cr, secrets, internalSecrets)
+		if err != nil {
+			return errors.Wrap(err, "manage operator admin user")
+		}
 	}
 
-	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	passDiscarded, err := r.isOldPasswordDiscarded(cr, internalSecrets, user)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && passDiscarded {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && !passDiscarded {
+		err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+		if err != nil {
+			return errors.Wrap(err, "discard old pass")
+		}
+		logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+
 		return nil
 	}
 
 	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
-	err = r.updateUserPass(cr, secrets, internalSecrets, user)
+	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update operator users pass")
 	}
 	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
+	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
-	err = r.client.Update(context.TODO(), internalSecrets)
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets operator user password")
 	}
 	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
 
 	actions.restartProxy = true
+
+	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "discard operator old password")
+	}
+	logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+
 	return nil
 }
 
@@ -290,77 +374,95 @@ func (r *ReconcilePerconaXtraDBCluster) manageOperatorAdminUser(cr *api.PerconaX
 func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
 	logger := r.logger(cr.Name, cr.Namespace)
 
-	if cr.Status.PXC.Ready == 0 {
-		return nil
-	}
-
 	user := &users.SysUser{
 		Name:  users.Monitor,
 		Pass:  string(secrets.Data[users.Monitor]),
 		Hosts: []string{"%"},
 	}
 
-	pxcUser := users.Root
-	pxcPass := string(internalSecrets.Data[users.Root])
-	if _, ok := internalSecrets.Data[users.Operator]; ok {
-		pxcUser = users.Operator
-		pxcPass = string(internalSecrets.Data[users.Operator])
-	}
-
-	addr := cr.Name + "-pxc-unready." + cr.Namespace + ":3306"
-	hasKey, err := cr.ConfigHasKey("mysqld", "proxy_protocol_networks")
-	if err != nil {
-		return errors.Wrap(err, "check if congfig has proxy_protocol_networks key")
-	}
-	if hasKey {
-		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
-	}
-
-	um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
-	if err != nil {
-		return errors.Wrap(err, "new users manager for grant")
-	}
-	defer um.Close()
-
-	// Regardless of password change, always ensure monitor user has the right privileges
-	if cr.CompareVersionWith("1.6.0") >= 0 {
-		err := r.updateMonitorUserGrant(cr, internalSecrets, &um)
+	if cr.Status.PXC.Ready > 0 {
+		um, err := getUserManager(cr, internalSecrets)
 		if err != nil {
-			return errors.Wrap(err, "update monitor user grant")
+			return err
 		}
-	}
+		defer um.Close()
 
-	if cr.CompareVersionWith("1.10.0") >= 0 {
-		mysqlVersion := cr.Status.PXC.Version
-		if mysqlVersion == "" {
-			var err error
-			mysqlVersion, err = r.mysqlVersion(cr, statefulset.NewNode(cr))
-			if err != nil && !errors.Is(err, versionNotReadyErr) {
-				return errors.Wrap(err, "retrieving pxc version")
-			}
-		}
-
-		if mysqlVersion != "" {
-			ver, err := version.NewVersion(mysqlVersion)
+		if cr.CompareVersionWith("1.6.0") >= 0 {
+			err := r.updateMonitorUserGrant(cr, internalSecrets, um)
 			if err != nil {
-				return errors.Wrap(err, "invalid pxc version")
+				return errors.Wrap(err, "update monitor user grant")
+			}
+		}
+
+		if cr.CompareVersionWith("1.10.0") >= 0 {
+			mysqlVersion := cr.Status.PXC.Version
+			if mysqlVersion == "" {
+				var err error
+				mysqlVersion, err = r.mysqlVersion(cr, statefulset.NewNode(cr))
+				if err != nil {
+					if errors.Is(err, versionNotReadyErr) {
+						return nil
+					}
+					return errors.Wrap(err, "retrieving pxc version")
+				}
 			}
 
-			if !ver.LessThan(privSystemUserAddedIn) {
-				if err := r.grantSystemUserPrivilege(cr, internalSecrets, user, &um); err != nil {
-					return errors.Wrap(err, "monitor user grant system privilege")
+			if mysqlVersion != "" {
+				ver, err := version.NewVersion(mysqlVersion)
+				if err != nil {
+					return errors.Wrap(err, "invalid pxc version")
+				}
+
+				if !ver.LessThan(privSystemUserAddedIn) {
+					if err := r.grantSystemUserPrivilege(cr, internalSecrets, user, um); err != nil {
+						return errors.Wrap(err, "monitor user grant system privilege")
+					}
 				}
 			}
 		}
 	}
 
-	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	passDiscarded, err := r.isOldPasswordDiscarded(cr, internalSecrets, user)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && passDiscarded {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && !passDiscarded {
+		logger.Info(fmt.Sprintf("User %s: password updated but old one not discarded", user.Name))
+
+		passPropagated, err := r.isPassPropagated(cr, user)
+		if err != nil {
+			return errors.Wrap(err, "is password propagated")
+		}
+		if !passPropagated {
+			return PassNotPropagatedError
+		}
+
+		actions.restartProxy = true
+		if cr.Spec.PMM != nil && cr.Spec.PMM.IsEnabled(internalSecrets) {
+			actions.restartPXC = true
+		}
+
+		err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+		if err != nil {
+			return errors.Wrap(err, "discard old pass")
+		}
+		logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+
 		return nil
 	}
 
 	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
-	err = r.updateUserPass(cr, secrets, internalSecrets, user)
+	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update monitor users pass")
 	}
@@ -374,17 +476,33 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(cr *api.PerconaXtraDBC
 		logger.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
 	}
 
+	actions.restartProxy = true
+	if cr.Spec.PMM != nil && cr.Spec.PMM.IsEnabled(internalSecrets) {
+		actions.restartPXC = true
+	}
+
+	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
-	err = r.client.Update(context.TODO(), internalSecrets)
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets monitor user password")
 	}
 	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
 
-	actions.restartProxy = true
-	if cr.Spec.PMM != nil && cr.Spec.PMM.IsEnabled(internalSecrets) {
-		actions.restartPXC = true
+	passPropagated, err := r.isPassPropagated(cr, user)
+	if err != nil {
+		return errors.Wrap(err, "is password propagated")
 	}
+	if !passPropagated {
+		return PassNotPropagatedError
+	}
+
+	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "discard monitor old password")
+	}
+	logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+
 	return nil
 }
 
@@ -418,82 +536,91 @@ func (r *ReconcilePerconaXtraDBCluster) updateMonitorUserGrant(cr *api.PerconaXt
 func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUser(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
 	logger := r.logger(cr.Name, cr.Namespace)
 
-	if cr.Status.PXC.Ready == 0 {
-		return nil
-	}
-
 	user := &users.SysUser{
 		Name:  users.Clustercheck,
 		Pass:  string(secrets.Data[users.Clustercheck]),
 		Hosts: []string{"localhost"},
 	}
 
-	// Regardless of password change, always ensure clustercheck user has the right privileges
-	if cr.CompareVersionWith("1.10.0") >= 0 {
-		mysqlVersion := cr.Status.PXC.Version
-		if mysqlVersion == "" {
-			var err error
-			mysqlVersion, err = r.mysqlVersion(cr, statefulset.NewNode(cr))
-			if err != nil && !errors.Is(err, versionNotReadyErr) {
-				return errors.Wrap(err, "retrieving pxc version")
-			}
-		}
-
-		if mysqlVersion != "" {
-			ver, err := version.NewVersion(mysqlVersion)
-			if err != nil {
-				return errors.Wrap(err, "invalid pxc version")
+	if cr.Status.PXC.Ready > 0 {
+		if cr.CompareVersionWith("1.10.0") >= 0 {
+			mysqlVersion := cr.Status.PXC.Version
+			if mysqlVersion == "" {
+				var err error
+				mysqlVersion, err = r.mysqlVersion(cr, statefulset.NewNode(cr))
+				if err != nil {
+					if errors.Is(err, versionNotReadyErr) {
+						return nil
+					}
+					return errors.Wrap(err, "retrieving pxc version")
+				}
 			}
 
-			if !ver.LessThan(privSystemUserAddedIn) {
-
-				pxcUser := users.Root
-				pxcPass := string(internalSecrets.Data[users.Root])
-				if _, ok := internalSecrets.Data[users.Operator]; ok {
-					pxcUser = users.Operator
-					pxcPass = string(internalSecrets.Data[users.Operator])
-				}
-			
-				addr := cr.Name + "-pxc-unready." + cr.Namespace + ":3306"
-				hasKey, err := cr.ConfigHasKey("mysqld", "proxy_protocol_networks")
+			if mysqlVersion != "" {
+				ver, err := version.NewVersion(mysqlVersion)
 				if err != nil {
-					return errors.Wrap(err, "check if congfig has proxy_protocol_networks key")
+					return errors.Wrap(err, "invalid pxc version")
 				}
-				if hasKey {
-					addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
-				}
-			
-				um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
-				if err != nil {
-					return errors.Wrap(err, "new users manager for grant")
-				}
-				defer um.Close()
 
-				if err := r.grantSystemUserPrivilege(cr, internalSecrets, user, &um); err != nil {
-					return errors.Wrap(err, "clustercheck user grant system privilege")
+				if !ver.LessThan(privSystemUserAddedIn) {
+					um, err := getUserManager(cr, internalSecrets)
+					if err != nil {
+						return err
+					}
+					defer um.Close()
+
+					if err := r.grantSystemUserPrivilege(cr, internalSecrets, user, um); err != nil {
+						return errors.Wrap(err, "clustercheck user grant system privilege")
+					}
 				}
 			}
 		}
 	}
 
-	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	passDiscarded, err := r.isOldPasswordDiscarded(cr, internalSecrets, user)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && passDiscarded {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && !passDiscarded {
+		err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+		if err != nil {
+			return errors.Wrap(err, "discard old pass")
+		}
+		logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+
 		return nil
 	}
 
 	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
-	err := r.updateUserPass(cr, secrets, internalSecrets, user)
+	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update clustercheck users pass")
 	}
 	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
+	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
-	err = r.client.Update(context.TODO(), internalSecrets)
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets clustercheck user password")
 	}
 	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "discard clustercheck old pass")
+	}
+	logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
 
 	return nil
 }
@@ -501,92 +628,100 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUser(cr *api.PerconaXt
 func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUser(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
 	logger := r.logger(cr.Name, cr.Namespace)
 
-	if cr.Status.PXC.Ready == 0 {
-		return nil
-	}
-
 	user := &users.SysUser{
 		Name:  users.Xtrabackup,
 		Pass:  string(secrets.Data[users.Xtrabackup]),
 		Hosts: []string{"localhost"},
 	}
+
 	if cr.CompareVersionWith("1.7.0") >= 0 {
 		user.Hosts = []string{"%"}
 	}
 
-	// Regardless of password change, always ensure xtrabackup user has the right privileges
-	if cr.CompareVersionWith("1.7.0") >= 0 {
-		// monitor user need more grants for work in version more then 1.6.0
-		err := r.updateXtrabackupUserGrant(cr, internalSecrets)
-		if err != nil {
-			return errors.Wrap(err, "update xtrabackup user grant")
+	if cr.Status.PXC.Ready > 0 {
+		if cr.CompareVersionWith("1.7.0") >= 0 {
+			// monitor user need more grants for work in version more then 1.6.0
+			err := r.updateXtrabackupUserGrant(cr, internalSecrets)
+			if err != nil {
+				return errors.Wrap(err, "update xtrabackup user grant")
+			}
 		}
 	}
 
-	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	passDiscarded, err := r.isOldPasswordDiscarded(cr, internalSecrets, user)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && passDiscarded {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && !passDiscarded {
+		err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+		if err != nil {
+			return errors.Wrap(err, "discard old pass")
+		}
+		logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+
 		return nil
 	}
 
 	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
-	err := r.updateUserPass(cr, secrets, internalSecrets, user)
+	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update xtrabackup users pass")
 	}
 	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
+	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
-	err = r.client.Update(context.TODO(), internalSecrets)
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets xtrabackup user password")
 	}
 	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
 
+	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "discard xtrabackup old pass")
+	}
+	logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+
 	actions.restartPXC = true
 	return nil
 }
 
-func (r *ReconcilePerconaXtraDBCluster) updateXtrabackupUserGrant(cr *api.PerconaXtraDBCluster, internalSysSecretObj *corev1.Secret) error {
+func (r *ReconcilePerconaXtraDBCluster) updateXtrabackupUserGrant(cr *api.PerconaXtraDBCluster, secrets *corev1.Secret) error {
 	logger := r.logger(cr.Name, cr.Namespace)
 
 	annotationName := "grant-for-1.7.0-xtrabackup-user"
-	if internalSysSecretObj.Annotations[annotationName] == "done" {
+	if secrets.Annotations[annotationName] == "done" {
 		return nil
 	}
 
-	pxcUser := users.Root
-	pxcPass := string(internalSysSecretObj.Data[users.Root])
-	if _, ok := internalSysSecretObj.Data[users.Operator]; ok {
-		pxcUser = users.Operator
-		pxcPass = string(internalSysSecretObj.Data[users.Operator])
-	}
-
-	addr := cr.Name + "-pxc-unready." + cr.Namespace + ":3306"
-	hasKey, err := cr.ConfigHasKey("mysqld", "proxy_protocol_networks")
+	um, err := getUserManager(cr, secrets)
 	if err != nil {
-		return errors.Wrap(err, "check if congfig has proxy_protocol_networks key")
-	}
-	if hasKey {
-		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
-	}
-
-	um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
-	if err != nil {
-		return errors.Wrap(err, "new users manager for grant")
+		return err
 	}
 	defer um.Close()
 
-	err = um.Update170XtrabackupUser(string(internalSysSecretObj.Data[users.Xtrabackup]))
+	err = um.Update170XtrabackupUser(string(secrets.Data[users.Xtrabackup]))
 	if err != nil {
 		return errors.Wrap(err, "update xtrabackup grant")
 	}
 
-	if internalSysSecretObj.Annotations == nil {
-		internalSysSecretObj.Annotations = make(map[string]string)
+	if secrets.Annotations == nil {
+		secrets.Annotations = make(map[string]string)
 	}
 
-	internalSysSecretObj.Annotations[annotationName] = "done"
-	err = r.client.Update(context.TODO(), internalSysSecretObj)
+	secrets.Annotations[annotationName] = "done"
+	err = r.client.Update(context.TODO(), secrets)
 	if err != nil {
 		return errors.Wrap(err, "update internal sys users secret annotation")
 	}
@@ -602,98 +737,109 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUser(cr *api.PerconaXtr
 		return nil
 	}
 
-	if cr.Status.PXC.Ready == 0 {
-		return nil
-	}
-
 	user := &users.SysUser{
 		Name:  users.Replication,
 		Pass:  string(secrets.Data[users.Replication]),
 		Hosts: []string{"%"},
 	}
 
-	// Even if there is no password change, always ensure that operator user is there handle its grants
-	err := r.manageReplicationUser(cr, secrets, internalSecrets)
-	if err != nil {
-		return errors.Wrap(err, "manage replication user")
+	if cr.Status.PXC.Ready > 0 {
+		err := r.manageReplicationUser(cr, secrets, internalSecrets)
+		if err != nil {
+			return errors.Wrap(err, "manage replication user")
+		}
 	}
 
-	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	passDiscarded, err := r.isOldPasswordDiscarded(cr, internalSecrets, user)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && passDiscarded {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && !passDiscarded {
+		err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+		if err != nil {
+			return errors.Wrap(err, "discard old pass")
+		}
+		logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+
 		return nil
 	}
 
 	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
-	err = r.updateUserPass(cr, secrets, internalSecrets, user)
+	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update replication users pass")
 	}
 	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
+	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
-	err = r.client.Update(context.TODO(), internalSecrets)
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets replication user password")
 	}
 	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "discard replicaiton old pass")
+	}
+	logger.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
 
 	actions.updateReplicationPass = true
 	return nil
 }
 
 // manageReplicationUser ensures that replication user is always present and with the right privileges
-func (r *ReconcilePerconaXtraDBCluster) manageReplicationUser(cr *api.PerconaXtraDBCluster, sysUsersSecretObj, internalSysSecretObj *corev1.Secret) error {
+func (r *ReconcilePerconaXtraDBCluster) manageReplicationUser(cr *api.PerconaXtraDBCluster, sysUsersSecretObj, secrets *corev1.Secret) error {
 	logger := r.logger(cr.Name, cr.Namespace)
 
-	pass, existInSys := sysUsersSecretObj.Data["replication"]
-	_, existInInternal := internalSysSecretObj.Data["replication"]
+	pass, existInSys := sysUsersSecretObj.Data[users.Replication]
+	_, existInInternal := secrets.Data[users.Replication]
 	if existInSys && !existInInternal {
-		if internalSysSecretObj.Data == nil {
-			internalSysSecretObj.Data = make(map[string][]byte)
+		if secrets.Data == nil {
+			secrets.Data = make(map[string][]byte)
 		}
-		internalSysSecretObj.Data["replication"] = pass
+		secrets.Data[users.Replication] = pass
 		return nil
 	}
 	if existInSys {
 		return nil
 	}
 
-	pass, err := generatePass()
+	um, err := getUserManager(cr, secrets)
+	if err != nil {
+		return err
+	}
+	defer um.Close()
+
+	pass, err = generatePass()
 	if err != nil {
 		return errors.Wrap(err, "generate password")
 	}
-
-	addr := cr.Name + "-pxc." + cr.Namespace
-	if cr.CompareVersionWith("1.6.0") >= 0 {
-		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
-	}
-
-	pxcUser := "root"
-	pxcPass := string(internalSysSecretObj.Data["root"])
-	if _, ok := internalSysSecretObj.Data["operator"]; ok {
-		pxcUser = "operator"
-		pxcPass = string(internalSysSecretObj.Data["operator"])
-	}
-
-	um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
-	if err != nil {
-		return errors.Wrap(err, "new users manager")
-	}
-	defer um.Close()
 
 	err = um.CreateReplicationUser(string(pass))
 	if err != nil {
 		return errors.Wrap(err, "create replication user")
 	}
 
-	sysUsersSecretObj.Data["replication"] = pass
-	internalSysSecretObj.Data["replication"] = pass
+	sysUsersSecretObj.Data[users.Replication] = pass
+	secrets.Data[users.Replication] = pass
 
 	err = r.client.Update(context.TODO(), sysUsersSecretObj)
 	if err != nil {
 		return errors.Wrap(err, "update sys users secret")
 	}
-	err = r.client.Update(context.TODO(), internalSysSecretObj)
+	err = r.client.Update(context.TODO(), secrets)
 	if err != nil {
 		return errors.Wrap(err, "update internal users secret")
 	}
@@ -718,6 +864,10 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUser(cr *api.PerconaXtra
 		return nil
 	}
 
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
 	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
 	err := r.updateProxyUser(cr, internalSecrets, user)
@@ -726,8 +876,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUser(cr *api.PerconaXtra
 	}
 	logger.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
 
+	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
-	err = r.client.Update(context.TODO(), internalSecrets)
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets proxyadmin user password")
 	}
@@ -768,10 +919,15 @@ func (r *ReconcilePerconaXtraDBCluster) handlePMMUser(cr *api.PerconaXtraDBClust
 		return nil
 	}
 
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
 	logger.Info(fmt.Sprintf("User %s: password changed, updating user", name))
 
+	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[name] = secrets.Data[name]
-	err := r.client.Update(context.TODO(), internalSecrets)
+	err := r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets pmm user password")
 	}
@@ -821,21 +977,10 @@ func (r *ReconcilePerconaXtraDBCluster) syncPXCUsersWithProxySQL(cr *api.Percona
 	return nil
 }
 
-func (r *ReconcilePerconaXtraDBCluster) updateUserPass(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, user *users.SysUser) error {
-	pxcUser := users.Root
-	pxcPass := string(internalSecrets.Data[users.Root])
-	if _, ok := secrets.Data[users.Operator]; ok {
-		pxcUser = users.Operator
-		pxcPass = string(internalSecrets.Data[users.Operator])
-	}
-
-	addr := cr.Name + "-pxc." + cr.Namespace
-	if cr.CompareVersionWith("1.6.0") >= 0 {
-		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
-	}
-	um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
+func (r *ReconcilePerconaXtraDBCluster) updateUserPassWithRetention(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, user *users.SysUser) error {
+	um, err := getUserManager(cr, internalSecrets)
 	if err != nil {
-		return errors.Wrap(err, "new users manager")
+		return err
 	}
 	defer um.Close()
 
@@ -845,6 +990,93 @@ func (r *ReconcilePerconaXtraDBCluster) updateUserPass(cr *api.PerconaXtraDBClus
 	}
 
 	return nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) discardOldPassword(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, user *users.SysUser) error {
+	um, err := getUserManager(cr, internalSecrets)
+	if err != nil {
+		return err
+	}
+	defer um.Close()
+
+	err = um.DiscardOldPassword(user)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("discard old user %s pass", user.Name))
+	}
+
+	return nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) isOldPasswordDiscarded(cr *api.PerconaXtraDBCluster, secrets *corev1.Secret, user *users.SysUser) (bool, error) {
+	um, err := getUserManager(cr, secrets)
+	if err != nil {
+		return false, err
+	}
+	defer um.Close()
+
+	discarded, err := um.IsOldPassDiscarded(user)
+	if err != nil {
+		return false, errors.Wrap(err, "is old password discarded")
+	}
+
+	return discarded, nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) isPassPropagated(cr *api.PerconaXtraDBCluster, user *users.SysUser) (bool, error) {
+	components := map[string]int32{
+		"pxc": cr.Spec.PXC.Size,
+	}
+
+	if cr.HAProxyEnabled() {
+		components["haproxy"] = cr.Spec.HAProxy.Size
+	}
+
+	eg := new(errgroup.Group)
+
+	for component, size := range components {
+		comp := component
+		compCount := size
+		eg.Go(func() error {
+			for i := 0; int32(i) < compCount; i++ {
+				pod := corev1.Pod{}
+				err := r.client.Get(context.TODO(),
+					types.NamespacedName{
+						Namespace: cr.Namespace,
+						Name:      fmt.Sprintf("%s-%s-%d", cr.Name, comp, i),
+					},
+					&pod,
+				)
+				if err != nil && k8serrors.IsNotFound(err) {
+					return err
+				} else if err != nil {
+					return errors.Wrapf(err, "get %s pod", comp)
+				}
+				var errb, outb bytes.Buffer
+				err = r.clientcmd.Exec(&pod, comp, []string{"cat", fmt.Sprintf("/etc/mysql/mysql-users-secret/%s", user.Name)}, nil, &outb, &errb, false)
+				if err != nil {
+					return errors.Errorf("exec cat on %s-%d: %v / %s / %s", comp, i, err, outb.String(), errb.String())
+				}
+				if len(errb.Bytes()) > 0 {
+					return errors.Errorf("cat on %s-%d: %s", comp, i, errb.String())
+				}
+
+				if outb.String() != user.Pass {
+					return PassNotPropagatedError
+				}
+			}
+
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		if err == PassNotPropagatedError {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (r *ReconcilePerconaXtraDBCluster) updateProxyUser(cr *api.PerconaXtraDBCluster, internalSecrets *corev1.Secret, user *users.SysUser) error {
@@ -890,4 +1122,29 @@ func (r *ReconcilePerconaXtraDBCluster) grantSystemUserPrivilege(cr *api.Percona
 
 	logger.Info(fmt.Sprintf("User %s: system user privileges granted", user.Name))
 	return nil
+}
+
+func getUserManager(cr *api.PerconaXtraDBCluster, secrets *corev1.Secret) (*users.Manager, error) {
+	pxcUser := users.Root
+	pxcPass := string(secrets.Data[users.Root])
+	if _, ok := secrets.Data[users.Operator]; ok {
+		pxcUser = users.Operator
+		pxcPass = string(secrets.Data[users.Operator])
+	}
+
+	addr := cr.Name + "-pxc-unready." + cr.Namespace + ":3306"
+	hasKey, err := cr.ConfigHasKey("mysqld", "proxy_protocol_networks")
+	if err != nil {
+		return nil, errors.Wrap(err, "check if congfig has proxy_protocol_networks key")
+	}
+	if hasKey {
+		addr = cr.Name + "-pxc-unready." + cr.Namespace + ":33062"
+	}
+
+	um, err := users.NewManager(addr, pxcUser, pxcPass, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
+	if err != nil {
+		return nil, errors.Wrap(err, "new users manager")
+	}
+
+	return &um, nil
 }

--- a/pkg/controller/pxc/users_without_dp.go
+++ b/pkg/controller/pxc/users_without_dp.go
@@ -1,0 +1,468 @@
+package pxc
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app/statefulset"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
+)
+
+func (r *ReconcilePerconaXtraDBCluster) updateUsersWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret) (*userUpdateActions, error) {
+	res := &userUpdateActions{}
+
+	for _, u := range users.UserNames {
+		if _, ok := secrets.Data[u]; !ok {
+			continue
+		}
+
+		switch u {
+		case users.Root:
+			if err := r.handleRootUserWithoutDP(cr, secrets, internalSecrets, res); err != nil {
+				return res, err
+			}
+		case users.Operator:
+			if err := r.handleOperatorUserWithoutDP(cr, secrets, internalSecrets, res); err != nil {
+				return res, err
+			}
+		case users.Monitor:
+			if err := r.handleMonitorUserWithoutDP(cr, secrets, internalSecrets, res); err != nil {
+				return res, err
+			}
+		case users.Clustercheck:
+			if err := r.handleClustercheckUserWithoutDP(cr, secrets, internalSecrets, res); err != nil {
+				return res, err
+			}
+		case users.Xtrabackup:
+			if err := r.handleXtrabackupUserWithoutDP(cr, secrets, internalSecrets, res); err != nil {
+				return res, err
+			}
+		case users.Replication:
+			if err := r.handleReplicationUserWithoutDP(cr, secrets, internalSecrets, res); err != nil {
+				return res, err
+			}
+		case users.ProxyAdmin:
+			if err := r.handleProxyadminUserWithoutDP(cr, secrets, internalSecrets, res); err != nil {
+				return res, err
+			}
+		case users.PMMServer, users.PMMServerKey:
+			if err := r.handlePMMUser(cr, secrets, internalSecrets, res); err != nil {
+				return res, err
+			}
+		}
+	}
+
+	return res, nil
+}
+func (r *ReconcilePerconaXtraDBCluster) handleRootUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	logger := r.logger(cr.Name, cr.Namespace)
+
+	user := &users.SysUser{
+		Name:  users.Root,
+		Pass:  string(secrets.Data[users.Root]),
+		Hosts: []string{"localhost", "%"},
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+		return nil
+	}
+
+	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+
+	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "update root users pass")
+	}
+	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+
+	err = r.syncPXCUsersWithProxySQL(cr)
+	if err != nil {
+		return errors.Wrap(err, "sync users")
+	}
+
+	orig := internalSecrets.DeepCopy()
+	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
+	if err != nil {
+		return errors.Wrap(err, "update internal secrets root user password")
+	}
+	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	return nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) handleOperatorUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
+	logger := r.logger(cr.Name, cr.Namespace)
+
+	user := &users.SysUser{
+		Name:  users.Operator,
+		Pass:  string(secrets.Data[users.Operator]),
+		Hosts: []string{"%"},
+	}
+
+	if cr.Status.PXC.Ready > 0 {
+		err := r.manageOperatorAdminUser(cr, secrets, internalSecrets)
+		if err != nil {
+			return errors.Wrap(err, "manage operator admin user")
+		}
+	}
+
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+		return nil
+	}
+
+	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+
+	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "update operator users pass")
+	}
+	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+
+	orig := internalSecrets.DeepCopy()
+	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
+	if err != nil {
+		return errors.Wrap(err, "update internal users secrets operator user password")
+	}
+	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	actions.restartProxy = true
+	return nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) handleMonitorUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
+	logger := r.logger(cr.Name, cr.Namespace)
+
+	user := &users.SysUser{
+		Name:  users.Monitor,
+		Pass:  string(secrets.Data[users.Monitor]),
+		Hosts: []string{"%"},
+	}
+
+	if cr.Status.PXC.Ready > 0 {
+		um, err := getUserManager(cr, internalSecrets)
+		if err != nil {
+			return err
+		}
+		defer um.Close()
+
+		if cr.CompareVersionWith("1.6.0") >= 0 {
+			err := r.updateMonitorUserGrant(cr, internalSecrets, um)
+			if err != nil {
+				return errors.Wrap(err, "update monitor user grant")
+			}
+		}
+
+		if cr.CompareVersionWith("1.10.0") >= 0 {
+			mysqlVersion := cr.Status.PXC.Version
+			if mysqlVersion == "" {
+				var err error
+				mysqlVersion, err = r.mysqlVersion(cr, statefulset.NewNode(cr))
+				if err != nil {
+					if errors.Is(err, versionNotReadyErr) {
+						return nil
+					}
+					return errors.Wrap(err, "retrieving pxc version")
+				}
+			}
+
+			if mysqlVersion != "" {
+				ver, err := version.NewVersion(mysqlVersion)
+				if err != nil {
+					return errors.Wrap(err, "invalid pxc version")
+				}
+
+				if !ver.LessThan(privSystemUserAddedIn) {
+					if err := r.grantSystemUserPrivilege(cr, internalSecrets, user, um); err != nil {
+						return errors.Wrap(err, "monitor user grant system privilege")
+					}
+				}
+			}
+		}
+	}
+
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+		return nil
+	}
+
+	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+
+	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "update monitor users pass")
+	}
+	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+
+	if cr.Spec.ProxySQL != nil && cr.Spec.ProxySQL.Enabled {
+		err := r.updateProxyUser(cr, internalSecrets, user)
+		if err != nil {
+			return errors.Wrap(err, "update monitor users pass")
+		}
+		logger.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
+	}
+
+	actions.restartProxy = true
+	if cr.Spec.PMM != nil && cr.Spec.PMM.IsEnabled(internalSecrets) {
+		actions.restartPXC = true
+	}
+
+	orig := internalSecrets.DeepCopy()
+	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
+	if err != nil {
+		return errors.Wrap(err, "update internal users secrets monitor user password")
+	}
+	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	return nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
+	logger := r.logger(cr.Name, cr.Namespace)
+
+	user := &users.SysUser{
+		Name:  users.Clustercheck,
+		Pass:  string(secrets.Data[users.Clustercheck]),
+		Hosts: []string{"localhost"},
+	}
+
+	if cr.Status.PXC.Ready > 0 {
+		if cr.CompareVersionWith("1.10.0") >= 0 {
+			mysqlVersion := cr.Status.PXC.Version
+			if mysqlVersion == "" {
+				var err error
+				mysqlVersion, err = r.mysqlVersion(cr, statefulset.NewNode(cr))
+				if err != nil {
+					if errors.Is(err, versionNotReadyErr) {
+						return nil
+					}
+					return errors.Wrap(err, "retrieving pxc version")
+				}
+			}
+
+			if mysqlVersion != "" {
+				ver, err := version.NewVersion(mysqlVersion)
+				if err != nil {
+					return errors.Wrap(err, "invalid pxc version")
+				}
+
+				if !ver.LessThan(privSystemUserAddedIn) {
+					um, err := getUserManager(cr, internalSecrets)
+					if err != nil {
+						return err
+					}
+					defer um.Close()
+
+					if err := r.grantSystemUserPrivilege(cr, internalSecrets, user, um); err != nil {
+						return errors.Wrap(err, "clustercheck user grant system privilege")
+					}
+				}
+			}
+		}
+	}
+
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+		return nil
+	}
+
+	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+
+	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "update clustercheck users pass")
+	}
+	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+
+	orig := internalSecrets.DeepCopy()
+	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
+	if err != nil {
+		return errors.Wrap(err, "update internal users secrets clustercheck user password")
+	}
+	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	return nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
+	logger := r.logger(cr.Name, cr.Namespace)
+
+	user := &users.SysUser{
+		Name:  users.Xtrabackup,
+		Pass:  string(secrets.Data[users.Xtrabackup]),
+		Hosts: []string{"localhost"},
+	}
+
+	if cr.CompareVersionWith("1.7.0") >= 0 {
+		user.Hosts = []string{"%"}
+	}
+
+	if cr.Status.PXC.Ready > 0 {
+		if cr.CompareVersionWith("1.7.0") >= 0 {
+			// monitor user need more grants for work in version more then 1.6.0
+			err := r.updateXtrabackupUserGrant(cr, internalSecrets)
+			if err != nil {
+				return errors.Wrap(err, "update xtrabackup user grant")
+			}
+		}
+	}
+
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+		return nil
+	}
+
+	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+
+	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "update xtrabackup users pass")
+	}
+	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+
+	orig := internalSecrets.DeepCopy()
+	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
+	if err != nil {
+		return errors.Wrap(err, "update internal users secrets xtrabackup user password")
+	}
+	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	actions.restartPXC = true
+	return nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) handleReplicationUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
+	logger := r.logger(cr.Name, cr.Namespace)
+
+	if cr.CompareVersionWith("1.9.0") < 0 {
+		return nil
+	}
+
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	user := &users.SysUser{
+		Name:  users.Replication,
+		Pass:  string(secrets.Data[users.Replication]),
+		Hosts: []string{"%"},
+	}
+
+	if cr.Status.PXC.Ready > 0 {
+		err := r.manageReplicationUser(cr, secrets, internalSecrets)
+		if err != nil {
+			return errors.Wrap(err, "manage replication user")
+		}
+	}
+
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+		return nil
+	}
+
+	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+
+	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "update replication users pass")
+	}
+	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+
+	orig := internalSecrets.DeepCopy()
+	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
+	if err != nil {
+		return errors.Wrap(err, "update internal users secrets replication user password")
+	}
+	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	actions.updateReplicationPass = true
+	return nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
+	logger := r.logger(cr.Name, cr.Namespace)
+
+	if cr.Spec.ProxySQL == nil || !cr.Spec.ProxySQL.Enabled {
+		return nil
+	}
+
+	user := &users.SysUser{
+		Name: users.ProxyAdmin,
+		Pass: string(secrets.Data[users.ProxyAdmin]),
+	}
+
+	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
+		return nil
+	}
+
+	if cr.Status.Status != api.AppStateReady {
+		return nil
+	}
+
+	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+
+	err := r.updateProxyUser(cr, internalSecrets, user)
+	if err != nil {
+		return errors.Wrap(err, "update Proxy users")
+	}
+	logger.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
+
+	orig := internalSecrets.DeepCopy()
+	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
+	err = r.client.Patch(context.TODO(), internalSecrets, client.MergeFrom(orig))
+	if err != nil {
+		return errors.Wrap(err, "update internal users secrets proxyadmin user password")
+	}
+	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+
+	actions.restartProxy = true
+
+	return nil
+}
+
+func (r *ReconcilePerconaXtraDBCluster) updateUserPassWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, user *users.SysUser) error {
+	um, err := getUserManager(cr, internalSecrets)
+	if err != nil {
+		return err
+	}
+	defer um.Close()
+
+	err = um.UpdateUserPassWithoutDP(user)
+	if err != nil {
+		return errors.Wrap(err, "update user pass")
+	}
+
+	return nil
+}

--- a/pkg/pxc/users/users.go
+++ b/pkg/pxc/users/users.go
@@ -79,7 +79,9 @@ func (u *Manager) CreateOperatorUser(pass string) error {
 	return nil
 }
 
-func (u *Manager) UpdateUserPass(user *SysUser) error {
+// UpdateUserPassWithoutDP updates user pass without Dual Password
+// feature introduced in MsSQL 8
+func (u *Manager) UpdateUserPassWithoutDP(user *SysUser) error {
 	if user == nil {
 		return nil
 	}
@@ -92,6 +94,89 @@ func (u *Manager) UpdateUserPass(user *SysUser) error {
 	}
 
 	return nil
+}
+
+// UpdateUserPass updates user passwords but retains the current password
+// using Dual Password feature of MySQL 8.
+func (m *Manager) UpdateUserPass(user *SysUser) error {
+	if user == nil {
+		return nil
+	}
+
+	tx, err := m.db.Begin()
+	if err != nil {
+		return errors.Wrap(err, "begin transaction")
+	}
+
+	for _, host := range user.Hosts {
+		_, err = tx.Exec("ALTER USER ?@? IDENTIFIED BY ? RETAIN CURRENT PASSWORD", user.Name, host, user.Pass)
+		if err != nil {
+			err = errors.Wrap(err, "alter user")
+
+			if errT := tx.Rollback(); errT != nil {
+				return errors.Wrap(errors.Wrap(errT, "rollback"), err.Error())
+			}
+
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "commit transaction")
+	}
+
+	return nil
+}
+
+// DiscardOldPassword discards old passwords of given users
+func (m *Manager) DiscardOldPassword(user *SysUser) error {
+	if user == nil {
+		return nil
+	}
+
+	tx, err := m.db.Begin()
+	if err != nil {
+		return errors.Wrap(err, "begin transaction")
+	}
+
+	for _, host := range user.Hosts {
+		_, err = tx.Exec("ALTER USER ?@? DISCARD OLD PASSWORD", user.Name, host)
+		if err != nil {
+			err = errors.Wrap(err, "alter user")
+
+			if errT := tx.Rollback(); errT != nil {
+				return errors.Wrap(errors.Wrap(errT, "rollback"), err.Error())
+			}
+
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "commit transaction")
+	}
+
+	return nil
+}
+
+// DiscardOldPassword discards old passwords of given users
+func (m *Manager) IsOldPassDiscarded(user *SysUser) (bool, error) {
+	var attributes sql.NullString
+	r := m.db.QueryRow("SELECT User_attributes FROM mysql.user WHERE user=?", user.Name)
+
+	err := r.Scan(&attributes)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return true, nil
+		}
+		return false, errors.Wrap(err, "select User_attributes field")
+	}
+
+	if attributes.Valid {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (u *Manager) UpdateProxyUser(user *SysUser) error {


### PR DESCRIPTION
[![K8SPXC-1113](https://badgen.net/badge/JIRA/K8SPXC-1113/green)](https://jira.percona.com/browse/K8SPXC-1113) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Support dual password

* Update internal secrets then check pass propagation and old pass discarding.

* Dual pass logic for all the users.

* Check if pass is propagated for components in parallel.

* Fix parallel pass propagation check.

* WIP - implemente propagation with annotation.

* Add isOldPassword discarded func.

* Check if pass is discarded.

* Fix sql scan issue.

* Use sql nullable string

* Log pxc ready.

* Fix isPassDiscarded func

* Imports fix

* Handle file not found case.

* Don't check pass propagation for proxysql.

* Add logs.

* Cleanup logs.

* Improved logs and added update user pass method for 5.7 mysql version.

* Update passwords without dual pass for pre mysql 8.

* Fix cr yaml changes.

* Minor cleanup.

* Improve naming.

* Fix case when pass is not propagated.

* Return false pass propagation properly.

* Check PassNotPropagatedError properly in the controller.

* Fix proxyadmin user

* update proxy monitor user  after discarding old pass

* dont check the PassNotPropagatedError

* Cleanup

* Reset err to nil

* Minor cleanup.

* Revert getting mysql version.

* K8SPXC-1142:Handle grants as soon as first node is running.

* fix malformed version errors

* fix changing proxyadmin password with others

* Update pkg/controller/pxc/users.go

Co-authored-by: Viacheslav Sarzhan <slava.sarzhan@percona.com>

* Update pkg/controller/pxc/users.go

Co-authored-by: Viacheslav Sarzhan <slava.sarzhan@percona.com>

* Update pkg/controller/pxc/users.go

Co-authored-by: Viacheslav Sarzhan <slava.sarzhan@percona.com>

* Update pkg/controller/pxc/users.go

Co-authored-by: Viacheslav Sarzhan <slava.sarzhan@percona.com>

* Update pkg/controller/pxc/users.go

Co-authored-by: Viacheslav Sarzhan <slava.sarzhan@percona.com>

* Update pkg/controller/pxc/users.go

Co-authored-by: Viacheslav Sarzhan <slava.sarzhan@percona.com>

* fix password checks if cluster is not ready

* fix init-deploy

* improve users test

* Fix proxyadmin issues in users_without_dp.

Co-authored-by: Ege Güneş <ege.gunes@percona.com>
Co-authored-by: Viacheslav Sarzhan <slava.sarzhan@percona.com>