### PR TITLE
K8SPXC-1247: don't use unready proxysql svc for `.status.host`

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -878,7 +878,6 @@ spinup_pxc() {
 	local proxy=$(get_proxy "$cluster")
 	wait_for_running "$proxy" 1
 	wait_for_running "$cluster-pxc" "$size"
-	wait_cluster_consistency "$cluster" "$size"
 	sleep $sleep
 
 	desc 'write data'

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -80,13 +80,25 @@ version_gt() {
 	fi
 }
 
+get_proxy_size() {
+	local cluster=${1}
+	if [[ "$(kubectl_bin get pxc "${cluster}" -o 'jsonpath={.spec.haproxy.enabled}')" == "true" ]]; then
+		kubectl_bin get pxc "${cluster}" -o 'jsonpath={.spec.haproxy.size}'
+		return
+	fi
+	if [[ "$(kubectl_bin get pxc "${cluster}" -o 'jsonpath={.spec.proxysql.enabled}')" == "true" ]]; then
+		kubectl_bin get pxc "${cluster}" -o 'jsonpath={.spec.proxysql.size}'
+		return
+	fi
+}
+
 wait_cluster_consistency() {
 	local cluster_name=${1}
 	local cluster_size=${2}
 	local proxy_size=${3}
 
 	if [ -z "${proxy_size}" ]; then
-		proxy_size=${cluster_size}
+		proxy_size="$(get_proxy_size "$cluster_name")"
 	fi
 	desc "wait cluster consistency"
 	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
@@ -866,6 +878,7 @@ spinup_pxc() {
 	local proxy=$(get_proxy "$cluster")
 	wait_for_running "$proxy" 1
 	wait_for_running "$cluster-pxc" "$size"
+	wait_cluster_consistency "$cluster" "$size"
 	sleep $sleep
 
 	desc 'write data'

--- a/e2e-tests/proxysql-sidecar-res-limits/run
+++ b/e2e-tests/proxysql-sidecar-res-limits/run
@@ -12,7 +12,9 @@ deploy_cert_manager
 
 desc 'create PXC cluster'
 cluster="side-car"
-spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml" "3" "10" "${conf_dir}/secrets_without_tls.yml"
+size="3"
+spinup_pxc "$cluster" "$test_dir/conf/$cluster.yml" "$size" "10" "${conf_dir}/secrets_without_tls.yml"
+wait_cluster_consistency "$cluster" "$size" "2"
 
 desc 'check if service and statefulset created with expected config'
 compare_kubectl service/$cluster-proxysql

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -236,13 +236,12 @@ func (r *ReconcilePerconaXtraDBCluster) appStatus(app api.StatefulApp, namespace
 }
 
 func (r *ReconcilePerconaXtraDBCluster) appHost(cr *api.PerconaXtraDBCluster, app api.StatefulApp, podSpec *api.PodSpec) (string, error) {
-	if podSpec.ServiceType != corev1.ServiceTypeLoadBalancer {
-		return app.Service() + "." + cr.Namespace, nil
-	}
-
 	svcName := app.Service()
 	if app.Name() == "proxysql" {
 		svcName = cr.Name + "-proxysql"
+	}
+	if podSpec.ServiceType != corev1.ServiceTypeLoadBalancer {
+		return svcName + "." + cr.Namespace, nil
 	}
 
 	svc := &corev1.Service{}

--- a/pkg/controller/pxc/status_test.go
+++ b/pkg/controller/pxc/status_test.go
@@ -214,7 +214,7 @@ func TestAppHostNoLoadBalancer(t *testing.T) {
 
 	r := buildFakeClient([]runtime.Object{cr, pxcSfs, haproxySfs})
 
-	host, err := r.appHost(haproxy, cr.Namespace, &cr.Spec.HAProxy.PodSpec)
+	host, err := r.appHost(cr, haproxy, &cr.Spec.HAProxy.PodSpec)
 	if err != nil {
 		t.Error(err)
 	}
@@ -237,7 +237,7 @@ func TestAppHostLoadBalancerNoSvc(t *testing.T) {
 
 	r := buildFakeClient([]runtime.Object{cr, pxcSfs, haproxySfs})
 
-	_, err := r.appHost(haproxy, cr.Namespace, &cr.Spec.HAProxy.PodSpec)
+	_, err := r.appHost(cr, haproxy, &cr.Spec.HAProxy.PodSpec)
 	if err == nil {
 		t.Error("want err, got nil")
 	}
@@ -267,7 +267,7 @@ func TestAppHostLoadBalancerOnlyIP(t *testing.T) {
 
 	r := buildFakeClient([]runtime.Object{cr, pxcSfs, haproxySfs, haproxySvc})
 
-	host, err := r.appHost(haproxy, cr.Namespace, &cr.Spec.HAProxy.PodSpec)
+	host, err := r.appHost(cr, haproxy, &cr.Spec.HAProxy.PodSpec)
 	if err != nil {
 		t.Error(err)
 	}
@@ -301,7 +301,7 @@ func TestAppHostLoadBalancerWithHostname(t *testing.T) {
 
 	r := buildFakeClient([]runtime.Object{cr, pxcSfs, haproxySfs, haproxySvc})
 
-	gotHost, err := r.appHost(haproxy, cr.Namespace, &cr.Spec.HAProxy.PodSpec)
+	gotHost, err := r.appHost(cr, haproxy, &cr.Spec.HAProxy.PodSpec)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -45,7 +45,7 @@ func NewProxy(cr *api.PerconaXtraDBCluster) *Proxy {
 	return &Proxy{
 		sfs:     sfs,
 		labels:  labels,
-		service: cr.Name + "-proxysql-unready",
+		service: cr.Name + "-" + proxyName,
 	}
 }
 

--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -45,7 +45,7 @@ func NewProxy(cr *api.PerconaXtraDBCluster) *Proxy {
 	return &Proxy{
 		sfs:     sfs,
 		labels:  labels,
-		service: cr.Name + "-" + proxyName,
+		service: cr.Name + "-proxysql-unready",
 	}
 }
 


### PR DESCRIPTION
[![K8SPXC-1247](https://badgen.net/badge/JIRA/K8SPXC-1247/green)](https://jira.percona.com/browse/K8SPXC-1247) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-1247

**DESCRIPTION**
---
**Problem:**
*Cluster with `.spec.proxysql.serviceType: LoadBalancer` cannot get ready.*

**Cause:**
*Operator used unready service for `.status.host` field.*

**Solution:**
*Operator should use exposed service for `.status.host` field.*

To be able to catch this error in tests, the check for ready cluster status was added to `spinup_pxc` function

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?