### PR TITLE
CLOUD-825 - Use community helm chart repo for installing MinIO

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -310,7 +310,7 @@ deploy_operator() {
 
 deploy_helm() {
 	helm repo add hashicorp https://helm.releases.hashicorp.com
-	helm repo add minio https://helm.min.io/
+	helm repo add minio https://charts.min.io/
 	helm repo update
 }
 
@@ -1245,15 +1245,19 @@ start_minio() {
 
 	local endpoint="http://minio-service:9000"
 	local minio_args=(
-		--version 8.0.5
-		--set accessKey=some-access-key
-		--set secretKey=some-secret-key
+		--version 5.0.14
+		--set replicas=1
+		--set mode=standalone
+		--set resources.requests.memory=256Mi
+		--set rootUser=rootuser
+		--set rootPassword=rootpass123
+		--set "users[0].accessKey=some-access-key"
+		--set "users[0].secretKey=some-secret-key"
+		--set "users[0].policy=consoleAdmin"
 		--set service.type=ClusterIP
 		--set configPathmc=/tmp/.minio/
 		--set securityContext.enabled=false
 		--set persistence.size=2G
-		--set environment.MINIO_REGION=us-east-1
-		--set environment.MINIO_HTTP_TRACE=/tmp/trace.log
 	)
 	if [[ -n $cert_secret ]]; then
 		endpoint="https://minio-service:9000"


### PR DESCRIPTION
[![CLOUD-825](https://badgen.net/badge/JIRA/CLOUD-825/green)](https://jira.percona.com/browse/CLOUD-825) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*https://helm.min.io/ is removed so we need to fix our tests to use something else.*

**Solution:**
*Since official docs use operator+tenants mode we decided to use [community helm](https://charts.min.io/) chart in standalone mode for tests (which is the same what we had before).*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?