### PR TITLE
K8SPXC-1345: Fix overriding container probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	DISABLE_TELEMETRY=true KUBEBUILDER_ASSETS="$(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -1054,7 +1054,13 @@ func (cr *PerconaXtraDBCluster) setProbesDefaults() {
 		cr.Spec.PXC.LivenessProbes.TimeoutSeconds = 5
 	}
 
-	cr.Spec.PXC.LivenessProbes.SuccessThreshold = 1
+	if cr.Spec.PXC.LivenessProbes.FailureThreshold == 0 {
+		cr.Spec.PXC.LivenessProbes.FailureThreshold = 3
+	}
+
+	if cr.Spec.PXC.LivenessProbes.SuccessThreshold == 0 {
+		cr.Spec.PXC.LivenessProbes.SuccessThreshold = 1
+	}
 
 	if cr.Spec.PXC.ReadinessInitialDelaySeconds != nil {
 		cr.Spec.PXC.ReadinessProbes.InitialDelaySeconds = *cr.Spec.PXC.ReadinessInitialDelaySeconds
@@ -1069,6 +1075,11 @@ func (cr *PerconaXtraDBCluster) setProbesDefaults() {
 	if cr.Spec.PXC.ReadinessProbes.FailureThreshold == 0 {
 		cr.Spec.PXC.ReadinessProbes.FailureThreshold = 5
 	}
+
+	if cr.Spec.PXC.ReadinessProbes.SuccessThreshold == 0 {
+		cr.Spec.PXC.ReadinessProbes.SuccessThreshold = 1
+	}
+
 	if cr.Spec.PXC.ReadinessProbes.TimeoutSeconds == 0 {
 		cr.Spec.PXC.ReadinessProbes.TimeoutSeconds = 15
 	}
@@ -1087,6 +1098,14 @@ func (cr *PerconaXtraDBCluster) setProbesDefaults() {
 			cr.Spec.HAProxy.ReadinessProbes.TimeoutSeconds = 1
 		}
 
+		if cr.Spec.HAProxy.ReadinessProbes.SuccessThreshold == 0 {
+			cr.Spec.HAProxy.ReadinessProbes.SuccessThreshold = 1
+		}
+
+		if cr.Spec.HAProxy.ReadinessProbes.FailureThreshold == 0 {
+			cr.Spec.HAProxy.ReadinessProbes.FailureThreshold = 3
+		}
+
 		if cr.Spec.HAProxy.LivenessInitialDelaySeconds != nil {
 			cr.Spec.HAProxy.LivenessProbes.InitialDelaySeconds = *cr.Spec.HAProxy.LivenessInitialDelaySeconds
 		} else if cr.Spec.HAProxy.LivenessProbes.InitialDelaySeconds == 0 {
@@ -1103,8 +1122,9 @@ func (cr *PerconaXtraDBCluster) setProbesDefaults() {
 			cr.Spec.HAProxy.LivenessProbes.PeriodSeconds = 30
 		}
 
-		cr.Spec.HAProxy.LivenessProbes.SuccessThreshold = 1
-
+		if cr.Spec.HAProxy.LivenessProbes.SuccessThreshold == 0 {
+			cr.Spec.HAProxy.LivenessProbes.SuccessThreshold = 1
+		}
 	}
 }
 

--- a/pkg/pxc/app/statefulset/node.go
+++ b/pkg/pxc/app/statefulset/node.go
@@ -254,6 +254,9 @@ func (c *Node) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXt
 			Name:      "mysql-init-file",
 			MountPath: "/etc/mysql/init-file",
 		})
+
+		appc.ReadinessProbe = app.Probe(&cr.Spec.PXC.ReadinessProbes, "/var/lib/mysql/readiness-check.sh")
+		appc.LivenessProbe = app.Probe(&cr.Spec.PXC.LivenessProbes, "/var/lib/mysql/liveness-check.sh")
 	}
 
 	if cr.Spec.PXC != nil && (cr.Spec.PXC.Lifecycle.PostStart != nil || cr.Spec.PXC.Lifecycle.PreStop != nil) {

--- a/pkg/pxc/users/users.go
+++ b/pkg/pxc/users/users.go
@@ -255,7 +255,7 @@ func (u *Manager) Update170XtrabackupUser(pass string) (err error) {
 	return nil
 }
 
-// Update1100MonitorUserPrivilege grants system_user privilege for monitor 
+// Update1100MonitorUserPrivilege grants system_user privilege for monitor
 func (u *Manager) Update1100MonitorUserPrivilege() (err error) {
 	if _, err := u.db.Exec("GRANT SYSTEM_USER ON *.* TO 'monitor'@'%'"); err != nil {
 		return errors.Wrap(err, "monitor user")


### PR DESCRIPTION
[![K8SPXC-1345](https://badgen.net/badge/JIRA/K8SPXC-1345/green)](https://jira.percona.com/browse/K8SPXC-1345) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Regression in customizing probes.

**Solution:**
Fix.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1345]: https://perconadev.atlassian.net/browse/K8SPXC-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ