### PR TITLE
K8SPXC-1163: fix cluster deletion in init state

### DIFF
--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -579,6 +579,15 @@ func (r *ReconcilePerconaXtraDBCluster) waitPodRestart(cr *api.PerconaXtraDBClus
 			for _, container := range pod.Status.ContainerStatuses {
 				if container.Name == "pxc" {
 					ready = container.Ready
+
+					if container.State.Waiting != nil {
+						switch container.State.Waiting.Reason {
+						case "ImagePullBackOff", "ErrImagePull":
+							return false, errors.Errorf("pod %s is in %s state", pod.Name, container.State.Waiting.Reason)
+						default:
+							logger.Info("pod is waiting", "pod name", pod.Name, "reason", container.State.Waiting.Reason)
+						}
+					}
 				}
 			}
 

--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -582,7 +582,7 @@ func (r *ReconcilePerconaXtraDBCluster) waitPodRestart(cr *api.PerconaXtraDBClus
 
 					if container.State.Waiting != nil {
 						switch container.State.Waiting.Reason {
-						case "ImagePullBackOff", "ErrImagePull":
+						case "ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff":
 							return false, errors.Errorf("pod %s is in %s state", pod.Name, container.State.Waiting.Reason)
 						default:
 							logger.Info("pod is waiting", "pod name", pod.Name, "reason", container.State.Waiting.Reason)


### PR DESCRIPTION
[![K8SPXC-1163](https://badgen.net/badge/JIRA/K8SPXC-1163/green)](https://jira.percona.com/browse/K8SPXC-1163) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-1163

**DESCRIPTION**
---
**Problem:**
*When pxc pod stuck in some error state during the cr update, operator is unable to execute finalizers*

**Cause:**
*When PXC statefulset is updated, operator updates PXC pods one by one using `applyNWait` method. This method waits pod to be restarted and can wait up to 2 hours until it's ready. In this period of time, we can't delete the cr if finalizers are used*

**Solution:**
*We should check PXC container state in the `applyNWait` method. If the pod has `ImagePullBackOff`, `ErrImagePull`, `CrashLoopBackOff`, we should return an error*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?