### PR TITLE
 K8SPXC-1198: Remove formatted strings from log messages

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -38,12 +38,6 @@ var (
 	setupLog  = ctrl.Log.WithName("setup")
 )
 
-func printVersion() {
-	setupLog.Info(fmt.Sprintf("Git commit: %s Git branch: %s Build time: %s", GitCommit, GitBranch, BuildTime))
-	setupLog.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	setupLog.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-}
-
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -76,7 +70,8 @@ func main() {
 	}
 	setupLog.Info("Runs on", "platform", sv.Platform, "version", sv.Info)
 
-	printVersion()
+	setupLog.Info("Manager starting up", "gitCommit", GitCommit, "gitBranch", GitBranch,
+		"goVersion", runtime.Version(), "os", runtime.GOOS, "arch", runtime.GOARCH)
 
 	namespace, err := k8s.GetWatchNamespace()
 	if err != nil {
@@ -181,7 +176,7 @@ func getLogEncoder(log logr.Logger) zapcore.Encoder {
 
 	useJson, err := strconv.ParseBool(s)
 	if err != nil {
-		log.Info(fmt.Sprintf("can't parse LOG_STRUCTURED env var: %s, using console logger", s))
+	log.Info("Cant't parse LOG_STRUCTURED env var, using console logger", "envVar", s)
 		return consoleEnc
 	}
 	if !useJson {
@@ -205,7 +200,7 @@ func getLogLevel(log logr.Logger) zapcore.LevelEnabler {
 	case "ERROR":
 		return zapcore.ErrorLevel
 	default:
-		log.Info(fmt.Sprintf("unsupported log level: %s, using INFO level", l))
+		log.Info("Unsupported log level", "level", l)
 		return zapcore.InfoLevel
 	}
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"runtime"
 	"strconv"
@@ -176,7 +175,7 @@ func getLogEncoder(log logr.Logger) zapcore.Encoder {
 
 	useJson, err := strconv.ParseBool(s)
 	if err != nil {
-	log.Info("Cant't parse LOG_STRUCTURED env var, using console logger", "envVar", s)
+		log.Info("Can't parse LOG_STRUCTURED env var, using console logger", "envVar", s)
 		return consoleEnc
 	}
 	if !useJson {

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -3,7 +3,6 @@
 package v1
 
 import (
-	"fmt"
 	"os"
 	"strings"
 

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -968,34 +968,34 @@ func setSafeDefaults(spec *PerconaXtraDBClusterSpec, log logr.Logger) {
 		return
 	}
 
-	loginfo := func(msg string, args ...interface{}) {
-		log.Info(fmt.Sprintf(msg, args...))
-		log.Info("Set allowUnsafeConfigurations=true to disable safe configuration")
-	}
-
 	if spec.PXC.Size < 3 {
-		loginfo("Cluster size will be changed from %d to %d due to safe config", spec.PXC.Size, 3)
+		log.Info("Setting safe defaults, updating cluster size",
+			"oldSize", spec.PXC.Size, "newSize", 3)
 		spec.PXC.Size = 3
 	} else if spec.PXC.Size > maxSafePXCSize {
-		loginfo("Cluster size will be changed from %d to %d due to safe config", spec.PXC.Size, maxSafePXCSize)
+		log.Info("Setting safe defaults, updating cluster size",
+			"oldSize", spec.PXC.Size, "newSize", maxSafePXCSize)
 		spec.PXC.Size = maxSafePXCSize
 	}
 
 	if spec.PXC.Size%2 == 0 {
-		loginfo("Cluster size will be changed from %d to %d due to safe config", spec.PXC.Size, spec.PXC.Size+1)
+		log.Info("Setting safe defaults, increasing cluster size to have a odd number of replicas",
+			"oldSize", spec.PXC.Size, "newSize", spec.PXC.Size+1)
 		spec.PXC.Size++
 	}
 
 	if spec.ProxySQL != nil && spec.ProxySQL.Enabled {
 		if spec.ProxySQL.Size < minSafeProxySize {
-			loginfo("ProxySQL size will be changed from %d to %d due to safe config", spec.ProxySQL.Size, minSafeProxySize)
+			log.Info("Setting safe defaults, updating ProxySQL size",
+				"oldSize", spec.ProxySQL.Size, "newSize", minSafeProxySize)
 			spec.ProxySQL.Size = minSafeProxySize
 		}
 	}
 
 	if spec.HAProxy != nil && spec.HAProxy.Enabled {
 		if spec.HAProxy.Size < minSafeProxySize {
-			loginfo("HAProxy size will be changed from %d to %d due to safe config", spec.HAProxy.Size, minSafeProxySize)
+			log.Info("Setting safe defaults, updating HAProxy size",
+				"oldSize", spec.HAProxy.Size, "newSize", minSafeProxySize)
 			spec.HAProxy.Size = minSafeProxySize
 		}
 	}
@@ -1120,7 +1120,7 @@ func (v *VolumeSpec) validate() error {
 	return nil
 }
 
-func AddSidecarContainers(logger logr.Logger, existing, sidecars []corev1.Container) []corev1.Container {
+func AddSidecarContainers(log logr.Logger, existing, sidecars []corev1.Container) []corev1.Container {
 	if len(sidecars) == 0 {
 		return existing
 	}
@@ -1132,7 +1132,7 @@ func AddSidecarContainers(logger logr.Logger, existing, sidecars []corev1.Contai
 
 	for _, c := range sidecars {
 		if _, ok := names[c.Name]; ok {
-			logger.Info(fmt.Sprintf("Sidecar container name cannot be %s. It's skipped", c.Name))
+			log.Info("Wrong sidecar container name, it is skipped", "containerName", c.Name)
 			continue
 		}
 
@@ -1142,45 +1142,45 @@ func AddSidecarContainers(logger logr.Logger, existing, sidecars []corev1.Contai
 	return existing
 }
 
-func AddSidecarVolumes(logger logr.Logger, existing, sidecarVolumes []corev1.Volume) []corev1.Volume {
+func AddSidecarVolumes(log logr.Logger, existing, sidecarVolumes []corev1.Volume) []corev1.Volume {
 	if len(sidecarVolumes) == 0 {
 		return existing
 	}
 
 	names := make(map[string]struct{}, len(existing))
-	for _, c := range existing {
-		names[c.Name] = struct{}{}
+	for _, v := range existing {
+		names[v.Name] = struct{}{}
 	}
 
-	for _, c := range sidecarVolumes {
-		if _, ok := names[c.Name]; ok {
-			logger.Info(fmt.Sprintf("Sidecar volume name cannot be %s. It's skipped", c.Name))
+	for _, v := range sidecarVolumes {
+		if _, ok := names[v.Name]; ok {
+			log.Info("Wrong sidecar volume name, it is skipped", "volumeName", v.Name)
 			continue
 		}
 
-		existing = append(existing, c)
+		existing = append(existing, v)
 	}
 
 	return existing
 }
 
-func AddSidecarPVCs(logger logr.Logger, existing, sidecarPVCs []corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
+func AddSidecarPVCs(log logr.Logger, existing, sidecarPVCs []corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
 	if len(sidecarPVCs) == 0 {
 		return existing
 	}
 
 	names := make(map[string]struct{}, len(existing))
-	for _, c := range existing {
-		names[c.Name] = struct{}{}
+	for _, p := range existing {
+		names[p.Name] = struct{}{}
 	}
 
-	for _, c := range sidecarPVCs {
-		if _, ok := names[c.Name]; ok {
-			logger.Info(fmt.Sprintf("Sidecar PVC name cannot be %s. It's skipped", c.Name))
+	for _, p := range sidecarPVCs {
+		if _, ok := names[p.Name]; ok {
+			log.Info("Wrong sidecar PVC name, it is skipped", "PVCName", p.Name)
 			continue
 		}
 
-		existing = append(existing, c)
+		existing = append(existing, p)
 	}
 
 	return existing

--- a/pkg/controller/pxc/backup.go
+++ b/pkg/controller/pxc/backup.go
@@ -33,7 +33,7 @@ type BackupScheduleJob struct {
 }
 
 func (r *ReconcilePerconaXtraDBCluster) reconcileBackups(cr *api.PerconaXtraDBCluster) error {
-	logger := r.logger("backup", cr.Namespace)
+	log := r.logger("backup", cr.Namespace)
 	backups := make(map[string]api.PXCScheduledBackupSchedule)
 	backupNamePrefix := backupJobClusterPrefix(cr.Name)
 
@@ -72,7 +72,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileBackups(cr *api.PerconaXtraDBCl
 			backups[bcp.Name] = bcp
 			strg, ok := cr.Spec.Backup.Storages[bcp.StorageName]
 			if !ok {
-				logger.Info("invalid storage name for backup", "backup name", cr.Spec.Backup.Schedule[i].Name, "storage name", bcp.StorageName)
+				log.Info("invalid storage name for backup", "backup name", cr.Spec.Backup.Schedule[i].Name, "storage name", bcp.StorageName)
 				continue
 			}
 
@@ -88,7 +88,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileBackups(cr *api.PerconaXtraDBCl
 				r.deleteBackupJob(bcp.Name)
 				jobID, err := r.crons.AddFuncWithSeconds(bcp.Schedule, r.createBackupJob(cr, bcp, strg.Type))
 				if err != nil {
-					logger.Error(err, "can't parse cronjob schedule", "backup name", cr.Spec.Backup.Schedule[i].Name, "schedule", bcp.Schedule)
+					log.Error(err, "can't parse cronjob schedule", "backup name", cr.Spec.Backup.Schedule[i].Name, "schedule", bcp.Schedule)
 					continue
 				}
 
@@ -109,14 +109,14 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileBackups(cr *api.PerconaXtraDBCl
 			if spec.Keep > 0 {
 				oldjobs, err := r.oldScheduledBackups(cr, item.Name, spec.Keep)
 				if err != nil {
-					logger.Error(err, "failed to list old backups", "job name", item.Name)
+					log.Error(err, "failed to list old backups", "job name", item.Name)
 					return true
 				}
 
 				for _, todel := range oldjobs {
 					err = r.client.Delete(context.TODO(), &todel)
 					if err != nil {
-						logger.Error(err, "failed to delete old backup", "backup name", todel.Name)
+						log.Error(err, "failed to delete old backup", "backup name", todel.Name)
 					}
 				}
 

--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -226,7 +226,7 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 		return reconcile.Result{}, errors.Wrap(err, "set CR version")
 	}
 
-	reqLogger := r.logger(o.Name, o.Namespace)
+	reqLog := r.logger(o.Name, o.Namespace)
 
 	if o.ObjectMeta.DeletionTimestamp != nil {
 		finalizers := []string{}
@@ -262,18 +262,18 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 
 	// wait until token issued to run PXC in data encrypted mode.
 	if o.ShouldWaitForTokenIssue() {
-		reqLogger.Info("wait for token issuing")
+		reqLog.Info("wait for token issuing")
 		return rr, nil
 	}
 
 	defer func() {
 		uerr := r.updateStatus(o, false, err)
 		if uerr != nil {
-			reqLogger.Error(uerr, "Update status")
+			reqLog.Error(uerr, "Update status")
 		}
 	}()
 
-	err = o.CheckNSetDefaults(r.serverVersion, reqLogger)
+	err = o.CheckNSetDefaults(r.serverVersion, reqLog)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "wrong PXC options")
 	}
@@ -281,7 +281,7 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 	if o.CompareVersionWith("1.7.0") >= 0 && *o.Spec.PXC.AutoRecovery {
 		err = r.recoverFullClusterCrashIfNeeded(o)
 		if err != nil {
-			reqLogger.Info("Failed to check if cluster needs to recover", "err", err.Error())
+			reqLog.Info("Failed to check if cluster needs to recover", "err", err.Error())
 		}
 	}
 
@@ -305,7 +305,7 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 	if o.Status.PXC.Version == "" || strings.HasSuffix(o.Status.PXC.Version, "intermediate") {
 		err := r.ensurePXCVersion(o, VersionServiceClient{OpVersion: o.Version().String()})
 		if err != nil {
-			reqLogger.Info("failed to ensure version, running with default", "error", err)
+			reqLog.Info("failed to ensure version, running with default", "error", err)
 		}
 	}
 
@@ -426,7 +426,7 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 	if o.CompareVersionWith("1.9.0") >= 0 {
 		err = r.reconcileReplication(o, userReconcileResult.updateReplicationPassword)
 		if err != nil {
-			reqLogger.Info("reconcile replication error", "err", err.Error())
+			reqLog.Info("reconcile replication error", "err", err.Error())
 		}
 	}
 
@@ -513,7 +513,7 @@ func (r *ReconcilePerconaXtraDBCluster) deploy(cr *api.PerconaXtraDBCluster) err
 		return errors.Wrap(err, "get operator deployment")
 	}
 
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 	inits := []corev1.Container{}
 	if cr.CompareVersionWith("1.5.0") >= 0 {
 		var imageName string
@@ -547,7 +547,7 @@ func (r *ReconcilePerconaXtraDBCluster) deploy(cr *api.PerconaXtraDBCluster) err
 	if client.IgnoreNotFound(err) != nil {
 		return errors.Wrap(err, "get internal secret")
 	}
-	nodeSet, err := pxc.StatefulSet(stsApp, cr.Spec.PXC.PodSpec, cr, secrets, inits, logger, r.getConfigVolume)
+	nodeSet, err := pxc.StatefulSet(stsApp, cr.Spec.PXC.PodSpec, cr, secrets, inits, log, r.getConfigVolume)
 	if err != nil {
 		return errors.Wrap(err, "get pxc statefulset")
 	}
@@ -639,7 +639,7 @@ func (r *ReconcilePerconaXtraDBCluster) deploy(cr *api.PerconaXtraDBCluster) err
 	// HAProxy StatefulSet
 	if cr.HAProxyEnabled() {
 		sfsHAProxy := statefulset.NewHAProxy(cr)
-		haProxySet, err := pxc.StatefulSet(sfsHAProxy, &cr.Spec.HAProxy.PodSpec, cr, secrets, nil, logger, r.getConfigVolume)
+		haProxySet, err := pxc.StatefulSet(sfsHAProxy, &cr.Spec.HAProxy.PodSpec, cr, secrets, nil, log, r.getConfigVolume)
 		if err != nil {
 			return errors.Wrap(err, "create HAProxy StatefulSet")
 		}
@@ -693,7 +693,7 @@ func (r *ReconcilePerconaXtraDBCluster) deploy(cr *api.PerconaXtraDBCluster) err
 
 	if cr.Spec.ProxySQL != nil && cr.Spec.ProxySQL.Enabled {
 		sfsProxy := statefulset.NewProxy(cr)
-		proxySet, err := pxc.StatefulSet(sfsProxy, cr.Spec.ProxySQL, cr, secrets, nil, logger, r.getConfigVolume)
+		proxySet, err := pxc.StatefulSet(sfsProxy, cr.Spec.ProxySQL, cr, secrets, nil, log, r.getConfigVolume)
 		if err != nil {
 			return errors.Wrap(err, "create ProxySQL Service")
 		}

--- a/pkg/controller/pxc/full_crash_recovery.go
+++ b/pkg/controller/pxc/full_crash_recovery.go
@@ -101,9 +101,9 @@ func (r *ReconcilePerconaXtraDBCluster) doFullCrashRecovery(crName, namespace st
 			maxSeqPod = podName
 		}
 	}
-	logger := r.logger(crName, namespace)
-	logger.Info("We are in full cluster crash, starting recovery")
-	logger.Info("Results of scanning sequences", "pod", maxSeqPod, "maxSeq", maxSeq)
+	log := r.logger(crName, namespace)
+	log.Info("We are in full cluster crash, starting recovery")
+	log.Info("Results of scanning sequences", "pod", maxSeqPod, "maxSeq", maxSeq)
 
 	pod := &corev1.Pod{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{

--- a/pkg/controller/pxc/replication.go
+++ b/pkg/controller/pxc/replication.go
@@ -101,7 +101,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileReplication(cr *api.PerconaXtra
 		return nil
 	}
 
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	sfs := statefulset.NewNode(cr)
 
@@ -142,7 +142,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileReplication(cr *api.PerconaXtra
 	}
 
 	if primaryPod == nil {
-		logger.Info("Unable to find primary pod for replication. No pod with name or ip like this", "primary name", primary)
+		log.Info("Unable to find primary pod for replication. No pod with name or ip like this", "primary name", primary)
 		return nil
 	}
 

--- a/pkg/controller/pxc/secrets.go
+++ b/pkg/controller/pxc/secrets.go
@@ -22,7 +22,7 @@ import (
 const internalSecretsPrefix = "internal-"
 
 func (r *ReconcilePerconaXtraDBCluster) reconcileUsersSecret(cr *api.PerconaXtraDBCluster) error {
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	secretObj := new(corev1.Secret)
 	err := r.client.Get(context.TODO(),
@@ -43,7 +43,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileUsersSecret(cr *api.PerconaXtra
 		if isChanged {
 			err := r.client.Update(context.TODO(), secretObj)
 			if err == nil {
-				logger.Info(fmt.Sprintf("User secrets updated: %s", cr.Spec.SecretsName))
+				log.Info("User secrets updated", "secrets", cr.Spec.SecretsName)
 			}
 			return err
 		}
@@ -69,7 +69,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileUsersSecret(cr *api.PerconaXtra
 		return fmt.Errorf("create Users secret: %v", err)
 	}
 
-	logger.Info(fmt.Sprintf("Created user secrets: %s", cr.Spec.SecretsName))
+	log.Info("Created user secrets", "secrets", cr.Spec.SecretsName)
 	return nil
 }
 

--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -262,22 +262,22 @@ func (r *ReconcilePerconaXtraDBCluster) smartUpdate(sfs api.StatefulApp, cr *api
 		return nil
 	}
 
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
-	logger.Info("statefulSet was changed, run smart update")
+	log.Info("statefulSet was changed, run smart update")
 
 	running, err := r.isBackupRunning(cr)
 	if err != nil {
-		logger.Error(err, "can't start 'SmartUpdate'")
+		log.Error(err, "can't start 'SmartUpdate'")
 		return nil
 	}
 	if running {
-		logger.Info("can't start/continue 'SmartUpdate': backup is running")
+		log.Info("can't start/continue 'SmartUpdate': backup is running")
 		return nil
 	}
 
 	if currentSet.Status.ReadyReplicas < currentSet.Status.Replicas {
-		logger.Info("can't start/continue 'SmartUpdate': waiting for all replicas are ready")
+		log.Info("can't start/continue 'SmartUpdate': waiting for all replicas are ready")
 		return nil
 	}
 
@@ -292,7 +292,7 @@ func (r *ReconcilePerconaXtraDBCluster) smartUpdate(sfs api.StatefulApp, cr *api
 		}
 	}
 
-	logger.Info("primary pod", "pod name", primary)
+	log.Info("primary pod", "pod name", primary)
 
 	waitLimit := 2 * 60 * 60 // 2 hours
 	if cr.Spec.PXC.LivenessInitialDelaySeconds != nil {
@@ -309,19 +309,19 @@ func (r *ReconcilePerconaXtraDBCluster) smartUpdate(sfs api.StatefulApp, cr *api
 		if strings.HasPrefix(primary, fmt.Sprintf("%s.%s.%s", pod.Name, currentSet.Name, currentSet.Namespace)) {
 			primaryPod = pod
 		} else {
-			logger.Info("apply changes to secondary pod", "pod name", pod.Name)
+			log.Info("apply changes to secondary pod", "pod name", pod.Name)
 			if err := r.applyNWait(cr, currentSet, &pod, waitLimit); err != nil {
 				return errors.Wrap(err, "failed to apply changes")
 			}
 		}
 	}
 
-	logger.Info("apply changes to primary pod", "pod name", primaryPod.Name)
+	log.Info("apply changes to primary pod", "pod name", primaryPod.Name)
 	if err := r.applyNWait(cr, currentSet, &primaryPod, waitLimit); err != nil {
 		return errors.Wrap(err, "failed to apply changes")
 	}
 
-	logger.Info("smart update finished")
+	log.Info("smart update finished")
 
 	return nil
 }

--- a/pkg/controller/pxc/users.go
+++ b/pkg/controller/pxc/users.go
@@ -218,7 +218,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUser(cr *api.PerconaXtraDBClus
 		if err != nil {
 			return errors.Wrap(err, "discard old pass")
 		}
-		log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+		log.Info("Old password discarded", "user", user.Name)
 
 		return nil
 	}
@@ -229,7 +229,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUser(cr *api.PerconaXtraDBClus
 	if err != nil {
 		return errors.Wrap(err, "update root users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("Password updated", "user", user.Name)
 
 	err = r.syncPXCUsersWithProxySQL(cr)
 	if err != nil {
@@ -248,7 +248,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUser(cr *api.PerconaXtraDBClus
 	if err != nil {
 		return errors.Wrap(err, "discard old password")
 	}
-	log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+	log.Info("Old password discarded", "user", user.Name)
 
 	return nil
 }
@@ -287,7 +287,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUser(cr *api.PerconaXtraDB
 		if err != nil {
 			return errors.Wrap(err, "discard old pass")
 		}
-		log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+		log.Info("Old password discarded", "user", user.Name)
 
 		return nil
 	}
@@ -298,7 +298,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUser(cr *api.PerconaXtraDB
 	if err != nil {
 		return errors.Wrap(err, "update operator users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("Password updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -314,7 +314,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUser(cr *api.PerconaXtraDB
 	if err != nil {
 		return errors.Wrap(err, "discard operator old password")
 	}
-	log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+	log.Info("Old password discarded", "user", user.Name)
 
 	return nil
 }
@@ -436,7 +436,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(cr *api.PerconaXtraDBC
 	}
 
 	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) && !passDiscarded {
-		log.Info(fmt.Sprintf("User %s: password updated but old one not discarded", user.Name))
+		log.Info("Password updated but old one not discarded", "user", user.Name)
 
 		passPropagated, err := r.isPassPropagated(cr, user)
 		if err != nil {
@@ -455,7 +455,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(cr *api.PerconaXtraDBC
 		if err != nil {
 			return errors.Wrap(err, "discard old pass")
 		}
-		log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+		log.Info("Old password discarded", "user", user.Name)
 
 		return nil
 	}
@@ -466,14 +466,14 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(cr *api.PerconaXtraDBC
 	if err != nil {
 		return errors.Wrap(err, "update monitor users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("Password updated", "user", user.Name)
 
 	if cr.Spec.ProxySQL != nil && cr.Spec.ProxySQL.Enabled {
 		err := r.updateProxyUser(cr, internalSecrets, user)
 		if err != nil {
 			return errors.Wrap(err, "update monitor users pass")
 		}
-		log.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
+		log.Info("Proxy user updated", "user", user.Name)
 	}
 
 	actions.restartProxy = true
@@ -501,7 +501,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(cr *api.PerconaXtraDBC
 	if err != nil {
 		return errors.Wrap(err, "discard monitor old password")
 	}
-	log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+	log.Info("Old password discarded", "user", user.Name)
 
 	return nil
 }
@@ -595,7 +595,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUser(cr *api.PerconaXt
 		if err != nil {
 			return errors.Wrap(err, "discard old pass")
 		}
-		log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+		log.Info("Old password discarded", "user", user.Name)
 
 		return nil
 	}
@@ -606,7 +606,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUser(cr *api.PerconaXt
 	if err != nil {
 		return errors.Wrap(err, "update clustercheck users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("Password updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -620,7 +620,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUser(cr *api.PerconaXt
 	if err != nil {
 		return errors.Wrap(err, "discard clustercheck old pass")
 	}
-	log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+	log.Info("Old password discarded", "user", user.Name)
 
 	return nil
 }
@@ -666,7 +666,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUser(cr *api.PerconaXtra
 		if err != nil {
 			return errors.Wrap(err, "discard old pass")
 		}
-		log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+		log.Info("Old password discarded", "user", user.Name)
 
 		return nil
 	}
@@ -677,7 +677,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUser(cr *api.PerconaXtra
 	if err != nil {
 		return errors.Wrap(err, "update xtrabackup users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("Password updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -691,7 +691,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUser(cr *api.PerconaXtra
 	if err != nil {
 		return errors.Wrap(err, "discard xtrabackup old pass")
 	}
-	log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+	log.Info("Old password discarded", "user", user.Name)
 
 	actions.restartPXC = true
 	return nil
@@ -768,7 +768,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUser(cr *api.PerconaXtr
 		if err != nil {
 			return errors.Wrap(err, "discard old pass")
 		}
-		log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+		log.Info("Old password discarded", "user", user.Name)
 
 		return nil
 	}
@@ -779,7 +779,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUser(cr *api.PerconaXtr
 	if err != nil {
 		return errors.Wrap(err, "update replication users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("Password updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -793,7 +793,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUser(cr *api.PerconaXtr
 	if err != nil {
 		return errors.Wrap(err, "discard replicaiton old pass")
 	}
-	log.Info(fmt.Sprintf("User %s: old password discarded", user.Name))
+	log.Info("Old password discarded", "user", user.Name)
 
 	actions.updateReplicationPass = true
 	return nil
@@ -874,7 +874,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUser(cr *api.PerconaXtra
 	if err != nil {
 		return errors.Wrap(err, "update Proxy users")
 	}
-	log.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
+	log.Info("Proxy user updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -904,7 +904,7 @@ func (r *ReconcilePerconaXtraDBCluster) handlePMMUser(cr *api.PerconaXtraDBClust
 			if err != nil {
 				return errors.Wrap(err, "update internal users secrets pmm user password")
 			}
-			log.Info(fmt.Sprintf("User %s: internal secrets updated", users.PMMServerKey))
+			log.Info("Internal secrets updated", "user", users.PMMServerKey)
 
 			return nil
 		}
@@ -923,7 +923,7 @@ func (r *ReconcilePerconaXtraDBCluster) handlePMMUser(cr *api.PerconaXtraDBClust
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("User %s: password changed, updating user", name))
+	log.Info("Password changed, updating user", "user", name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[name] = secrets.Data[name]
@@ -931,7 +931,7 @@ func (r *ReconcilePerconaXtraDBCluster) handlePMMUser(cr *api.PerconaXtraDBClust
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets pmm user password")
 	}
-	log.Info(fmt.Sprintf("User %s: internal secrets updated", name))
+	log.Info("Internal secrets updated", "user", name)
 
 	actions.restartPXC = true
 	actions.restartProxy = true
@@ -1120,7 +1120,7 @@ func (r *ReconcilePerconaXtraDBCluster) grantSystemUserPrivilege(cr *api.Percona
 		return errors.Wrap(err, "update internal sys users secret annotation")
 	}
 
-	log.Info(fmt.Sprintf("User %s: system user privileges granted", user.Name))
+	log.Info("System user privileges granted", "user", user.Name)
 	return nil
 }
 

--- a/pkg/controller/pxc/users.go
+++ b/pkg/controller/pxc/users.go
@@ -223,7 +223,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUser(cr *api.PerconaXtraDBClus
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	logger.Info("Password changed, updating user", "user", user.Name)
 
 	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -242,7 +242,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUser(cr *api.PerconaXtraDBClus
 	if err != nil {
 		return errors.Wrap(err, "update internal secrets root user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -292,7 +292,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUser(cr *api.PerconaXtraDB
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	logger.Info("Password changed, updating user", "user", user.Name)
 
 	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -306,7 +306,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUser(cr *api.PerconaXtraDB
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets operator user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	actions.restartProxy = true
 
@@ -460,7 +460,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(cr *api.PerconaXtraDBC
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	logger.Info("Password changed, updating user", "user", user.Name)
 
 	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -487,7 +487,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(cr *api.PerconaXtraDBC
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets monitor user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	passPropagated, err := r.isPassPropagated(cr, user)
 	if err != nil {
@@ -600,7 +600,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUser(cr *api.PerconaXt
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	logger.Info("Password changed, updating user", "user", user.Name)
 
 	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -614,7 +614,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUser(cr *api.PerconaXt
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets clustercheck user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -671,7 +671,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUser(cr *api.PerconaXtra
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	logger.Info("Password changed, updating user", "user", user.Name)
 
 	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -685,7 +685,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUser(cr *api.PerconaXtra
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets xtrabackup user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -773,7 +773,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUser(cr *api.PerconaXtr
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	logger.Info("Password changed, updating user", "user", user.Name)
 
 	err = r.updateUserPassWithRetention(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -787,7 +787,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUser(cr *api.PerconaXtr
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets replication user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	err = r.discardOldPassword(cr, secrets, internalSecrets, user)
 	if err != nil {
@@ -868,7 +868,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUser(cr *api.PerconaXtra
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	logger.Info("Password changed, updating user", "user", user.Name)
 
 	err := r.updateProxyUser(cr, internalSecrets, user)
 	if err != nil {
@@ -882,7 +882,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUser(cr *api.PerconaXtra
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets proxyadmin user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	actions.restartProxy = true
 

--- a/pkg/controller/pxc/users_without_dp.go
+++ b/pkg/controller/pxc/users_without_dp.go
@@ -3,7 +3,6 @@ package pxc
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
@@ -78,13 +77,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUserWithoutDP(cr *api.PerconaX
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info("Password changed, updating user", "user", user.Name)
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update root users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("User password updated", "user", user.Name)
 
 	err = r.syncPXCUsersWithProxySQL(cr)
 	if err != nil {
@@ -126,13 +125,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUserWithoutDP(cr *api.Perc
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info("Password changed, updating user", "user", user.Name)
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update operator users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("User password updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -205,20 +204,20 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUserWithoutDP(cr *api.Perco
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info("Password changed, updating user", "user", user.Name)
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update monitor users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("User password updated", "user", user.Name)
 
 	if cr.Spec.ProxySQL != nil && cr.Spec.ProxySQL.Enabled {
 		err := r.updateProxyUser(cr, internalSecrets, user)
 		if err != nil {
 			return errors.Wrap(err, "update monitor users pass")
 		}
-		log.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
+		log.Info("Proxy user updated", "user", user.Name)
 	}
 
 	actions.restartProxy = true
@@ -289,13 +288,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUserWithoutDP(cr *api.
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info("Password changed, updating user", "user", user.Name)
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update clustercheck users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("User password updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -339,13 +338,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUserWithoutDP(cr *api.Pe
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info("Password changed, updating user", "user", user.Name)
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update xtrabackup users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("User password updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -391,13 +390,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUserWithoutDP(cr *api.P
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info("Password changed, updating user", "user", user.Name)
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update replication users pass")
 	}
-	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info("User password updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -431,13 +430,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUserWithoutDP(cr *api.Pe
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info("Password changed, updating user", "user", user.Name)
 
 	err := r.updateProxyUser(cr, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update Proxy users")
 	}
-	log.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
+	log.Info("Proxy user updated", "user", user.Name)
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]

--- a/pkg/controller/pxc/users_without_dp.go
+++ b/pkg/controller/pxc/users_without_dp.go
@@ -97,7 +97,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUserWithoutDP(cr *api.PerconaX
 	if err != nil {
 		return errors.Wrap(err, "update internal secrets root user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	return nil
 }
@@ -140,7 +140,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUserWithoutDP(cr *api.Perc
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets operator user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	actions.restartProxy = true
 	return nil
@@ -232,7 +232,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUserWithoutDP(cr *api.Perco
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets monitor user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	return nil
 }
@@ -303,7 +303,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUserWithoutDP(cr *api.
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets clustercheck user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	return nil
 }
@@ -353,7 +353,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUserWithoutDP(cr *api.Pe
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets xtrabackup user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	actions.restartPXC = true
 	return nil
@@ -405,7 +405,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUserWithoutDP(cr *api.P
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets replication user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	actions.updateReplicationPass = true
 	return nil
@@ -445,7 +445,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUserWithoutDP(cr *api.Pe
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets proxyadmin user password")
 	}
-	logger.Info(fmt.Sprintf("User %s: internal secrets updated", user.Name))
+	logger.Info("Internal secrets updated", "user", user.Name)
 
 	actions.restartProxy = true
 

--- a/pkg/controller/pxc/users_without_dp.go
+++ b/pkg/controller/pxc/users_without_dp.go
@@ -66,7 +66,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUserWithoutDP(cr *api.PerconaX
 		return nil
 	}
 
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	user := &users.SysUser{
 		Name:  users.Root,
@@ -78,13 +78,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUserWithoutDP(cr *api.PerconaX
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update root users pass")
 	}
-	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
 	err = r.syncPXCUsersWithProxySQL(cr)
 	if err != nil {
@@ -97,13 +97,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUserWithoutDP(cr *api.PerconaX
 	if err != nil {
 		return errors.Wrap(err, "update internal secrets root user password")
 	}
-	logger.Info("Internal secrets updated", "user", user.Name)
+	log.Info("Internal secrets updated", "user", user.Name)
 
 	return nil
 }
 
 func (r *ReconcilePerconaXtraDBCluster) handleOperatorUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	user := &users.SysUser{
 		Name:  users.Operator,
@@ -126,13 +126,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUserWithoutDP(cr *api.Perc
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update operator users pass")
 	}
-	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -140,14 +140,14 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUserWithoutDP(cr *api.Perc
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets operator user password")
 	}
-	logger.Info("Internal secrets updated", "user", user.Name)
+	log.Info("Internal secrets updated", "user", user.Name)
 
 	actions.restartProxy = true
 	return nil
 }
 
 func (r *ReconcilePerconaXtraDBCluster) handleMonitorUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	user := &users.SysUser{
 		Name:  users.Monitor,
@@ -205,20 +205,20 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUserWithoutDP(cr *api.Perco
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update monitor users pass")
 	}
-	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
 	if cr.Spec.ProxySQL != nil && cr.Spec.ProxySQL.Enabled {
 		err := r.updateProxyUser(cr, internalSecrets, user)
 		if err != nil {
 			return errors.Wrap(err, "update monitor users pass")
 		}
-		logger.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
+		log.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
 	}
 
 	actions.restartProxy = true
@@ -232,13 +232,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUserWithoutDP(cr *api.Perco
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets monitor user password")
 	}
-	logger.Info("Internal secrets updated", "user", user.Name)
+	log.Info("Internal secrets updated", "user", user.Name)
 
 	return nil
 }
 
 func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	user := &users.SysUser{
 		Name:  users.Clustercheck,
@@ -289,13 +289,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUserWithoutDP(cr *api.
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update clustercheck users pass")
 	}
-	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -303,13 +303,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUserWithoutDP(cr *api.
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets clustercheck user password")
 	}
-	logger.Info("Internal secrets updated", "user", user.Name)
+	log.Info("Internal secrets updated", "user", user.Name)
 
 	return nil
 }
 
 func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	user := &users.SysUser{
 		Name:  users.Xtrabackup,
@@ -339,13 +339,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUserWithoutDP(cr *api.Pe
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update xtrabackup users pass")
 	}
-	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -353,14 +353,14 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUserWithoutDP(cr *api.Pe
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets xtrabackup user password")
 	}
-	logger.Info("Internal secrets updated", "user", user.Name)
+	log.Info("Internal secrets updated", "user", user.Name)
 
 	actions.restartPXC = true
 	return nil
 }
 
 func (r *ReconcilePerconaXtraDBCluster) handleReplicationUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	if cr.CompareVersionWith("1.9.0") < 0 {
 		return nil
@@ -391,13 +391,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUserWithoutDP(cr *api.P
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
 	err := r.updateUserPassWithoutDP(cr, secrets, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update replication users pass")
 	}
-	logger.Info(fmt.Sprintf("User %s: password updated", user.Name))
+	log.Info(fmt.Sprintf("User %s: password updated", user.Name))
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -405,14 +405,14 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUserWithoutDP(cr *api.P
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets replication user password")
 	}
-	logger.Info("Internal secrets updated", "user", user.Name)
+	log.Info("Internal secrets updated", "user", user.Name)
 
 	actions.updateReplicationPass = true
 	return nil
 }
 
 func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUserWithoutDP(cr *api.PerconaXtraDBCluster, secrets, internalSecrets *corev1.Secret, actions *userUpdateActions) error {
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	if cr.Spec.ProxySQL == nil || !cr.Spec.ProxySQL.Enabled {
 		return nil
@@ -431,13 +431,13 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUserWithoutDP(cr *api.Pe
 		return nil
 	}
 
-	logger.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
+	log.Info(fmt.Sprintf("User %s: password changed, updating user", user.Name))
 
 	err := r.updateProxyUser(cr, internalSecrets, user)
 	if err != nil {
 		return errors.Wrap(err, "update Proxy users")
 	}
-	logger.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
+	log.Info(fmt.Sprintf("User %s: proxy user updated", user.Name))
 
 	orig := internalSecrets.DeepCopy()
 	internalSecrets.Data[user.Name] = secrets.Data[user.Name]
@@ -445,7 +445,7 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUserWithoutDP(cr *api.Pe
 	if err != nil {
 		return errors.Wrap(err, "update internal users secrets proxyadmin user password")
 	}
-	logger.Info("Internal secrets updated", "user", user.Name)
+	log.Info("Internal secrets updated", "user", user.Name)
 
 	actions.restartProxy = true
 

--- a/pkg/controller/pxcbackup/controller.go
+++ b/pkg/controller/pxcbackup/controller.go
@@ -133,7 +133,7 @@ func (r *ReconcilePerconaXtraDBClusterBackup) logger(name, namespace string) log
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcilePerconaXtraDBClusterBackup) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	logger := r.logger(request.Name, request.Namespace)
+	log := r.logger(request.Name, request.Namespace)
 
 	rr := reconcile.Result{
 		RequeueAfter: time.Second * 5,
@@ -172,11 +172,11 @@ func (r *ReconcilePerconaXtraDBClusterBackup) Reconcile(ctx context.Context, req
 
 	cluster, err := r.getCluster(cr)
 	if err != nil {
-		logger.Error(err, "invalid backup cluster")
+		log.Error(err, "invalid backup cluster")
 		return rr, nil
 	}
 
-	err = cluster.CheckNSetDefaults(r.serverVersion, logger)
+	err = cluster.CheckNSetDefaults(r.serverVersion, log)
 	if err != nil {
 		return rr, errors.Wrap(err, "wrong PXC options")
 	}
@@ -225,7 +225,7 @@ func (r *ReconcilePerconaXtraDBClusterBackup) Reconcile(ctx context.Context, req
 		// Check if this PVC already exists
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, pvc)
 		if err != nil && k8sErrors.IsNotFound(err) {
-			logger.Info("Creating a new volume for backup", "Namespace", pvc.Namespace, "Name", pvc.Name)
+			log.Info("Creating a new volume for backup", "Namespace", pvc.Namespace, "Name", pvc.Name)
 			err = r.client.Create(context.TODO(), pvc)
 			if err != nil {
 				return rr, errors.Wrap(err, "create backup pvc")
@@ -271,7 +271,7 @@ func (r *ReconcilePerconaXtraDBClusterBackup) Reconcile(ctx context.Context, req
 	if err != nil && !k8sErrors.IsAlreadyExists(err) {
 		return rr, errors.Wrap(err, "create backup job")
 	} else if err == nil {
-		logger.Info("Created a new backup job", "Namespace", job.Namespace, "Name", job.Name)
+		log.Info("Created a new backup job", "Namespace", job.Namespace, "Name", job.Name)
 	}
 
 	err = r.updateJobStatus(cr, job, cr.Spec.StorageName, storage, cluster)
@@ -310,7 +310,7 @@ func (r *ReconcilePerconaXtraDBClusterBackup) tryRunBackupFinalizers(ctx context
 }
 
 func (r *ReconcilePerconaXtraDBClusterBackup) runDeleteBackupFinalizer(ctx context.Context, cr *api.PerconaXtraDBClusterBackup) {
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	defer func() {
 		r.bcpDeleteInProgress.Delete(cr.Name)
@@ -340,22 +340,22 @@ func (r *ReconcilePerconaXtraDBClusterBackup) runDeleteBackupFinalizer(ctx conte
 			finalizers = append(finalizers, f)
 		}
 		if err != nil {
-			logger.Info("failed to delete backup", "backup path", cr.Status.Destination, "error", err.Error())
+			log.Info("failed to delete backup", "backup path", cr.Status.Destination, "error", err.Error())
 			finalizers = append(finalizers, f)
 		} else if f == api.FinalizerDeleteS3Backup {
-			logger.Info("backup was removed", "name", cr.Name)
+			log.Info("backup was removed", "name", cr.Name)
 		}
 	}
 	cr.SetFinalizers(finalizers)
 
 	err := r.client.Update(ctx, cr)
 	if err != nil {
-		logger.Error(err, "failed to update finalizers for backup", "backup", cr.Name)
+		log.Error(err, "failed to update finalizers for backup", "backup", cr.Name)
 	}
 }
 
 func (r *ReconcilePerconaXtraDBClusterBackup) runS3BackupFinalizer(cr *api.PerconaXtraDBClusterBackup) error {
-	logger := r.logger(cr.Name, cr.Namespace)
+	log := r.logger(cr.Name, cr.Namespace)
 
 	if cr.Status.S3 == nil {
 		return errors.New("s3 storage is not specified")
@@ -367,7 +367,7 @@ func (r *ReconcilePerconaXtraDBClusterBackup) runS3BackupFinalizer(cr *api.Perco
 	} else if k8sErrors.IsNotFound(err) {
 		return nil
 	}
-	logger.Info("deleting backup from s3", "name", cr.Name)
+	log.Info("deleting backup from s3", "name", cr.Name)
 
 	spl := strings.Split(cr.Status.Destination, "/")
 	backup := spl[len(spl)-1]

--- a/pkg/pxc/statefulset.go
+++ b/pkg/pxc/statefulset.go
@@ -54,7 +54,7 @@ func StatefulSet(sfs api.StatefulApp, podSpec *api.PodSpec, cr *api.PerconaXtraD
 
 	if cr.Spec.PMM != nil && cr.Spec.PMM.Enabled {
 		if !cr.Spec.PMM.HasSecret(secret) {
-			log.Info(fmt.Sprintf(`Can't enable PMM: either "pmmserverkey" key doesn't exist in the %s, or %s and %s secrets are out of sync`, cr.Spec.SecretsName, cr.Spec.SecretsName, "internal-"+cr.Name))
+			log.Info("Can't enable PMM, credentials are not setup correctly or secrets and internal secrets are our of sync")
 		} else {
 			pmmC, err := sfs.PMMContainer(cr.Spec.PMM, secret, cr)
 			if err != nil {

--- a/pkg/pxc/statefulset.go
+++ b/pkg/pxc/statefulset.go
@@ -54,7 +54,8 @@ func StatefulSet(sfs api.StatefulApp, podSpec *api.PodSpec, cr *api.PerconaXtraD
 
 	if cr.Spec.PMM != nil && cr.Spec.PMM.Enabled {
 		if !cr.Spec.PMM.HasSecret(secret) {
-			log.Info("Can't enable PMM, credentials are not setup correctly or secrets and internal secrets are our of sync")
+			log.Info(`Can't enable PMM: either "pmmserverkey" key doesn't exist in the secrets, or secrets and internal secrets are out of sync`,
+				"secrets", cr.Spec.SecretsName, "internalSecrets", "internal-"+cr.Name)
 		} else {
 			pmmC, err := sfs.PMMContainer(cr.Spec.PMM, secret, cr)
 			if err != nil {


### PR DESCRIPTION
[![K8SPXC-1198](https://badgen.net/badge/JIRA/K8SPXC-1198/green)](https://jira.percona.com/browse/K8SPXC-1198) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
In a couple of places, we use formatted log messages, breaking the whole structured logging thing we have.

**Cause:**
Misuse of our logging lib.

**Solution:**
Replace formatted messages with constant messages and proper use of KV pairs for the dynamic part of a log.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Are E2E tests passing?
- [x] Are unit tests passing?
- [x] Are linting tests passing?
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?