### PR TITLE
K8SPXC-1269 add possibility to switch from haproxy to proxysql in 5.7

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -266,8 +266,8 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 			},
 		}
 		err = r.client.Get(ctx, client.ObjectKeyFromObject(&haproxySts), &haproxySts)
-		if err == nil {
-			return reconcile.Result{}, errors.Errorf("failed to enable ProxySQL: you can't switch from HAProxy to ProxySQL on the fly")
+		if err == nil && !strings.HasPrefix(o.Status.PXC.Version, "5.7") {
+		    return reconcile.Result{}, errors.Errorf("failed to enable ProxySQL: for mysql version 8.0 you can't switch from HAProxy to ProxySQL")
 		}
 	}
 

--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -267,7 +267,7 @@ func (r *ReconcilePerconaXtraDBCluster) Reconcile(ctx context.Context, request r
 		}
 		err = r.client.Get(ctx, client.ObjectKeyFromObject(&haproxySts), &haproxySts)
 		if err == nil && !strings.HasPrefix(o.Status.PXC.Version, "5.7") {
-		    return reconcile.Result{}, errors.Errorf("failed to enable ProxySQL: for mysql version 8.0 you can't switch from HAProxy to ProxySQL")
+			return reconcile.Result{}, errors.Errorf("failed to enable ProxySQL: for mysql version 8.0 you can't switch from HAProxy to ProxySQL")
 		}
 	}
 

--- a/pkg/controller/pxc/controller_test.go
+++ b/pkg/controller/pxc/controller_test.go
@@ -671,7 +671,7 @@ var _ = Describe("Authentication policy", Ordered, func() {
 
 			It("should NOT reconcile", func() {
 				_, err := reconciler().Reconcile(ctx, ctrl.Request{NamespacedName: crNamespacedName})
-				Expect(err).To(MatchError("failed to enable ProxySQL: you can't switch from HAProxy to ProxySQL on the fly"))
+				Expect(err).To(MatchError("failed to enable ProxySQL: for mysql version 8.0 you can't switch from HAProxy to ProxySQL"))
 			})
 		})
 	})


### PR DESCRIPTION
[![K8SPXC-1269](https://badgen.net/badge/JIRA/K8SPXC-1269/green)](https://jira.percona.com/browse/K8SPXC-1269) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

switching from haproxy to proxysql was broken for 5.7

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*
added possibility to switch from haproxy to proxysql in 5.7
**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1269]: https://perconadev.atlassian.net/browse/K8SPXC-1269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ