### PR TITLE
K8SPXC-1193: remove `isCA: true` from certificates

### DIFF
--- a/e2e-tests/init-deploy/compare/certificate_no-proxysql-ssl-internal.yml
+++ b/e2e-tests/init-deploy/compare/certificate_no-proxysql-ssl-internal.yml
@@ -14,7 +14,6 @@ spec:
     - no-proxysql-haproxy.namespace.svc.cluster.local
     - no-proxysql-haproxy.namespace
     - no-proxysql-haproxy
-  isCA: true
   issuerRef:
     kind: Issuer
     name: no-proxysql-pxc-issuer

--- a/e2e-tests/init-deploy/compare/certificate_no-proxysql-ssl.yml
+++ b/e2e-tests/init-deploy/compare/certificate_no-proxysql-ssl.yml
@@ -10,7 +10,6 @@ spec:
     - no-proxysql-proxysql
     - '*.no-proxysql-pxc'
     - '*.no-proxysql-proxysql'
-  isCA: true
   issuerRef:
     kind: Issuer
     name: no-proxysql-pxc-issuer

--- a/e2e-tests/tls-issue-cert-manager-ref/compare/certificate_some-name-tls-issueref-ssl.yml
+++ b/e2e-tests/tls-issue-cert-manager-ref/compare/certificate_some-name-tls-issueref-ssl.yml
@@ -11,7 +11,6 @@ spec:
     - '*.some-name-tls-issueref-pxc'
     - '*.some-name-tls-issueref-proxysql'
     - test.com
-  isCA: true
   issuerRef:
     kind: ClusterIssuer
     name: special-selfsigned-issuer

--- a/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-tls-issue-ssl.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-tls-issue-ssl.yml
@@ -11,7 +11,6 @@ spec:
     - '*.some-name-tls-issue-pxc'
     - '*.some-name-tls-issue-proxysql'
     - test.com
-  isCA: true
   issuerRef:
     kind: Issuer
     name: some-name-tls-issue-pxc-issuer

--- a/pkg/controller/pxc/tls.go
+++ b/pkg/controller/pxc/tls.go
@@ -122,7 +122,6 @@ func (r *ReconcilePerconaXtraDBCluster) createSSLByCertManager(cr *api.PerconaXt
 				"*." + cr.Name + "-pxc",
 				"*." + cr.Name + "-proxysql",
 			},
-			IsCA: true,
 			IssuerRef: cmmeta.ObjectReference{
 				Name:  issuerName,
 				Kind:  issuerKind,
@@ -162,7 +161,6 @@ func (r *ReconcilePerconaXtraDBCluster) createSSLByCertManager(cr *api.PerconaXt
 				cr.Name + "-haproxy." + cr.Namespace,
 				cr.Name + "-haproxy",
 			},
-			IsCA: true,
 			IssuerRef: cmmeta.ObjectReference{
 				Name:  issuerName,
 				Kind:  issuerKind,


### PR DESCRIPTION
[![K8SPXC-1193](https://badgen.net/badge/JIRA/K8SPXC-1193/green)](https://jira.percona.com/browse/K8SPXC-1193) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-1193

**DESCRIPTION**
---
**Problem:**
*Server certificates issued by cert-manager contain `isCA: true`*

**Solution:**
*Remove `isCA: true` from server certificates*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?