### PR TITLE
CLOUD-808 Fix PMM server deployment in tests

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -99,7 +99,7 @@ full list of variables is the following one:
 
 * `IMAGE` - the Operator, `perconalab/percona-xtradb-cluster-operator:main` by default,
 * `IMAGE_PXC` - Percona XtraDB Cluster, `perconalab/percona-xtradb-cluster-operator:main-pxc8.0` by default,
-* `IMAGE_PMM` - Percona Monitoring and Management (PMM) client, `perconalab/pmm-client:dev-latest` by default,
+* `IMAGE_PMM_CLIENT` - Percona Monitoring and Management (PMM) client, `perconalab/pmm-client:dev-latest` by default,
 * `IMAGE_PROXY` - ProxySQL, `perconalab/percona-xtradb-cluster-operator:main-proxysql` by default,
 * `IMAGE_HAPROXY` - HA Proxy, `perconalab/percona-xtradb-cluster-operator:main-haproxy` by default,
 * `IMAGE_BACKUP` - backups, `perconalab/percona-xtradb-cluster-operator:main-pxc8.0-backup` by default,

--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -64,24 +64,8 @@ function main() {
 	compare_kubectl service/$(get_proxy ${cluster})
 	compare_kubectl service/$(get_proxy ${cluster})-replicas
 
-	desc 'starting PMM up'
-	platform=kubernetes
-	helm uninstall monitoring || :
-	if [ ! -z "$OPENSHIFT" ]; then
-		platform=openshift
-		oc create sa pmm-server
-		oc adm policy add-scc-to-user privileged -z pmm-server
-		if [ -n "$OPERATOR_NS" ]; then
-			oc create clusterrolebinding pmm-pxc-operator-cluster-wide --clusterrole=percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
-			oc patch clusterrole/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]' ${OPERATOR_NS:+-n $OPERATOR_NS}
-		else
-			oc create rolebinding pmm-pxc-operator-namespace-only --role percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
-			oc patch role/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]'
-		fi
-		retry 10 60 helm install monitoring --set imageTag=$IMAGE_PMM_SERVER_TAG --set imageRepo=$IMAGE_PMM_SERVER_REPO --set platform=$platform --set sa=pmm-server --set supresshttp2=false https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
-	else
-		helm install monitoring --set imageTag=$IMAGE_PMM_SERVER_TAG --set imageRepo=$IMAGE_PMM_SERVER_REPO --set platform=$platform https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
-	fi
+	desc 'install PMM Server'
+	deploy_pmm_server
 	sleep 120
 	ADMIN_PASSWORD=$(kubectl_bin exec monitoring-0 -- bash -c "printenv | grep ADMIN_PASSWORD | cut -d '=' -f2")
 	MONITORING_ENDPOINT=$(get_service_endpoint monitoring-service)

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -8,15 +8,14 @@ OPERATOR_VERSION="$(grep 'crVersion' $(realpath $(dirname ${BASH_SOURCE[0]})/../
 IMAGE=${IMAGE:-"perconalab/percona-xtradb-cluster-operator:${GIT_BRANCH}"}
 MYSQL_VERSION=${MYSQL_VERSION:-"8.0"}
 IMAGE_PXC=${IMAGE_PXC:-"perconalab/percona-xtradb-cluster-operator:main-pxc${MYSQL_VERSION}"}
-IMAGE_PMM=${IMAGE_PMM:-"perconalab/pmm-client:dev-latest"}
 IMAGE_PROXY=${IMAGE_PROXY:-"perconalab/percona-xtradb-cluster-operator:main-proxysql"}
 IMAGE_HAPROXY=${IMAGE_HAPROXY:-"perconalab/percona-xtradb-cluster-operator:main-haproxy"}
 IMAGE_BACKUP=${IMAGE_BACKUP:-"perconalab/percona-xtradb-cluster-operator:main-pxc${MYSQL_VERSION}-backup"}
 IMAGE_LOGCOLLECTOR=${IMAGE_LOGCOLLECTOR:-"perconalab/percona-xtradb-cluster-operator:main-logcollector"}
 SKIP_REMOTE_BACKUPS=${SKIP_REMOTE_BACKUPS:-1}
 PMM_SERVER_VER=${PMM_SERVER_VER:-"9.9.9"}
-IMAGE_PMM_SERVER_REPO=${IMAGE_PMM_SERVER_REPO:-"perconalab/pmm-server"}
-IMAGE_PMM_SERVER_TAG=${IMAGE_PMM_SERVER_TAG:-"dev-latest"}
+IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT:-"perconalab/pmm-client:dev-latest"}
+IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER:-"perconalab/pmm-server:dev-latest"}
 CERT_MANAGER_VER="1.12.1"
 tmp_dir=$(mktemp -d)
 sed=$(which gsed || which sed)
@@ -311,7 +310,6 @@ deploy_operator() {
 
 deploy_helm() {
 	helm repo add hashicorp https://helm.releases.hashicorp.com
-	helm repo add percona https://percona-charts.storage.googleapis.com/
 	helm repo add minio https://helm.min.io/
 	helm repo update
 }
@@ -813,7 +811,7 @@ cat_config() {
 		| $sed -e "s#image:.*-pxc\([0-9]*.[0-9]*\)\{0,1\}\$#image: $IMAGE_PXC#" \
 		| $sed -e "s#image:.*\/percona-xtradb-cluster:.*\$#image: $IMAGE_PXC#" \
 		| $sed -e "s#initImage:.*-init\$#initImage: $IMAGE#" \
-		| $sed -e "s#image:.*-pmm\$#image: $IMAGE_PMM#" \
+		| $sed -e "s#image:.*-pmm\$#image: $IMAGE_PMM_CLIENT#" \
 		| $sed -e "s#image:.*-backup\$#image: $IMAGE_BACKUP#" \
 		| $sed -e "s#image:.*-proxysql\$#image: $IMAGE_PROXY#" \
 		| $sed -e "s#image:.*-haproxy\$#image: $IMAGE_HAPROXY#" \
@@ -1571,4 +1569,27 @@ check_passwords_leak() {
 		pods=$(kubectl_bin -n "${OPERATOR_NS}" get pods -o name | awk -F "/" '{print $2}')
 		collect_logs $OPERATOR_NS
 	fi
+}
+
+deploy_pmm_server() {
+	if [ ! -z "$OPENSHIFT" ]; then
+		platform=openshift
+		oc create sa pmm-server
+		oc adm policy add-scc-to-user privileged -z pmm-server
+		if [[ $OPERATOR_NS ]]; then
+			timeout 30 oc delete clusterrolebinding $(kubectl get clusterrolebinding | grep 'pmm-pxc-operator-' | awk '{print $1}') || :
+			oc create clusterrolebinding pmm-pxc-operator-cluster-wide --clusterrole=percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
+			oc patch clusterrole/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]' -n $OPERATOR_NS
+		else
+			oc create rolebinding pmm-pxc-operator-namespace-only --role percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
+			oc patch role/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]'
+		fi
+		local additional_params="--set platform=openshift --set sa=pmm-server --set supresshttp2=false"
+	fi
+
+	helm repo add percona https://percona.github.io/percona-helm-charts/
+	helm repo update
+	helm uninstall monitoring || :
+
+	helm install monitoring --set imageRepo=${IMAGE_PMM_SERVER%:*} --set imageTag=${IMAGE_PMM_SERVER#*:} --set service.type=ClusterIP --set secret.pmm_password=pmm_srv_admin_pass $additional_params percona/pmm
 }

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -49,24 +49,7 @@ create_infra $namespace
 deploy_helm $namespace
 
 desc 'install PMM Server'
-platform=kubernetes
-helm uninstall monitoring || :
-if [ ! -z "$OPENSHIFT" ]; then
-	platform=openshift
-	oc create sa pmm-server
-	oc adm policy add-scc-to-user privileged -z pmm-server
-	if [ -n "$OPERATOR_NS" ]; then
-		timeout 30 oc delete clusterrolebinding $(kubectl get clusterrolebinding | grep 'pmm-pxc-operator-' | awk '{print $1}') || :
-		oc create clusterrolebinding pmm-pxc-operator-cluster-wide --clusterrole=percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
-		oc patch clusterrole/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]' ${OPERATOR_NS:+-n $OPERATOR_NS}
-	else
-		oc create rolebinding pmm-pxc-operator-namespace-only --role percona-xtradb-cluster-operator --serviceaccount=$namespace:pmm-server
-		oc patch role/percona-xtradb-cluster-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]'
-	fi
-	retry 10 60 helm install monitoring --set imageTag=$IMAGE_PMM_SERVER_TAG --set imageRepo=$IMAGE_PMM_SERVER_REPO --set platform=$platform --set sa=pmm-server --set supresshttp2=false https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
-else
-	helm install monitoring --set imageTag=$IMAGE_PMM_SERVER_TAG --set imageRepo=$IMAGE_PMM_SERVER_REPO --set platform=$platform https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
-fi
+deploy_pmm_server
 kubectl_bin wait --for=condition=Ready pod/${cluster}-0 --timeout=120s
 until kubectl_bin exec monitoring-0 -- bash -c "ls -l /proc/*/exe 2>/dev/null| grep postgres >/dev/null"; do
 	echo "Retry $retry"

--- a/e2e-tests/upgrade-haproxy/run
+++ b/e2e-tests/upgrade-haproxy/run
@@ -12,7 +12,7 @@ CLUSTER_SIZE=3
 TARGET_OPERATOR_VER="${OPERATOR_VERSION}"
 TARGET_IMAGE="${IMAGE}"
 TARGET_IMAGE_PXC="${IMAGE_PXC}"
-TARGET_IMAGE_PMM="${IMAGE_PMM}"
+TARGET_IMAGE_PMM_CLIENT="${IMAGE_PMM_CLIENT}"
 TARGET_IMAGE_PROXY="${IMAGE_PROXY}"
 TARGET_IMAGE_HAPROXY="${IMAGE_HAPROXY}"
 TARGET_IMAGE_BACKUP="${IMAGE_BACKUP}"
@@ -38,7 +38,7 @@ if [[ "$(echo ${TARGET_IMAGE} | cut -d'/' -f1)" == "perconalab" ]]; then
 	IMAGE="${IMAGE/percona/perconalab}"
 fi
 IMAGE_PXC=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.pxc[].imagePath')
-IMAGE_PMM=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.pmm[].imagePath')
+IMAGE_PMM_CLIENT=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.pmm[].imagePath')
 IMAGE_PROXY=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.proxysql[].imagePath')
 IMAGE_HAPROXY=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.haproxy[].imagePath')
 IMAGE_BACKUP=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.backup[].imagePath')
@@ -97,7 +97,7 @@ function main() {
 	${IMAGE_PROXY} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.proxysql.image}') &&
 	${IMAGE_HAPROXY} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.haproxy.image}') &&
 	${IMAGE_BACKUP} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.backup.image}') &&
-	${IMAGE_PMM} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pmm.image}') &&
+	${IMAGE_PMM_CLIENT} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pmm.image}') &&
 	${IMAGE_PXC} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pxc.image}') ]]; then
 		: Operator image has been updated correctly
 	else
@@ -111,7 +111,7 @@ function main() {
         "spec": {
             "crVersion": "'"${TARGET_OPERATOR_VER}"'",
             "pxc": { "image": "'"${TARGET_IMAGE_PXC}"'" },
-            "pmm": { "image": "'"${TARGET_IMAGE_PMM}"'" },
+            "pmm": { "image": "'"${TARGET_IMAGE_PMM_CLIENT}"'" },
             "haproxy": { "image": "'"${TARGET_IMAGE_HAPROXY}"'" },
             "proxysql": { "image": "'"${TARGET_IMAGE_PROXY}"'" },
             "backup": { "image": "'"${TARGET_IMAGE_BACKUP}"'" }
@@ -124,7 +124,7 @@ function main() {
 	${TARGET_IMAGE_PROXY} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.proxysql.image}') &&
 	${TARGET_IMAGE_HAPROXY} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.haproxy.image}') &&
 	${TARGET_IMAGE_BACKUP} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.backup.image}') &&
-	${TARGET_IMAGE_PMM} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pmm.image}') &&
+	${TARGET_IMAGE_PMM_CLIENT} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pmm.image}') &&
 	${TARGET_IMAGE_PXC} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pxc.image}') ]]; then
 		: Cluster images have been updated correctly
 	else

--- a/e2e-tests/upgrade-proxysql/run
+++ b/e2e-tests/upgrade-proxysql/run
@@ -12,7 +12,7 @@ CLUSTER_SIZE=3
 TARGET_OPERATOR_VER="${OPERATOR_VERSION}"
 TARGET_IMAGE="${IMAGE}"
 TARGET_IMAGE_PXC="${IMAGE_PXC}"
-TARGET_IMAGE_PMM="${IMAGE_PMM}"
+TARGET_IMAGE_PMM_CLIENT="${IMAGE_PMM_CLIENT}"
 TARGET_IMAGE_PROXY="${IMAGE_PROXY}"
 TARGET_IMAGE_HAPROXY="${IMAGE_HAPROXY}"
 TARGET_IMAGE_BACKUP="${IMAGE_BACKUP}"
@@ -37,7 +37,7 @@ if [[ "$(echo ${TARGET_IMAGE} | cut -d'/' -f1)" == "perconalab" ]]; then
 	IMAGE="${IMAGE/percona/perconalab}"
 fi
 IMAGE_PXC=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.pxc[].imagePath')
-IMAGE_PMM=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.pmm[].imagePath')
+IMAGE_PMM_CLIENT=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.pmm[].imagePath')
 IMAGE_PROXY=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.proxysql[].imagePath')
 IMAGE_HAPROXY=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.haproxy[].imagePath')
 IMAGE_BACKUP=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.backup[].imagePath')
@@ -93,7 +93,7 @@ function main() {
 	${IMAGE_PROXY} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.proxysql.image}') &&
 	${IMAGE_HAPROXY} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.haproxy.image}') &&
 	${IMAGE_BACKUP} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.backup.image}') &&
-	${IMAGE_PMM} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pmm.image}') &&
+	${IMAGE_PMM_CLIENT} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pmm.image}') &&
 	${IMAGE_PXC} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pxc.image}') ]]; then
 		: Operator image has been updated correctly
 	else
@@ -107,7 +107,7 @@ function main() {
         "spec": {
             "crVersion": "'"${TARGET_OPERATOR_VER}"'",
             "pxc": { "image": "'"${TARGET_IMAGE_PXC}"'" },
-            "pmm": { "image": "'"${TARGET_IMAGE_PMM}"'" },
+            "pmm": { "image": "'"${TARGET_IMAGE_PMM_CLIENT}"'" },
             "haproxy": { "image": "'"${TARGET_IMAGE_HAPROXY}"'" },
             "proxysql": { "image": "'"${TARGET_IMAGE_PROXY}"'" },
             "backup": { "image": "'"${TARGET_IMAGE_BACKUP}"'" }
@@ -120,7 +120,7 @@ function main() {
 	${TARGET_IMAGE_PROXY} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.proxysql.image}') &&
 	${TARGET_IMAGE_HAPROXY} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.haproxy.image}') &&
 	${TARGET_IMAGE_BACKUP} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.backup.image}') &&
-	${TARGET_IMAGE_PMM} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pmm.image}') &&
+	${TARGET_IMAGE_PMM_CLIENT} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pmm.image}') &&
 	${TARGET_IMAGE_PXC} == $(kubectl_bin get pxc "${CLUSTER}" -o jsonpath='{.spec.pxc.image}') ]]; then
 		: Cluster images have been updated correctly
 	else


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---

- In "functions" file create a function to deploy PMM server since we use it in at least two tests "monitoring" and "default-cr" and there's a possibility of having them different (actually bumped into this case).
- Combine IMAGE_PMM_SERVER_REPO and IMAGE_PMM_SERVER_TAG parameters in Jenkins pipelines into one IMAGE_PMM_SERVER (it's just excessive copy pasting, all the other images we have only one parameter for both)
- Rename IMAGE_PMM to IMAGE_PMM_CLIENT

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
