### PR TITLE
K8SPXC-1207 - Remove setTestsResults() from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,17 +166,6 @@ void makeReport() {
     TestsReport = TestsReport + "\r\n| We run $startedTestAmount out of $wholeTestAmount|"
 }
 
-void setTestsResults() {
-    for (int i=0; i<tests.size(); i++) {
-        def testNameWithMysqlVersion = tests[i]["name"] +"-"+ tests[i]["mysql_ver"].replace(".", "-")
-        def file="${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$testNameWithMysqlVersion"
-
-        if (tests[i]["result"] == "passed") {
-            pushArtifactFile(file)
-        }
-    }
-}
-
 void clusterRunner(String cluster) {
     def clusterCreated=0
 
@@ -220,6 +209,7 @@ void runTest(Integer TEST_ID) {
                 """
             }
             echo "end test url is $testUrl"
+            pushArtifactFile("$testNameWithMysqlVersion")
             tests[TEST_ID]["result"] = "passed"
             return true
         }
@@ -463,7 +453,6 @@ pipeline {
         always {
             script {
                 echo "CLUSTER ASSIGNMENTS\n" + tests.toString().replace("], ","]\n").replace("]]","]").replaceFirst("\\[","")
-                setTestsResults()
                 if (currentBuild.result != null && currentBuild.result != 'SUCCESS' && currentBuild.nextBuild == null) {
 
                     try {


### PR DESCRIPTION
[![K8SPXC-1207](https://badgen.net/badge/JIRA/K8SPXC-1207/green)](https://jira.percona.com/browse/K8SPXC-1207) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*In some pipelines we push "passed" file in the moment when the test passes, in some in the pipeline post action and in some in both places.*

**Solution:**
*Optimally we should create "passed" file in the moment when the test passes and there's no need to redo it in the pipeline post action.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?