### PR TITLE
Few tweaks for proxy protocol test on openshift

### DIFF
--- a/e2e-tests/proxy-protocol/run
+++ b/e2e-tests/proxy-protocol/run
@@ -13,14 +13,14 @@ if [[ $IMAGE_PXC =~ 5\.7 ]]; then
 fi
 
 prepare_config() {
-	nodes=$(kubectl get nodes | grep -v "NAME" | awk '{print $1}')
+	nodes=$(kubectl get nodes | grep -v "NAME" | grep -v 'master' | awk '{print $1}')
 	if [ $(printf "${nodes}\n" | wc -l) -lt 3 ]; then
 		echo "3 nodes are expected for this test to run."
 		exit 1
 	fi
-	haproxy_node=$(echo "${nodes}" | head -n1)
-	pxc_node=$(echo "${nodes}" | head -n2 | tail -n1)
-	client_node=$(echo "${nodes}" | head -n3 | tail -n1)
+	haproxy_node=$(echo "${nodes}" | tail -n1)
+	pxc_node=$(echo "${nodes}" | tail -n2 | head -n1)
+	client_node=$(echo "${nodes}" | tail -n3 | head -n1)
 	cat ${test_dir}/conf/${cluster}.yml \
 		| $sed -e "s#kubernetes.io/hostname:.*-node1\$#kubernetes.io/hostname: ${haproxy_node}#" \
 		| $sed -e "s#kubernetes.io/hostname:.*-node2\$#kubernetes.io/hostname: ${pxc_node}#" >${tmp_dir}/${cluster}.yml
@@ -38,6 +38,10 @@ client_ip=$(kubectl_bin get pods --selector=name=pxc-client -o 'jsonpath={.items
 if [ ${EKS} -eq 1 ]; then
 	node_name=$(kubectl_bin get pods --selector=name=pxc-client -o 'jsonpath={.items[].spec.nodeName}')
 	client_ip=$(kubectl_bin get nodes ${node_name} -o 'jsonpath={.status.addresses[?(@.type == "ExternalIP")].address}')
+fi
+if [[ -n ${OPENSHIFT} ]]; then
+	pod_name=$(kubectl_bin get pods --selector=name=pxc-client -o 'jsonpath={.items[].metadata.name}')
+	client_ip=$(kubectl_bin exec ${pod_name} -- curl -s ifconfig.io)
 fi
 
 service_ip=$(get_service_endpoint proxy-protocol-haproxy)


### PR DESCRIPTION
- Master nodes do not except incoming pods, so need to filter them out
- Top nodes in list are more utilized then others. It's better to pick nodes in reverse order
- client ip is public on openshift. Needs to be reflected