### PR TITLE
K8SPXC-1294: Crash collector container if binlog is not processed before timeout

### DIFF
--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -41,6 +41,7 @@ type Config struct {
 	BufferSize         int64   `env:"BUFFER_SIZE"`
 	CollectSpanSec     float64 `env:"COLLECT_SPAN_SEC" envDefault:"60"`
 	VerifyTLS          bool    `env:"VERIFY_TLS" envDefault:"true"`
+	TimeoutSeconds     float64 `env:"TIMEOUT_SECONDS" envDefault:"60"`
 }
 
 type BackupS3 struct {

--- a/cmd/pitr/main.go
+++ b/cmd/pitr/main.go
@@ -45,9 +45,12 @@ func runCollector(ctx context.Context) {
 	}
 	log.Println("run binlog collector")
 	for {
-		err := c.Run(ctx)
+		timeout, cancel := context.WithTimeout(ctx, time.Duration(config.CollectSpanSec)*time.Second)
+		defer cancel()
+
+		err := c.Run(timeout)
 		if err != nil {
-			log.Println("ERROR:", err)
+			log.Fatalln("ERROR:", err)
 		}
 
 		t := time.NewTimer(time.Duration(config.CollectSpanSec) * time.Second)

--- a/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
+++ b/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
@@ -115,6 +115,8 @@ spec:
                         type: string
                       timeBetweenUploads:
                         type: number
+                      timeoutSeconds:
+                        type: number
                     type: object
                   schedule:
                     items:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -852,6 +852,8 @@ spec:
                         type: string
                       timeBetweenUploads:
                         type: number
+                      timeoutSeconds:
+                        type: number
                     type: object
                   schedule:
                     items:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -507,6 +507,7 @@ spec:
       enabled: false
       storageName: STORAGE-NAME-HERE
       timeBetweenUploads: 60
+      timeoutSeconds: 60
 #      resources:
 #        requests:
 #          memory: 0.1G

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -852,6 +852,8 @@ spec:
                         type: string
                       timeBetweenUploads:
                         type: number
+                      timeoutSeconds:
+                        type: number
                     type: object
                   schedule:
                     items:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -852,6 +852,8 @@ spec:
                         type: string
                       timeBetweenUploads:
                         type: number
+                      timeoutSeconds:
+                        type: number
                     type: object
                   schedule:
                     items:

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -148,6 +148,7 @@ type PITRSpec struct {
 	StorageName        string                      `json:"storageName"`
 	Resources          corev1.ResourceRequirements `json:"resources,omitempty"`
 	TimeBetweenUploads float64                     `json:"timeBetweenUploads,omitempty"`
+	TimeoutSeconds     float64                     `json:"timeoutSeconds,omitempty"`
 }
 
 type PXCScheduledBackupSchedule struct {
@@ -875,6 +876,10 @@ func (cr *PerconaXtraDBCluster) CheckNSetDefaults(serverVersion *version.ServerV
 		if cr.Spec.Backup.PITR.Enabled {
 			if cr.Spec.Backup.PITR.TimeBetweenUploads == 0 {
 				cr.Spec.Backup.PITR.TimeBetweenUploads = 60
+			}
+
+			if cr.Spec.Backup.PITR.TimeoutSeconds == 0 {
+				cr.Spec.Backup.PITR.TimeoutSeconds = 60
 			}
 		}
 

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -879,7 +879,7 @@ func (cr *PerconaXtraDBCluster) CheckNSetDefaults(serverVersion *version.ServerV
 			}
 
 			if cr.Spec.Backup.PITR.TimeoutSeconds == 0 {
-				cr.Spec.Backup.PITR.TimeoutSeconds = 60
+				cr.Spec.Backup.PITR.TimeoutSeconds = 3600
 			}
 		}
 

--- a/pkg/pxc/app/deployment/binlog-collector.go
+++ b/pkg/pxc/app/deployment/binlog-collector.go
@@ -69,6 +69,16 @@ func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster) (appsv1.Deployme
 			Value: strconv.FormatInt(bufferSize, 10),
 		},
 	}...)
+
+	if cr.CompareVersionWith("1.14.0") >= 0 {
+		timeout := fmt.Sprintf("%.2f", cr.Spec.Backup.PITR.TimeoutSeconds)
+
+		envs = append(envs, corev1.EnvVar{
+			Name:  "TIMEOUT_SECONDS",
+			Value: timeout,
+		})
+	}
+
 	container := corev1.Container{
 		Name:            "pitr",
 		Image:           cr.Spec.Backup.Image,


### PR DESCRIPTION
[![K8SPXC-1294](https://badgen.net/badge/JIRA/K8SPXC-1294/green)](https://jira.percona.com/browse/K8SPXC-1294) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Collector can hung indefinitely if there's a problem with network.

**Solution:**
Configure timeout for processing each binlog, if timeout exceeds crash the container.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?