### PR TITLE
 K8SPXC-1225: System users with PASSWORD EXPIRE NEVER policy

### DIFF
--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -347,7 +347,7 @@ if [ -z "$CLUSTER_JOIN" ] && [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			# no, we don't care if read finds a terminating character in this heredoc
 			# https://unix.stackexchange.com/questions/265149/why-is-set-o-errexit-breaking-this-read-heredoc-expression/265151#265151
 			read -r -d '' rootCreate <<-EOSQL || true
-				CREATE USER 'root'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '$(escape_special "${MYSQL_ROOT_PASSWORD}")' ;
+				CREATE USER 'root'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '$(escape_special "${MYSQL_ROOT_PASSWORD}")' PASSWORD EXPIRE NEVER;
 				GRANT ALL ON *.* TO 'root'@'${MYSQL_ROOT_HOST}' WITH GRANT OPTION ;
 			EOSQL
 		fi
@@ -381,23 +381,23 @@ if [ -z "$CLUSTER_JOIN" ] && [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			${rootCreate}
 			/*!80016 REVOKE SYSTEM_USER ON *.* FROM root */;
 
-			CREATE USER 'operator'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '$(escape_special "${OPERATOR_ADMIN_PASSWORD}")' ;
+			CREATE USER 'operator'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '$(escape_special "${OPERATOR_ADMIN_PASSWORD}")' PASSWORD EXPIRE NEVER;
 			GRANT ALL ON *.* TO 'operator'@'${MYSQL_ROOT_HOST}' WITH GRANT OPTION ;
 
-			CREATE USER 'xtrabackup'@'%' IDENTIFIED BY '$(escape_special "${XTRABACKUP_PASSWORD}")';
+			CREATE USER 'xtrabackup'@'%' IDENTIFIED BY '$(escape_special "${XTRABACKUP_PASSWORD}")' PASSWORD EXPIRE NEVER;
 			GRANT ALL ON *.* TO 'xtrabackup'@'%';
 
-			CREATE USER 'monitor'@'${MONITOR_HOST}' IDENTIFIED BY '$(escape_special "${MONITOR_PASSWORD}")' WITH MAX_USER_CONNECTIONS 100;
+			CREATE USER 'monitor'@'${MONITOR_HOST}' IDENTIFIED BY '$(escape_special "${MONITOR_PASSWORD}")' WITH MAX_USER_CONNECTIONS 100 PASSWORD EXPIRE NEVER;
 			GRANT SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD ON *.* TO 'monitor'@'${MONITOR_HOST}';
 			GRANT SELECT ON performance_schema.* TO 'monitor'@'${MONITOR_HOST}';
 			${monitorConnectGrant}
 
-			CREATE USER 'clustercheck'@'localhost' IDENTIFIED BY '$(escape_special "${CLUSTERCHECK_PASSWORD}")';
+			CREATE USER 'clustercheck'@'localhost' IDENTIFIED BY '$(escape_special "${CLUSTERCHECK_PASSWORD}")' PASSWORD EXPIRE NEVER;
 			GRANT PROCESS ON *.* TO 'clustercheck'@'localhost';
 
 			${systemUserGrant}
 
-			CREATE USER 'replication'@'%' IDENTIFIED BY '$(escape_special "${REPLICATION_PASSWORD}")';
+			CREATE USER 'replication'@'%' IDENTIFIED BY '$(escape_special "${REPLICATION_PASSWORD}")' PASSWORD EXPIRE NEVER;
 			GRANT REPLICATION SLAVE ON *.* to 'replication'@'%';
 			DROP DATABASE IF EXISTS test;
 			FLUSH PRIVILEGES ;

--- a/e2e-tests/pitr/run
+++ b/e2e-tests/pitr/run
@@ -210,12 +210,21 @@ main() {
 
 	write_data_for_pitr "$cluster"
 	sleep 120 # need to wait while collector catch new data
-	binlogs_exist=$(
-		kubectl_bin run -n "${NAMESPACE}" -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
-			/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
-			/usr/bin/aws --endpoint-url https://minio-service:9000 --no-verify-ssl s3 ls operator-testing/binlogs/ | grep -c "binlog" | cat
-		exit "${PIPESTATUS[0]}"
-	)
+
+	timeout=60
+	binlogs_exist=0
+	for i in $(seq 2 3); do
+		binlogs_exist=$(
+			kubectl_bin run -n "${NAMESPACE}" -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
+				/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
+				/usr/bin/aws --endpoint-url https://minio-service:9000 --no-verify-ssl s3 ls operator-testing/binlogs/ | grep -c "binlog" | cat
+			exit "${PIPESTATUS[0]}"
+		)
+		if [ "$binlogs_exist" -eq 0 ]; then
+			sleep "$((timeout * i))"
+		fi
+	done
+
 	if [ "$binlogs_exist" -eq 0 ]; then
 		echo "Binlogs are not found in S3"
 		exit 1

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 	"github.com/percona/percona-xtradb-cluster-operator/version"
 )
 
@@ -472,7 +473,7 @@ func (spec *PMMSpec) IsEnabled(secret *corev1.Secret) bool {
 }
 
 func (spec *PMMSpec) HasSecret(secret *corev1.Secret) bool {
-	for _, key := range []string{"pmmserver", "pmmserverkey"} {
+	for _, key := range []string{users.PMMServer, users.PMMServerKey} {
 		if _, ok := secret.Data[key]; ok {
 			return true
 		}
@@ -481,8 +482,8 @@ func (spec *PMMSpec) HasSecret(secret *corev1.Secret) bool {
 }
 
 func (spec *PMMSpec) UseAPI(secret *corev1.Secret) bool {
-	if _, ok := secret.Data["pmmserverkey"]; !ok {
-		if _, ok := secret.Data["pmmserver"]; ok {
+	if _, ok := secret.Data[users.PMMServerKey]; !ok {
+		if _, ok := secret.Data[users.PMMServer]; ok {
 			return false
 		}
 	}

--- a/pkg/controller/pxc/secrets.go
+++ b/pkg/controller/pxc/secrets.go
@@ -78,7 +78,8 @@ func setUserSecretDefaults(secret *corev1.Secret) (isChanged bool, err error) {
 	if secret.Data == nil {
 		secret.Data = make(map[string][]byte)
 	}
-	users := []string{"root", "xtrabackup", "monitor", "clustercheck", "proxyadmin", "operator", "replication"}
+	users := []string{users.Root, users.Xtrabackup, users.Monitor, users.Clustercheck,
+		users.ProxyAdmin, users.Operator, users.Replication}
 	for _, user := range users {
 		if pass, ok := secret.Data[user]; !ok || len(pass) == 0 {
 			secret.Data[user], err = generatePass()

--- a/pkg/controller/pxc/users.go
+++ b/pkg/controller/pxc/users.go
@@ -205,7 +205,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUser(ctx context.Context, cr *
 		return nil
 	}
 
-	r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+	if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+		return err
+	}
 
 	passDiscarded, err := r.isOldPasswordDiscarded(cr, internalSecrets, user)
 	if err != nil {
@@ -271,7 +273,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUser(ctx context.Context, 
 			return errors.Wrap(err, "manage operator admin user")
 		}
 
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 	}
 
 	if cr.Status.Status != api.AppStateReady {
@@ -386,7 +390,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUser(ctx context.Context, c
 	}
 
 	if cr.Status.PXC.Ready > 0 {
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 
 		um, err := getUserManager(cr, internalSecrets)
 		if err != nil {
@@ -550,7 +556,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUser(ctx context.Conte
 	}
 
 	if cr.Status.PXC.Ready > 0 {
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 
 		if cr.CompareVersionWith("1.10.0") >= 0 {
 			mysqlVersion := cr.Status.PXC.Version
@@ -648,7 +656,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUser(ctx context.Context
 	}
 
 	if cr.Status.PXC.Ready > 0 {
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 
 		if cr.CompareVersionWith("1.7.0") >= 0 {
 			// xtrabackup user need more grants for work in version more then 1.6.0
@@ -760,7 +770,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUser(ctx context.Contex
 			return errors.Wrap(err, "manage replication user")
 		}
 
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 	}
 
 	if cr.Status.Status != api.AppStateReady {
@@ -881,7 +893,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUser(ctx context.Context
 		return nil
 	}
 
-	r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+	if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+		return err
+	}
 
 	log.Info("Password changed, updating user", "user", user.Name)
 

--- a/pkg/controller/pxc/users.go
+++ b/pkg/controller/pxc/users.go
@@ -1180,6 +1180,7 @@ func getUserManager(cr *api.PerconaXtraDBCluster, secrets *corev1.Secret) (*user
 
 func (r *ReconcilePerconaXtraDBCluster) updateUserPassExpirationPolicy(ctx context.Context, cr *api.PerconaXtraDBCluster, internalSecrets *corev1.Secret, user *users.SysUser) error {
 	log := logf.FromContext(ctx)
+
 	annotationName := "pass-expire-policy-for-1.13.0-user-" + user.Name
 	if internalSecrets.Annotations[annotationName] == "done" {
 		return nil
@@ -1193,6 +1194,10 @@ func (r *ReconcilePerconaXtraDBCluster) updateUserPassExpirationPolicy(ctx conte
 
 		if err := um.UpdatePassExpirationPolicy(user); err != nil {
 			return errors.Wrapf(err, "update %s user password expiration policy", user.Name)
+		}
+
+		if internalSecrets.Annotations == nil {
+			internalSecrets.Annotations = make(map[string]string)
 		}
 
 		internalSecrets.Annotations[annotationName] = "done"

--- a/pkg/controller/pxc/users.go
+++ b/pkg/controller/pxc/users.go
@@ -521,7 +521,7 @@ func (r *ReconcilePerconaXtraDBCluster) updateMonitorUserGrant(ctx context.Conte
 		return nil
 	}
 
-	err := um.Update160MonitorUserGrant(string(internalSysSecretObj.Data["monitor"]))
+	err := um.Update160MonitorUserGrant(string(internalSysSecretObj.Data[users.Monitor]))
 	if err != nil {
 		return errors.Wrap(err, "update monitor grant")
 	}

--- a/pkg/controller/pxc/users_without_dp.go
+++ b/pkg/controller/pxc/users_without_dp.go
@@ -74,6 +74,8 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUserWithoutDP(ctx context.Cont
 		Hosts: []string{"localhost", "%"},
 	}
 
+	r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+
 	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
 		return nil
 	}
@@ -116,6 +118,8 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUserWithoutDP(ctx context.
 		if err != nil {
 			return errors.Wrap(err, "manage operator admin user")
 		}
+
+		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
 	}
 
 	if cr.Status.Status != api.AppStateReady {
@@ -156,6 +160,8 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUserWithoutDP(ctx context.C
 	}
 
 	if cr.Status.PXC.Ready > 0 {
+		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+
 		um, err := getUserManager(cr, internalSecrets)
 		if err != nil {
 			return err
@@ -247,6 +253,8 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUserWithoutDP(ctx cont
 	}
 
 	if cr.Status.PXC.Ready > 0 {
+		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+
 		if cr.CompareVersionWith("1.10.0") >= 0 {
 			mysqlVersion := cr.Status.PXC.Version
 			if mysqlVersion == "" {
@@ -322,6 +330,8 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUserWithoutDP(ctx contex
 	}
 
 	if cr.Status.PXC.Ready > 0 {
+		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+
 		if cr.CompareVersionWith("1.7.0") >= 0 {
 			// monitor user need more grants for work in version more then 1.6.0
 			err := r.updateXtrabackupUserGrant(ctx, cr, internalSecrets)
@@ -381,6 +391,8 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUserWithoutDP(ctx conte
 		if err != nil {
 			return errors.Wrap(err, "manage replication user")
 		}
+
+		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
 	}
 
 	if cr.Status.Status != api.AppStateReady {
@@ -430,6 +442,8 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUserWithoutDP(ctx contex
 	if cr.Status.Status != api.AppStateReady {
 		return nil
 	}
+
+	r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
 
 	log.Info("Password changed, updating user", "user", user.Name)
 

--- a/pkg/controller/pxc/users_without_dp.go
+++ b/pkg/controller/pxc/users_without_dp.go
@@ -74,7 +74,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleRootUserWithoutDP(ctx context.Cont
 		Hosts: []string{"localhost", "%"},
 	}
 
-	r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+	if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+		return err
+	}
 
 	if bytes.Equal(secrets.Data[user.Name], internalSecrets.Data[user.Name]) {
 		return nil
@@ -119,7 +121,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleOperatorUserWithoutDP(ctx context.
 			return errors.Wrap(err, "manage operator admin user")
 		}
 
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 	}
 
 	if cr.Status.Status != api.AppStateReady {
@@ -160,7 +164,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleMonitorUserWithoutDP(ctx context.C
 	}
 
 	if cr.Status.PXC.Ready > 0 {
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 
 		um, err := getUserManager(cr, internalSecrets)
 		if err != nil {
@@ -253,7 +259,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleClustercheckUserWithoutDP(ctx cont
 	}
 
 	if cr.Status.PXC.Ready > 0 {
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 
 		if cr.CompareVersionWith("1.10.0") >= 0 {
 			mysqlVersion := cr.Status.PXC.Version
@@ -330,7 +338,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleXtrabackupUserWithoutDP(ctx contex
 	}
 
 	if cr.Status.PXC.Ready > 0 {
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 
 		if cr.CompareVersionWith("1.7.0") >= 0 {
 			// monitor user need more grants for work in version more then 1.6.0
@@ -392,7 +402,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleReplicationUserWithoutDP(ctx conte
 			return errors.Wrap(err, "manage replication user")
 		}
 
-		r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+		if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+			return err
+		}
 	}
 
 	if cr.Status.Status != api.AppStateReady {
@@ -443,7 +455,9 @@ func (r *ReconcilePerconaXtraDBCluster) handleProxyadminUserWithoutDP(ctx contex
 		return nil
 	}
 
-	r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user)
+	if err := r.updateUserPassExpirationPolicy(ctx, cr, internalSecrets, user); err != nil {
+		return err
+	}
 
 	log.Info("Password changed, updating user", "user", user.Name)
 

--- a/pkg/controller/pxc/version.go
+++ b/pkg/controller/pxc/version.go
@@ -21,6 +21,7 @@ import (
 	apiv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/k8s"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/queries"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 	"github.com/percona/percona-xtradb-cluster-operator/version"
 )
 
@@ -290,7 +291,6 @@ func (r *ReconcilePerconaXtraDBCluster) mysqlVersion(ctx context.Context, cr *ap
 		return "", errors.Wrap(err, "get pod list")
 	}
 
-	user := "root"
 	port := int32(3306)
 	secrets := cr.Spec.SecretsName
 	if cr.CompareVersionWith("1.6.0") >= 0 {
@@ -303,7 +303,7 @@ func (r *ReconcilePerconaXtraDBCluster) mysqlVersion(ctx context.Context, cr *ap
 			continue
 		}
 
-		database, err := queries.New(r.client, cr.Namespace, secrets, user, pod.Name+"."+cr.Name+"-pxc."+cr.Namespace, port, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
+		database, err := queries.New(r.client, cr.Namespace, secrets, users.Root, pod.Name+"."+cr.Name+"-pxc."+cr.Namespace, port, cr.Spec.PXC.ReadinessProbes.TimeoutSeconds)
 		if err != nil {
 			log.Error(err, "failed to create db instance")
 			continue

--- a/pkg/pxc/app/deployment/binlog-collector.go
+++ b/pkg/pxc/app/deployment/binlog-collector.go
@@ -18,11 +18,12 @@ import (
 	"github.com/percona/percona-xtradb-cluster-operator/clientcmd"
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 )
 
 func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster) (appsv1.Deployment, error) {
 	binlogCollectorName := GetBinlogCollectorDeploymentName(cr)
-	pxcUser := "xtrabackup"
+	pxcUser := users.Xtrabackup
 	sleepTime := fmt.Sprintf("%.2f", cr.Spec.Backup.PITR.TimeBetweenUploads)
 
 	bufferSize, err := getBufferSize(cr.Spec)

--- a/pkg/pxc/app/pmm.go
+++ b/pkg/pxc/app/pmm.go
@@ -1,9 +1,11 @@
 package app
 
 import (
-	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 )
 
 func PMMClient(spec *api.PMMSpec, secret *corev1.Secret, v120OrGreater bool, v170OrGreater bool) corev1.Container {
@@ -82,9 +84,9 @@ func pmmAgentEnvs(pmmServerHost, pmmServerUser, secrets string, useAPI bool) []c
 	var pmmServerPassKey string
 	if useAPI {
 		pmmServerUser = "api_key"
-		pmmServerPassKey = "pmmserverkey"
+		pmmServerPassKey = users.PMMServerKey
 	} else {
-		pmmServerPassKey = "pmmserver"
+		pmmServerPassKey = users.PMMServer
 	}
 	return []corev1.EnvVar{
 		{
@@ -191,9 +193,9 @@ func pmmEnvServerUser(user, secrets string, useAPI bool) []corev1.EnvVar {
 	var passKey string
 	if useAPI {
 		user = "api_key"
-		passKey = "pmmserverkey"
+		passKey = users.PMMServerKey
 	} else {
-		passKey = "pmmserver"
+		passKey = users.PMMServer
 	}
 	return []corev1.EnvVar{
 		{

--- a/pkg/pxc/app/statefulset/haproxy.go
+++ b/pkg/pxc/app/statefulset/haproxy.go
@@ -3,12 +3,14 @@ package statefulset
 import (
 	"fmt"
 
-	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
-	app "github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
+	app "github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 )
 
 const (
@@ -100,7 +102,7 @@ func (c *HAProxy) AppContainer(spec *api.PodSpec, secrets string, cr *api.Percon
 		appc.Env = append(appc.Env, corev1.EnvVar{
 			Name: "MONITOR_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secrets, "monitor"),
+				SecretKeyRef: app.SecretKeySelector(secrets, users.Monitor),
 			},
 		})
 	}
@@ -252,7 +254,7 @@ func (c *HAProxy) SidecarContainers(spec *api.PodSpec, secrets string, cr *api.P
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name: "MONITOR_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secrets, "monitor"),
+				SecretKeyRef: app.SecretKeySelector(secrets, users.Monitor),
 			},
 		})
 	}
@@ -301,22 +303,22 @@ func (c *HAProxy) PMMContainer(spec *api.PMMSpec, secret *corev1.Secret, cr *api
 		},
 		{
 			Name:  "MONITOR_USER",
-			Value: "monitor",
+			Value: users.Monitor,
 		},
 		{
 			Name: "MONITOR_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secret.Name, "monitor"),
+				SecretKeyRef: app.SecretKeySelector(secret.Name, users.Monitor),
 			},
 		},
 		{
 			Name:  "DB_USER",
-			Value: "monitor",
+			Value: users.Monitor,
 		},
 		{
 			Name: "DB_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secret.Name, "monitor"),
+				SecretKeyRef: app.SecretKeySelector(secret.Name, users.Monitor),
 			},
 		},
 		{

--- a/pkg/pxc/app/statefulset/node.go
+++ b/pkg/pxc/app/statefulset/node.go
@@ -10,6 +10,7 @@ import (
 
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	app "github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 )
 
 const (
@@ -126,19 +127,19 @@ func (c *Node) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXt
 			{
 				Name: "MYSQL_ROOT_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "root"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.Root),
 				},
 			},
 			{
 				Name: "XTRABACKUP_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "xtrabackup"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.Xtrabackup),
 				},
 			},
 			{
 				Name: "MONITOR_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "monitor"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.Monitor),
 				},
 			},
 		},
@@ -158,7 +159,7 @@ func (c *Node) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXt
 		appc.Env = append(appc.Env, corev1.EnvVar{
 			Name: "CLUSTERCHECK_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secrets, "clustercheck"),
+				SecretKeyRef: app.SecretKeySelector(secrets, users.Clustercheck),
 			},
 		})
 	}
@@ -233,7 +234,7 @@ func (c *Node) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXt
 		appc.Env = append(appc.Env, corev1.EnvVar{
 			Name: "OPERATOR_ADMIN_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secrets, "operator"),
+				SecretKeyRef: app.SecretKeySelector(secrets, users.Operator),
 			},
 		})
 		if cr.CompareVersionWith("1.11.0") >= 0 && cr.Spec.PXC != nil && cr.Spec.PXC.HookScript != "" {
@@ -325,7 +326,7 @@ func (c *Node) LogCollectorContainer(spec *api.LogCollectorSpec, logPsecrets str
 		{
 			Name: "MONITOR_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(logRsecrets, "monitor"),
+				SecretKeyRef: app.SecretKeySelector(logRsecrets, users.Monitor),
 			},
 		},
 	}
@@ -403,12 +404,12 @@ func (c *Node) PMMContainer(spec *api.PMMSpec, secret *corev1.Secret, cr *api.Pe
 		},
 		{
 			Name:  "DB_USER",
-			Value: "monitor",
+			Value: users.Monitor,
 		},
 		{
 			Name: "DB_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secret.Name, "monitor"),
+				SecretKeyRef: app.SecretKeySelector(secret.Name, users.Monitor),
 			},
 		},
 		{

--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -3,11 +3,13 @@ package statefulset
 import (
 	"errors"
 
-	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
-	app "github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
+	app "github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 )
 
 const (
@@ -91,23 +93,23 @@ func (c *Proxy) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaX
 			{
 				Name: "MYSQL_ROOT_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "root"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.Root),
 				},
 			},
 			{
 				Name:  "PROXY_ADMIN_USER",
-				Value: "proxyadmin",
+				Value: users.ProxyAdmin,
 			},
 			{
 				Name: "PROXY_ADMIN_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "proxyadmin"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.ProxyAdmin),
 				},
 			},
 			{
 				Name: "MONITOR_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "monitor"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.Monitor),
 				},
 			},
 		},
@@ -140,7 +142,7 @@ func (c *Proxy) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaX
 		appc.Env[1] = corev1.EnvVar{
 			Name: "OPERATOR_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secrets, "operator"),
+				SecretKeyRef: app.SecretKeySelector(secrets, users.Operator),
 			},
 		}
 	}
@@ -173,23 +175,23 @@ func (c *Proxy) SidecarContainers(spec *api.PodSpec, secrets string, cr *api.Per
 			{
 				Name: "MYSQL_ROOT_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "root"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.Root),
 				},
 			},
 			{
 				Name:  "PROXY_ADMIN_USER",
-				Value: "proxyadmin",
+				Value: users.ProxyAdmin,
 			},
 			{
 				Name: "PROXY_ADMIN_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "proxyadmin"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.ProxyAdmin),
 				},
 			},
 			{
 				Name: "MONITOR_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "monitor"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.Monitor),
 				},
 			},
 		},
@@ -213,23 +215,23 @@ func (c *Proxy) SidecarContainers(spec *api.PodSpec, secrets string, cr *api.Per
 			{
 				Name: "MYSQL_ROOT_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "root"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.Root),
 				},
 			},
 			{
 				Name:  "PROXY_ADMIN_USER",
-				Value: "proxyadmin",
+				Value: users.ProxyAdmin,
 			},
 			{
 				Name: "PROXY_ADMIN_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "proxyadmin"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.ProxyAdmin),
 				},
 			},
 			{
 				Name: "MONITOR_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: app.SecretKeySelector(secrets, "monitor"),
+					SecretKeyRef: app.SecretKeySelector(secrets, users.Monitor),
 				},
 			},
 		},
@@ -261,7 +263,7 @@ func (c *Proxy) SidecarContainers(spec *api.PodSpec, secrets string, cr *api.Per
 		operEnv := corev1.EnvVar{
 			Name: "OPERATOR_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secrets, "operator"),
+				SecretKeyRef: app.SecretKeySelector(secrets, users.Operator),
 			},
 		}
 		pxcMonit.Env[1] = operEnv
@@ -285,12 +287,12 @@ func (c *Proxy) PMMContainer(spec *api.PMMSpec, secret *corev1.Secret, cr *api.P
 		},
 		{
 			Name:  "MONITOR_USER",
-			Value: "monitor",
+			Value: users.Monitor,
 		},
 		{
 			Name: "MONITOR_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secret.Name, "monitor"),
+				SecretKeyRef: app.SecretKeySelector(secret.Name, users.Monitor),
 			},
 		},
 	}
@@ -298,12 +300,12 @@ func (c *Proxy) PMMContainer(spec *api.PMMSpec, secret *corev1.Secret, cr *api.P
 	dbEnvs := []corev1.EnvVar{
 		{
 			Name:  "DB_USER",
-			Value: "monitor",
+			Value: users.Monitor,
 		},
 		{
 			Name: "DB_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: app.SecretKeySelector(secret.Name, "monitor"),
+				SecretKeyRef: app.SecretKeySelector(secret.Name, users.Monitor),
 			},
 		},
 		{

--- a/pkg/pxc/backup/job.go
+++ b/pkg/pxc/backup/job.go
@@ -12,6 +12,7 @@ import (
 
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 )
 
 func (*Backup) Job(cr *api.PerconaXtraDBClusterBackup, cluster *api.PerconaXtraDBCluster) *batchv1.Job {
@@ -83,7 +84,7 @@ func (bcp *Backup) JobSpec(spec api.PXCBackupSpec, cluster *api.PerconaXtraDBClu
 							{
 								Name: "PXC_PASS",
 								ValueFrom: &corev1.EnvVarSource{
-									SecretKeyRef: app.SecretKeySelector(cluster.Spec.SecretsName, "xtrabackup"),
+									SecretKeyRef: app.SecretKeySelector(cluster.Spec.SecretsName, users.Xtrabackup),
 								},
 							},
 							{

--- a/pkg/pxc/backup/restore.go
+++ b/pkg/pxc/backup/restore.go
@@ -13,6 +13,7 @@ import (
 
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 )
 
 var log = logf.Log.WithName("backup/restore")
@@ -251,7 +252,7 @@ func AzureRestoreJob(cr *api.PerconaXtraDBClusterRestore, bcp *api.PerconaXtraDB
 		jobPVC,
 		app.GetSecretVolumes("vault-keyring-secret", cluster.PXC.VaultSecretName, true),
 	}
-	pxcUser := "xtrabackup"
+	pxcUser := users.Xtrabackup
 	command := []string{"recovery-cloud.sh"}
 
 	verifyTLS := true
@@ -476,7 +477,7 @@ func S3RestoreJob(cr *api.PerconaXtraDBClusterRestore, bcp *api.PerconaXtraDBClu
 		jobPVC,
 		app.GetSecretVolumes("vault-keyring-secret", cluster.Spec.PXC.VaultSecretName, true),
 	}
-	pxcUser := "xtrabackup"
+	pxcUser := users.Xtrabackup
 	command := []string{"recovery-cloud.sh"}
 	if cluster.CompareVersionWith("1.12.0") < 0 {
 		command = []string{"recovery-s3.sh"}

--- a/pkg/pxc/users/users.go
+++ b/pkg/pxc/users/users.go
@@ -287,3 +287,16 @@ func (u *Manager) CreateReplicationUser(password string) error {
 
 	return nil
 }
+
+// UpdatePassExpirationPolicy sets user password expiration policy to never
+func (u *Manager) UpdatePassExpirationPolicy(user *SysUser) error {
+	if user == nil {
+		return nil
+	}
+
+	for _, host := range user.Hosts {
+		_, err := u.db.Exec("ALTER USER ?@? PASSWORD EXPIRE NEVER", user.Name, host)
+		return err
+	}
+	return nil
+}

--- a/pkg/pxc/users/users.go
+++ b/pkg/pxc/users/users.go
@@ -296,7 +296,9 @@ func (u *Manager) UpdatePassExpirationPolicy(user *SysUser) error {
 
 	for _, host := range user.Hosts {
 		_, err := u.db.Exec("ALTER USER ?@? PASSWORD EXPIRE NEVER", user.Name, host)
-		return err
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
[![K8SPXC-1225](https://badgen.net/badge/JIRA/K8SPXC-1225/green)](https://jira.percona.com/browse/K8SPXC-1225) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
The operator does not handle password expiration for system users it creates, so when a user sets `default_password_lifetime` the cluster will break.

**Solution:**
Create system users with `PASSWORD EXPIRE NEVER` policy. Also, when the operator is upgraded, we will update existing sys users with the same expiration policy. Users are updated only once by using annotations on our `internalSecret` object, like:

```
    pass-expire-policy-for-1.13.0-user-clustercheck: done
    pass-expire-policy-for-1.13.0-user-monitor: done
    pass-expire-policy-for-1.13.0-user-operator: done
    pass-expire-policy-for-1.13.0-user-replication: done
    pass-expire-policy-for-1.13.0-user-root: done
    pass-expire-policy-for-1.13.0-user-xtrabackup: done
```

Also, I took the chance to refactor a bit, I removed repeating strings for our user names all over the place and instead use constants we have, like `users.Root`. 

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?