### PR TITLE
K8SPXC-1329: add `PMM_AGENT_PATHS_TEMPDIR` to pmm-agent sidecar

### DIFF
--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127.yml
@@ -120,6 +120,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-proxysql

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-oc.yml
@@ -117,6 +117,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-proxysql

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased.yml
@@ -117,6 +117,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-proxysql

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127.yml
@@ -120,6 +120,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-proxysql

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-oc.yml
@@ -117,6 +117,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-proxysql

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql.yml
@@ -117,6 +117,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-proxysql

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-k127.yml
@@ -115,6 +115,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-pxc

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-oc.yml
@@ -112,6 +112,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-pxc

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased.yml
@@ -112,6 +112,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-pxc

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-k127.yml
@@ -115,6 +115,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-pxc

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-oc.yml
@@ -112,6 +112,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-pxc

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc.yml
@@ -112,6 +112,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: no-limits-env-vars-pxc

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-k127.yml
@@ -121,6 +121,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
@@ -118,6 +118,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-k127.yml
@@ -116,6 +116,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: monitoring-env-vars-pxc

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-oc.yml
@@ -113,6 +113,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: monitoring-env-vars-pxc

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc.yml
@@ -113,6 +113,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           envFrom:
             - secretRef:
                 name: monitoring-env-vars-pxc

--- a/pkg/pxc/app/statefulset/haproxy.go
+++ b/pkg/pxc/app/statefulset/haproxy.go
@@ -59,7 +59,8 @@ func (c *HAProxy) Name() string {
 }
 
 func (c *HAProxy) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXtraDBCluster,
-	_ []corev1.Volume) (corev1.Container, error) {
+	_ []corev1.Volume,
+) (corev1.Container, error) {
 	appc := corev1.Container{
 		Name:            haproxyName,
 		Image:           spec.Image,
@@ -359,6 +360,18 @@ func (c *HAProxy) PMMContainer(spec *api.PMMSpec, secret *corev1.Secret, cr *api
 			{
 				Name:  "PMM_AGENT_SIDECAR_SLEEP",
 				Value: "5",
+			},
+		}
+		ct.Env = append(ct.Env, sidecarEnvs...)
+	}
+
+	if cr.CompareVersionWith("1.14.0") >= 0 {
+		// PMM team moved temp directory to /usr/local/percona/pmm2/tmp
+		// but it doesn't work on OpenShift so we set it back to /tmp
+		sidecarEnvs := []corev1.EnvVar{
+			{
+				Name:  "PMM_AGENT_PATHS_TEMPDIR",
+				Value: "/tmp",
 			},
 		}
 		ct.Env = append(ct.Env, sidecarEnvs...)

--- a/pkg/pxc/app/statefulset/node.go
+++ b/pkg/pxc/app/statefulset/node.go
@@ -456,6 +456,18 @@ func (c *Node) PMMContainer(spec *api.PMMSpec, secret *corev1.Secret, cr *api.Pe
 		ct.Env = append(ct.Env, sidecarEnvs...)
 	}
 
+	if cr.CompareVersionWith("1.14.0") >= 0 {
+		// PMM team moved temp directory to /usr/local/percona/pmm2/tmp
+		// but it doesn't work on OpenShift so we set it back to /tmp
+		sidecarEnvs := []corev1.EnvVar{
+			{
+				Name:  "PMM_AGENT_PATHS_TEMPDIR",
+				Value: "/tmp",
+			},
+		}
+		ct.Env = append(ct.Env, sidecarEnvs...)
+	}
+
 	ct.VolumeMounts = []corev1.VolumeMount{
 		{
 			Name:      app.DataVolumeName,

--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -56,7 +56,8 @@ func (c *Proxy) Name() string {
 }
 
 func (c *Proxy) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXtraDBCluster,
-	availableVolumes []corev1.Volume) (corev1.Container, error) {
+	availableVolumes []corev1.Volume,
+) (corev1.Container, error) {
 	appc := corev1.Container{
 		Name:            proxyName,
 		Image:           spec.Image,
@@ -383,6 +384,18 @@ func (c *Proxy) PMMContainer(spec *api.PMMSpec, secret *corev1.Secret, cr *api.P
 			{
 				Name:  "PMM_AGENT_SIDECAR_SLEEP",
 				Value: "5",
+			},
+		}
+		ct.Env = append(ct.Env, sidecarEnvs...)
+	}
+
+	if cr.CompareVersionWith("1.14.0") >= 0 {
+		// PMM team moved temp directory to /usr/local/percona/pmm2/tmp
+		// but it doesn't work on OpenShift so we set it back to /tmp
+		sidecarEnvs := []corev1.EnvVar{
+			{
+				Name:  "PMM_AGENT_PATHS_TEMPDIR",
+				Value: "/tmp",
 			},
 		}
 		ct.Env = append(ct.Env, sidecarEnvs...)


### PR DESCRIPTION
[![K8SPXC-1329](https://badgen.net/badge/JIRA/K8SPXC-1329/green)](https://jira.percona.com/browse/K8SPXC-1329) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-1329

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1329]: https://perconadev.atlassian.net/browse/K8SPXC-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ