### PR TITLE
K8SPXC-1333: Include namespace to scheduled backup prefix

### DIFF
--- a/pkg/controller/pxc/backup.go
+++ b/pkg/controller/pxc/backup.go
@@ -34,7 +34,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileBackups(ctx context.Context, cr
 	log := logf.FromContext(ctx)
 
 	backups := make(map[string]api.PXCScheduledBackupSchedule)
-	backupNamePrefix := backupJobClusterPrefix(cr.Name)
+	backupNamePrefix := backupJobClusterPrefix(cr.Namespace + "-" + cr.Name)
 
 	if cr.Spec.Backup != nil {
 		restoreRunning, err := r.isRestoreRunning(cr.Name, cr.Namespace)


### PR DESCRIPTION
[![K8SPXC-1333](https://badgen.net/badge/JIRA/K8SPXC-1333/green)](https://jira.percona.com/browse/K8SPXC-1333) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
#1544 

**Cause:**
When operator runs in cluster wide mode, it mixes up scheduled backups if cluster names are the same in multiple namespaces because it only uses cluster name as the prefix.

**Solution:**
Include namespace to scheduled backup prefix.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?