### PR TITLE
K8SPXC-1293: Use admin port in PiTR collector/recoverer

### DIFF
--- a/cmd/pitr/pxc/pxc.go
+++ b/cmd/pitr/pxc/pxc.go
@@ -29,7 +29,7 @@ func NewPXC(addr string, user, pass string) (*PXC, error) {
 	config.User = user
 	config.Passwd = pass
 	config.Net = "tcp"
-	config.Addr = addr
+	config.Addr = addr + ":33062"
 	config.Params = map[string]string{"interpolateParams": "true"}
 
 	mysqlDB, err := sql.Open("mysql", config.FormatDSN())


### PR DESCRIPTION
[![K8SPXC-1293](https://badgen.net/badge/JIRA/K8SPXC-1293/green)](https://jira.percona.com/browse/K8SPXC-1293) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
If proxy_protocol enabled (esp. with `proxy_protocol_networks="*"`), pitr collector fails to connect to MySQL and just hangs.

**Solution:**
Using admin port for connections fixes the problem.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?