### PR TITLE
K8SPXC-1192 add missing options into restore.yaml file

### DIFF
--- a/deploy/backup/restore.yaml
+++ b/deploy/backup/restore.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   pxcCluster: cluster1
   backupName: backup1
+#  backupSource:
+#    storageName: "STORAGE-NAME-HERE"
+#    s3:
+#      bucket: S3-BINLOG-BACKUP-BUCKET-NAME-HERE
+#      credentialsSecret: my-cluster-name-backup-s3
+#      endpointUrl: https://s3.us-west-2.amazonaws.com/
+#      region: us-west-2
 #  pitr:
 #    type: latest
 #    date: "yyyy-mm-dd hh:mm:ss"


### PR DESCRIPTION
[![K8SPXC-1192](https://badgen.net/badge/JIRA/K8SPXC-1192/green)](https://jira.percona.com/browse/K8SPXC-1192) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
restore.yaml file does not have all needed options

**Solution:**
Add spec.backupSource section into restore.yaml file

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?