### PR TITLE
K8SPXC-1341: Improve logs for PVC resize

### DIFF
--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -1471,3 +1471,10 @@ func (s *PerconaXtraDBClusterSpec) HAProxyEnabled() bool {
 func (s *PerconaXtraDBClusterSpec) ProxySQLEnabled() bool {
 	return s.ProxySQL != nil && s.ProxySQL.Enabled
 }
+
+const AnnotationPVCResizeInProgress = "percona.com/pvc-resize-in-progress"
+
+func (cr *PerconaXtraDBCluster) PVCResizeInProgress() bool {
+	_, ok := cr.Annotations[AnnotationPVCResizeInProgress]
+	return ok
+}

--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -531,6 +531,12 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileHAProxy(ctx context.Context, cr
 
 func (r *ReconcilePerconaXtraDBCluster) deploy(ctx context.Context, cr *api.PerconaXtraDBCluster) error {
 	log := logf.FromContext(ctx)
+
+	if cr.PVCResizeInProgress() {
+		log.V(1).Info("PVC resize in progress, skipping statefulset")
+		return nil
+	}
+
 	stsApp := statefulset.NewNode(cr)
 	err := r.reconcileConfigMap(cr)
 	if err != nil {

--- a/pkg/controller/pxc/status.go
+++ b/pkg/controller/pxc/status.go
@@ -42,6 +42,11 @@ func (r *ReconcilePerconaXtraDBCluster) updateStatus(cr *api.PerconaXtraDBCluste
 		return r.writeStatus(cr)
 	}
 
+	if cr.PVCResizeInProgress() {
+		cr.Status.Status = api.AppStateInit
+		return r.writeStatus(cr)
+	}
+
 	cr.Status.Messages = cr.Status.Messages[:0]
 
 	type sfsstatus struct {

--- a/pkg/k8s/annotation.go
+++ b/pkg/k8s/annotation.go
@@ -1,0 +1,46 @@
+package k8s
+
+import (
+	"context"
+
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AnnotateObject adds the specified annotations to the object
+func AnnotateObject(ctx context.Context, c client.Client, obj client.Object, annotations map[string]string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_obj := obj.DeepCopyObject().(client.Object)
+		c.Get(ctx, client.ObjectKeyFromObject(obj), _obj)
+
+		a := _obj.GetAnnotations()
+		if a == nil {
+			a = make(map[string]string)
+		}
+
+		for k, v := range annotations {
+			a[k] = v
+		}
+		_obj.SetAnnotations(a)
+
+		return c.Patch(ctx, _obj, client.MergeFrom(obj))
+	})
+}
+
+// DeannotateObject removes the specified annotation from the object
+func DeannotateObject(ctx context.Context, c client.Client, obj client.Object, annotation string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_obj := obj.DeepCopyObject().(client.Object)
+		c.Get(ctx, client.ObjectKeyFromObject(obj), _obj)
+
+		a := _obj.GetAnnotations()
+		if a == nil {
+			a = make(map[string]string)
+		}
+
+		delete(a, annotation)
+		_obj.SetAnnotations(a)
+
+		return c.Patch(ctx, _obj, client.MergeFrom(obj))
+	})
+}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Errors in the operator log during PVC resize.

**Cause:**
Operator still tries to reconcile PXC statefulset during resize.

**Solution:**
Temporarily pause reconciliation using annotations.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?
