### PR TITLE
Fix Misassigned pxc container resources to init container

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -312,9 +312,6 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 	inits := []corev1.Container{}
 	if o.CompareVersionWith("1.5.0") >= 0 {
 		var initResources corev1.ResourceRequirements
-		if o.CompareVersionWith("1.6.0") >= 0 {
-			initResources = o.Spec.PXC.Resources
-		}
 		initC := statefulset.EntrypointInitContainer(initImageName, app.DataVolumeName, initResources, o.Spec.PXC.ContainerSecurityContext, o.Spec.PXC.ImagePullPolicy)
 		inits = append(inits, initC)
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*Misassigned pxc container resources to init container.*

**Solution:**
*Init containers don't require significant resource demands. Moreover, even if resource requests need to be set for init containers, they don't need to be excessive, and certainly should not match those of the pxc containers!A simpler approach would be to remove the resource settings for the init containers.*