### PR TITLE
K8SPXC-927 Add support for serviceLabels and serviceAnnotations on the PXC service

### DIFF
--- a/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
+++ b/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
@@ -1709,6 +1709,11 @@ spec:
                               items:
                                 type: string
                               type: array
+                            allocatedResourceStatuses:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              x-kubernetes-map-type: granular
                             allocatedResources:
                               additionalProperties:
                                 anyOf:
@@ -1748,8 +1753,6 @@ spec:
                                 type: object
                               type: array
                             phase:
-                              type: string
-                            resizeStatus:
                               type: string
                           type: object
                       type: object
@@ -2904,6 +2907,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -4341,6 +4346,11 @@ spec:
                               items:
                                 type: string
                               type: array
+                            allocatedResourceStatuses:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              x-kubernetes-map-type: granular
                             allocatedResources:
                               additionalProperties:
                                 anyOf:
@@ -4380,8 +4390,6 @@ spec:
                                 type: object
                               type: array
                             phase:
-                              type: string
-                            resizeStatus:
                               type: string
                           type: object
                       type: object
@@ -5536,6 +5544,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -6791,6 +6801,11 @@ spec:
                               items:
                                 type: string
                               type: array
+                            allocatedResourceStatuses:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              x-kubernetes-map-type: granular
                             allocatedResources:
                               additionalProperties:
                                 anyOf:
@@ -6830,8 +6845,6 @@ spec:
                                 type: object
                               type: array
                             phase:
-                              type: string
-                            resizeStatus:
                               type: string
                           type: object
                       type: object
@@ -7986,6 +7999,8 @@ spec:
                                 x-kubernetes-int-or-string: true
                               type: object
                           type: object
+                        restartPolicy:
+                          type: string
                         securityContext:
                           properties:
                             allowPrivilegeEscalation:
@@ -8196,6 +8211,14 @@ spec:
                           type: string
                       type: object
                     type: array
+                  unreadyServiceAnnotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  unreadyServiceLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   vaultSecretName:
                     type: string
                   volumeSpec:

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -49,10 +49,12 @@ type PerconaXtraDBClusterSpec struct {
 }
 
 type PXCSpec struct {
-	AutoRecovery        *bool                `json:"autoRecovery,omitempty"`
-	ReplicationChannels []ReplicationChannel `json:"replicationChannels,omitempty"`
-	Expose              ServiceExpose        `json:"expose,omitempty"`
-	*PodSpec            `json:",inline"`
+	AutoRecovery              *bool                `json:"autoRecovery,omitempty"`
+	ReplicationChannels       []ReplicationChannel `json:"replicationChannels,omitempty"`
+	Expose                    ServiceExpose        `json:"expose,omitempty"`
+	UnreadyServiceAnnotations map[string]string    `json:"unreadyServiceAnnotations,omitempty"`
+	UnreadyServiceLabels      map[string]string    `json:"unreadyServiceLabels,omitempty"`
+	*PodSpec                  `json:",inline"`
 }
 
 type ServiceExpose struct {

--- a/pkg/apis/pxc/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pxc/v1/zz_generated.deepcopy.go
@@ -437,6 +437,20 @@ func (in *PXCSpec) DeepCopyInto(out *PXCSpec) {
 		}
 	}
 	in.Expose.DeepCopyInto(&out.Expose)
+	if in.UnreadyServiceAnnotations != nil {
+		in, out := &in.UnreadyServiceAnnotations, &out.UnreadyServiceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.UnreadyServiceLabels != nil {
+		in, out := &in.UnreadyServiceLabels, &out.UnreadyServiceLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.PodSpec != nil {
 		in, out := &in.PodSpec, &out.PodSpec
 		*out = new(PodSpec)

--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -332,7 +332,7 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 			return reconcile.Result{}, errors.Wrap(err, "setControllerReference")
 		}
 
-		err = r.createOrUpdateService(o, pxcService, true)
+		err = r.createOrUpdateService(o, pxcService, len(o.Spec.PXC.ServiceLabels) == 0 && len(o.Spec.PXC.ServiceAnnotations) == 0)
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "PXC service upgrade error")
 		}

--- a/pkg/pxc/service.go
+++ b/pkg/pxc/service.go
@@ -14,18 +14,27 @@ const (
 )
 
 func NewServicePXC(cr *api.PerconaXtraDBCluster) *corev1.Service {
+	serviceAnnotations := make(map[string]string)
+	serviceLabels := map[string]string{
+		"app.kubernetes.io/name":     "percona-xtradb-cluster",
+		"app.kubernetes.io/instance": cr.Name,
+	}
+
+	if cr.Spec.PXC != nil {
+		serviceAnnotations = cr.Spec.PXC.ServiceAnnotations
+		serviceLabels = fillServiceLabels(serviceLabels, cr.Spec.PXC.ServiceLabels)
+	}
+
 	obj := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-" + appName,
-			Namespace: cr.Namespace,
-			Labels: map[string]string{
-				"app.kubernetes.io/name":     "percona-xtradb-cluster",
-				"app.kubernetes.io/instance": cr.Name,
-			},
+			Name:        cr.Name + "-" + appName,
+			Namespace:   cr.Namespace,
+			Labels:      serviceLabels,
+			Annotations: serviceAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{


### PR DESCRIPTION
[![K8SPXC-1303](https://badgen.net/badge/JIRA/K8SPXC-1303/green)](https://jira.percona.com/browse/K8SPXC-1303) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Problem:**
If you specify serviceLabels/serviceAnnotations in your PXC config, the service doesn't get any of the labels/annotations applied.

**Cause:**
There isn't any code to apply them.

**Solution:**
This edits the NewServicePXC method to add support for adding these labels/annotations.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?