### PR TITLE
K8SPXC-1151: Fix status after PiTR finished

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -70,7 +70,7 @@ func main() {
 	setupLog.Info("Runs on", "platform", sv.Platform, "version", sv.Info)
 
 	setupLog.Info("Manager starting up", "gitCommit", GitCommit, "gitBranch", GitBranch,
-		"goVersion", runtime.Version(), "os", runtime.GOOS, "arch", runtime.GOARCH)
+		"buildTime", BuildTime, "goVersion", runtime.Version(), "os", runtime.GOOS, "arch", runtime.GOARCH)
 
 	namespace, err := k8s.GetWatchNamespace()
 	if err != nil {

--- a/pkg/controller/pxcrestore/controller.go
+++ b/pkg/controller/pxcrestore/controller.go
@@ -234,6 +234,13 @@ func (r *ReconcilePerconaXtraDBClusterRestore) Reconcile(ctx context.Context, re
 
 		cluster.Spec.PXC.Size = oldSize
 		cluster.Spec.AllowUnsafeConfig = oldUnsafe
+
+		log.Info("starting cluster", "cluster", cr.Spec.PXCCluster)
+		err = r.setStatus(cr, api.RestoreStartCluster, "")
+		if err != nil {
+			err = errors.Wrap(err, "set status")
+			return rr, err
+		}
 	}
 
 	err = r.startCluster(clusterOrig)


### PR DESCRIPTION
[![K8SPXC-1151](https://badgen.net/badge/JIRA/K8SPXC-1151/green)](https://jira.percona.com/browse/K8SPXC-1151) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Restore status is "Point-in-time recovering" even though PiTR is finished.

**Solution:**
Set status to "Starting cluster" after PiTR is finished.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?