### PR TITLE
K8SPXC-1179 add possibility of using tls connections to mysql

### DIFF
--- a/pkg/pxc/queries/queries.go
+++ b/pkg/pxc/queries/queries.go
@@ -78,6 +78,7 @@ func New(client client.Client, namespace, secretName, user, host string, port in
 		"timeout":           timeoutStr,
 		"readTimeout":       timeoutStr,
 		"writeTimeout":      timeoutStr,
+		"tls":               "preferred",
 	}
 
 	db, err := sql.Open("mysql", config.FormatDSN())

--- a/pkg/pxc/users/users.go
+++ b/pkg/pxc/users/users.go
@@ -49,6 +49,7 @@ func NewManager(addr string, user, pass string, timeout int32) (Manager, error) 
 		"timeout":           timeoutStr,
 		"readTimeout":       timeoutStr,
 		"writeTimeout":      timeoutStr,
+		"tls":               "preferred",
 	}
 
 	mysqlDB, err := sql.Open("mysql", config.FormatDSN())


### PR DESCRIPTION
[![K8SPXC-1179](https://badgen.net/badge/JIRA/K8SPXC-1179/green)](https://jira.percona.com/browse/K8SPXC-1179) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* by default operator does not use tls connection to database
      even if you create the user with 'REQUIRE SSL' it will not
      work because tls is disabled by defult. In order to fix it
      "tls: preferred" is set.