### PR TITLE
CLOUD-761 - Add test report and duration in Jenkins test runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ void initTests() {
     def records = readCSV file: 'e2e-tests/run-pr.csv'
 
     for (int i=0; i<records.size(); i++) {
-        tests.add(["name": records[i][0], "mysql_ver": records[i][1], "cluster": "NA", "result": "NA", "time": "0"])
+        tests.add(["name": records[i][0], "mysql_ver": records[i][1], "cluster": "NA", "result": "skipped", "time": "0"])
     }
 
     markPassedTests()
@@ -161,7 +161,7 @@ void makeReport() {
         def testNameWithMysqlVersion = tests[i]["name"] +"-"+ tests[i]["mysql_ver"].replace(".", "-")
         def testUrl = "${testUrlPrefix}/${env.GIT_BRANCH}/${env.GIT_SHORT_COMMIT}/${testNameWithMysqlVersion}.log"
 
-        if (tests[i]["result"] != "NA") {
+        if (tests[i]["result"] != "skipped") {
             startedTestAmount++
         }
         TestsReport = TestsReport + "\r\n| "+ testNameWithMysqlVersion +" | ["+ tests[i]["result"] +"]("+ testUrl +") |"
@@ -175,7 +175,7 @@ void clusterRunner(String cluster) {
     def clusterCreated=0
 
     for (int i=0; i<tests.size(); i++) {
-        if (tests[i]["result"] == "NA" && currentBuild.nextBuild == null) {
+        if (tests[i]["result"] == "skipped" && currentBuild.nextBuild == null) {
             tests[i]["result"] = "failure"
             tests[i]["cluster"] = cluster
             if (clusterCreated == 0) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -212,7 +212,7 @@ void runTest(Integer TEST_ID) {
                     time bash ./e2e-tests/$testName/run
                 """
             }
-            pushArtifactFile("$testNameWithMysqlVersion")
+            pushArtifactFile("${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$testNameWithMysqlVersion")
             tests[TEST_ID]["result"] = "passed"
             return true
         }


### PR DESCRIPTION
[![CLOUD-761](https://badgen.net/badge/JIRA/CLOUD-761/green)](https://jira.percona.com/browse/CLOUD-761) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Currently for PXC we don't generate JUnit test report and there are list of test durations is also missing.*

**Solution:**
*Add Jenkins test report and durations and fix parallel test pipeline cancelation https://jira.percona.com/browse/CLOUD-775*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?