### PR TITLE
K8SPXC-1165 - Fix cert-manager installation on OpenShift 4.10

### DIFF
--- a/e2e-tests/conf/some-name.yml
+++ b/e2e-tests/conf/some-name.yml
@@ -29,7 +29,7 @@ spec:
       antiAffinityTopologyKey: "kubernetes.io/hostname"
   proxysql:
     enabled: true
-    size: 1
+    size: 2
     image: -proxysql
     resources:
       requests:

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -43,11 +43,7 @@ if [ -f "$conf_dir/cloud-secret.yml" ]; then
 fi
 
 if oc get projects 2>/dev/null; then
-	# Guessing Openshift version from master node API version
-	case "$(oc get nodes --no-headers=true | grep master | head -n1 | grep -Eo 'v[0-9]+\.[0-9]+')" in
-		"v1.11") OPENSHIFT=3.11 ;;
-		*) OPENSHIFT=4 ;;
-	esac
+	OPENSHIFT=$(oc version -o json | jq -r '.openshiftVersion' | grep -oE '^[0-9]+\.[0-9]+')
 fi
 
 if [ $(kubectl version -o json | jq -r '.serverVersion.gitVersion' | grep "\-eks\-") ]; then
@@ -639,6 +635,15 @@ deploy_cert_manager() {
 	kubectl_bin create namespace cert-manager || :
 	kubectl_bin label namespace cert-manager certmanager.k8s.io/disable-validation=true || :
 	kubectl_bin apply -f "https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VER}/cert-manager.yaml" --validate=false || : 2>/dev/null
+	if [ "$OPENSHIFT" == "4.10" ]; then
+		oc delete scc restricted-seccomp || true
+		oc get scc restricted -o yaml | yq eval '.metadata.name = "restricted-seccomp" |
+		.seccompProfiles[0] = "runtime/default"' \
+			| oc create -f -
+		oc adm policy add-scc-to-user restricted-seccomp -z cert-manager
+		oc adm policy add-scc-to-user restricted-seccomp -z cert-manager-cainjector
+		oc adm policy add-scc-to-user restricted-seccomp -z cert-manager-webhook
+	fi
 	sleep 70
 }
 
@@ -891,6 +896,7 @@ spinup_pxc() {
 	kubectl_bin wait --for=condition=Ready pod -l app.kubernetes.io/instance=monitoring,app.kubernetes.io/managed-by=percona-xtradb-cluster-operator --timeout=300s -n ${namespace} || true
 	wait_for_running "$proxy" 1
 	wait_for_running "$cluster-pxc" "$size"
+	wait_cluster_consistency "${cluster}" "${size}"
 	sleep $sleep
 
 	desc 'write data'

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -896,7 +896,6 @@ spinup_pxc() {
 	kubectl_bin wait --for=condition=Ready pod -l app.kubernetes.io/instance=monitoring,app.kubernetes.io/managed-by=percona-xtradb-cluster-operator --timeout=300s -n ${namespace} || true
 	wait_for_running "$proxy" 1
 	wait_for_running "$cluster-pxc" "$size"
-	wait_cluster_consistency "${cluster}" "${size}"
 	sleep $sleep
 
 	desc 'write data'

--- a/e2e-tests/pitr-gap-errors/run
+++ b/e2e-tests/pitr-gap-errors/run
@@ -11,7 +11,7 @@ GTID_PATTERN='[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-
 
 if [[ $IMAGE_PXC =~ 5\.7 ]]; then
 	echo "Skipping PITR test because 5.7 doesn't support it!"
-	exit 1
+	exit 0
 fi
 
 run_recovery_check_pitr() {

--- a/e2e-tests/pitr/run
+++ b/e2e-tests/pitr/run
@@ -11,7 +11,7 @@ GTID_PATTERN='[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-
 
 if [[ $IMAGE_PXC =~ 5\.7 ]]; then
 	echo "Skipping PITR test because 5.7 doesn't support it!"
-	exit 1
+	exit 0
 fi
 
 run_recovery_check_pitr() {


### PR DESCRIPTION
[![K8SPXC-1165](https://badgen.net/badge/JIRA/K8SPXC-1165/green)](https://jira.percona.com/browse/K8SPXC-1165) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
1. Cert-manager requires some additional privileges on different openshift versions and for us it failed on 4.10.
More info: https://cert-manager.io/docs/release-notes/release-notes-1.10/
https://docs.openshift.com/container-platform/4.10/security/seccomp-profiles.html#configuring-default-seccomp-profile_configuring-seccomp-profiles

2. Test cluster some-name specifies 1 proxysql pod, but it always installs 2 because we don't allow unsafe configurations so some-name.yaml is updated with this to have up to date config.

3. Sometimes there is a write error on the cluster so I put wait_cluster_consistency in the `spinup_pxc` function to make the tests more stable.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?