### PR TITLE
fix sst thread lost

### DIFF
--- a/build/liveness-check.sh
+++ b/build/liveness-check.sh
@@ -9,7 +9,7 @@ if [ -f /tmp/recovery-case ] || [ -f '/var/lib/mysql/sleep-forever' ]; then
 	exit 0
 fi
 
-if [[ -f '/var/lib/mysql/sst_in_progress' ]] || [[ -f '/var/lib/mysql/wsrep_recovery_verbose.log' ]]; then
+if  ps -ef | grep -q "mysql.*sst" || [[ -f '/var/lib/mysql/wsrep_recovery_verbose.log' ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
After the PXC instance is started, there is a POD that cannot join the cluster.

**Cause:**
During PXC instance startup, the SST process within the POD is abnormally interrupted. When checking the POD, the SST
process cannot be found, but the st_in_progress file is present. The liveness-check.sh script does not detect any
exceptions and does not trigger a POD restart.

**Solution:**
Change the check from st_in_progress to SST process.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?