### PR TITLE
K8SPXC-1005: fix azure backup deletion

### DIFF
--- a/cmd/pitr/storage/storage.go
+++ b/cmd/pitr/storage/storage.go
@@ -145,7 +145,7 @@ func (a *Azure) PutObject(ctx context.Context, name string, data io.Reader, _ in
 }
 
 func (a *Azure) ListObjects(ctx context.Context, prefix string) ([]string, error) {
-	listPrefix := url.QueryEscape(a.prefix + prefix)
+	listPrefix := a.prefix + prefix
 	pg := a.client.NewListBlobsFlatPager(a.container, &container.ListBlobsFlatOptions{
 		Prefix: &listPrefix,
 	})

--- a/cmd/pitr/storage/storage.go
+++ b/cmd/pitr/storage/storage.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -128,7 +129,7 @@ func NewAzure(storageAccount, accessKey, endpoint, container, prefix string) (*A
 }
 
 func (a *Azure) GetObject(ctx context.Context, name string) (io.ReadCloser, error) {
-	resp, err := a.client.DownloadStream(ctx, a.container, a.prefix+name, &azblob.DownloadStreamOptions{})
+	resp, err := a.client.DownloadStream(ctx, a.container, url.QueryEscape(a.prefix+name), &azblob.DownloadStreamOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "download stream: %s", a.prefix+name)
 	}
@@ -136,7 +137,7 @@ func (a *Azure) GetObject(ctx context.Context, name string) (io.ReadCloser, erro
 }
 
 func (a *Azure) PutObject(ctx context.Context, name string, data io.Reader, _ int64) error {
-	_, err := a.client.UploadStream(ctx, a.container, a.prefix+name, data, nil)
+	_, err := a.client.UploadStream(ctx, a.container, url.QueryEscape(a.prefix+name), data, nil)
 	if err != nil {
 		return errors.Wrapf(err, "upload stream: %s", a.prefix+name)
 	}
@@ -144,7 +145,7 @@ func (a *Azure) PutObject(ctx context.Context, name string, data io.Reader, _ in
 }
 
 func (a *Azure) ListObjects(ctx context.Context, prefix string) ([]string, error) {
-	listPrefix := a.prefix + prefix
+	listPrefix := url.QueryEscape(a.prefix + prefix)
 	pg := a.client.NewListBlobsFlatPager(a.container, &container.ListBlobsFlatOptions{
 		Prefix: &listPrefix,
 	})

--- a/pkg/controller/pxcbackup/controller.go
+++ b/pkg/controller/pxcbackup/controller.go
@@ -523,8 +523,9 @@ func (r *ReconcilePerconaXtraDBClusterBackup) azureClient(ctx context.Context, c
 
 func azureListBlobs(ctx context.Context, client *azblob.Client, containerName, prefix string) ([]string, error) {
 	var blobs []string
+	escapedPrefix := url.QueryEscape(prefix)
 	pager := client.NewListBlobsFlatPager(containerName, &azblob.ListBlobsFlatOptions{
-		Prefix: &prefix,
+		Prefix: &escapedPrefix,
 	})
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)

--- a/pkg/controller/pxcbackup/controller.go
+++ b/pkg/controller/pxcbackup/controller.go
@@ -523,9 +523,8 @@ func (r *ReconcilePerconaXtraDBClusterBackup) azureClient(ctx context.Context, c
 
 func azureListBlobs(ctx context.Context, client *azblob.Client, containerName, prefix string) ([]string, error) {
 	var blobs []string
-	escapedPrefix := url.QueryEscape(prefix)
 	pager := client.NewListBlobsFlatPager(containerName, &azblob.ListBlobsFlatOptions{
-		Prefix: &escapedPrefix,
+		Prefix: &prefix,
 	})
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)

--- a/pkg/controller/pxcbackup/controller.go
+++ b/pkg/controller/pxcbackup/controller.go
@@ -3,6 +3,7 @@ package pxcbackup
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -340,6 +341,7 @@ func (r *ReconcilePerconaXtraDBClusterBackup) runDeleteBackupFinalizer(ctx conte
 		}
 		if err != nil {
 			logger.Info("failed to delete backup", "backup path", cr.Status.Destination, "error", err.Error())
+			finalizers = append(finalizers, f)
 		} else if f == api.FinalizerDeleteS3Backup {
 			logger.Info("backup was removed", "name", cr.Name)
 		}
@@ -405,7 +407,7 @@ func removeAzureBackup(ctx context.Context, cli *azblob.Client, container, desti
 			return errors.Wrap(err, "list backup blobs")
 		}
 		for _, blob := range blobs {
-			_, err = cli.DeleteBlob(ctx, container, blob, nil)
+			_, err = cli.DeleteBlob(ctx, container, url.QueryEscape(blob), nil)
 			if err != nil {
 				return errors.Wrapf(err, "delete blob %s", blob)
 			}
@@ -415,7 +417,7 @@ func removeAzureBackup(ctx context.Context, cli *azblob.Client, container, desti
 			return errors.Wrap(err, "list backup blobs")
 		}
 		for _, blob := range blobs {
-			_, err = cli.DeleteBlob(ctx, container, blob, nil)
+			_, err = cli.DeleteBlob(ctx, container, url.QueryEscape(blob), nil)
 			if err != nil {
 				return errors.Wrapf(err, "delete blob %s", blob)
 			}


### PR DESCRIPTION
[![K8SPXC-1005](https://badgen.net/badge/JIRA/K8SPXC-1005/green)](https://jira.percona.com/browse/K8SPXC-1005) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-1005

There was a problem while deleting the `#innodb_redo` folder in azure backup. The `azblob` package has problems with deleting blobs that contain special characters. This issue is mentioned here: https://github.com/Azure/azure-sdk-for-go/issues/19475.

We should url escape the blob names during the delete request.

Also, in this PR, we keep finalizers in backup, if they were failed