### PR TITLE
K8SPXC-1293: Fix hanging mysqlbinlog in case proxy protocol enabled

### DIFF
--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -361,7 +361,7 @@ func (c *Collector) manageBinlog(ctx context.Context, binlog pxc.Binlog) (err er
 	}
 
 	errBuf := &bytes.Buffer{}
-	cmd := exec.CommandContext(ctx, "mysqlbinlog", "-R", "--raw", "-h"+c.db.GetHost(), "-u"+c.pxcUser, binlog.Name)
+	cmd := exec.CommandContext(ctx, "mysqlbinlog", "-R", "-P", "33062", "--raw", "-h"+c.db.GetHost(), "-u"+c.pxcUser, binlog.Name)
 	cmd.Env = append(cmd.Env, "MYSQL_PWD="+c.pxcPass)
 	cmd.Dir = os.TempDir()
 	cmd.Stderr = errBuf

--- a/cmd/pitr/recoverer/recoverer.go
+++ b/cmd/pitr/recoverer/recoverer.go
@@ -338,7 +338,7 @@ func (r *Recoverer) recover(ctx context.Context) (err error) {
 			return errors.Wrap(err, "set mysql pwd env var")
 		}
 
-		cmdString := "mysqlbinlog --disable-log-bin" + r.recoverFlag + " - | mysql -h" + r.db.GetHost() + " -u" + r.pxcUser
+		cmdString := "mysqlbinlog --disable-log-bin" + r.recoverFlag + " - | mysql -h" + r.db.GetHost() + " -P 33062 -u" + r.pxcUser
 		cmd := exec.CommandContext(ctx, "sh", "-c", cmdString)
 
 		cmd.Stdin = binlogObj


### PR DESCRIPTION
[![K8SPXC-1293](https://badgen.net/badge/JIRA/K8SPXC-1293/green)](https://jira.percona.com/browse/K8SPXC-1293) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
mysqlbinlog hangs and collector deadlocks.

**Cause:**
In case proxy protocol enabled mysqlbinlog fails to connect to DB using port 3306. Collector creates a named piped with read only mode but it hangs forever because no one writes to it.

**Solution:**
mysqlbinlog needs to use port 33062.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?