### PR TITLE
K8SPXC-1295 - Fix tests for Kubernetes 1.29

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version: '1.21'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version: '1.21'
       - run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
       - run: $(go env GOPATH)/bin/shfmt -f . | grep -v 'vendor' | xargs $(go env GOPATH)/bin/shfmt -bn -ci -s -w
       - name: suggester / shfmt
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version: '1.21'
       - run: |
           make generate manifests VERSION=main
           git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.21'
+          go-version: '1.21'
       - uses: actions/checkout@v4
       - name: go test
         run: make test

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_restore-job-on-demand-backup-azure-demand-backup-cloud-k129.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_restore-job-on-demand-backup-azure-demand-backup-cloud-k129.yml
@@ -1,0 +1,86 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    batch.kubernetes.io/job-name: restore-job-on-demand-backup-azure-demand-backup-cloud
+    job-name: restore-job-on-demand-backup-azure-demand-backup-cloud
+  name: restore-job-on-demand-backup-azure-demand-backup-cloud
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterRestore
+      name: on-demand-backup-azure
+spec:
+  backoffLimit: 4
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels: {}
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/job-name: restore-job-on-demand-backup-azure-demand-backup-cloud
+        job-name: restore-job-on-demand-backup-azure-demand-backup-cloud
+    spec:
+      containers:
+        - command:
+            - recovery-cloud.sh
+          env:
+            - name: PXC_SERVICE
+              value: demand-backup-cloud-pxc
+            - name: PXC_USER
+              value: xtrabackup
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: VERIFY_TLS
+              value: "true"
+            - name: AZURE_STORAGE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_ACCOUNT_NAME
+                  name: azure-secret
+            - name: AZURE_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_ACCOUNT_KEY
+                  name: azure-secret
+            - name: AZURE_ENDPOINT
+            - name: AZURE_STORAGE_CLASS
+            - name: XB_USE_MEMORY
+              value: 100MB
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /datadir
+              name: datadir
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir-demand-backup-cloud-pxc-0
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-vault

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_restore-job-on-demand-backup-s3-demand-backup-cloud-k129.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_restore-job-on-demand-backup-s3-demand-backup-cloud-k129.yml
@@ -1,0 +1,91 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    batch.kubernetes.io/job-name: restore-job-on-demand-backup-s3-demand-backup-cloud
+    job-name: restore-job-on-demand-backup-s3-demand-backup-cloud
+  name: restore-job-on-demand-backup-s3-demand-backup-cloud
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterRestore
+      name: on-demand-backup-s3
+spec:
+  backoffLimit: 4
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels: {}
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/job-name: restore-job-on-demand-backup-s3-demand-backup-cloud
+        job-name: restore-job-on-demand-backup-s3-demand-backup-cloud
+    spec:
+      containers:
+        - command:
+            - recovery-cloud.sh
+          env:
+            - name: PXC_SERVICE
+              value: demand-backup-cloud-pxc
+            - name: PXC_USER
+              value: xtrabackup
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: VERIFY_TLS
+              value: "true"
+            - name: ENDPOINT
+            - name: DEFAULT_REGION
+              value: us-east-1
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_ACCESS_KEY_ID
+                  name: aws-s3-secret
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_SECRET_ACCESS_KEY
+                  name: aws-s3-secret
+            - name: XBCLOUD_EXTRA_ARGS
+              value: --parallel=2
+            - name: XBSTREAM_EXTRA_ARGS
+              value: --parallel=2
+            - name: XB_USE_MEMORY
+              value: 100MB
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /datadir
+              name: datadir
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir-demand-backup-cloud-pxc-0
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-vault

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-k129.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-k129.yml
@@ -1,0 +1,107 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    backup-name: on-demand-backup-aws-s3
+    cluster: demand-backup-cloud
+    job-name: xb-on-demand-backup-aws-s3
+    type: xtrabackup
+  name: xb-on-demand-backup-aws-s3
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterBackup
+      name: on-demand-backup-aws-s3
+spec:
+  backoffLimit: 10
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: true
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      backup-name: on-demand-backup-aws-s3
+      cluster: demand-backup-cloud
+      job-name: xb-on-demand-backup-aws-s3
+      type: xtrabackup
+  suspend: false
+  template:
+    metadata:
+      labels:
+        backup-name: on-demand-backup-aws-s3
+        cluster: demand-backup-cloud
+        job-name: xb-on-demand-backup-aws-s3
+        type: xtrabackup
+    spec:
+      containers:
+        - command:
+            - bash
+            - /usr/bin/backup.sh
+          env:
+            - name: BACKUP_DIR
+              value: /backup
+            - name: PXC_SERVICE
+              value: demand-backup-cloud-pxc
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: VERIFY_TLS
+              value: "true"
+            - name: XBCLOUD_EXTRA_ARGS
+              value: --parallel=2
+            - name: XBSTREAM_EXTRA_ARGS
+              value: --parallel=2
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_ACCESS_KEY_ID
+                  name: aws-s3-secret
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_SECRET_ACCESS_KEY
+                  name: aws-s3-secret
+            - name: DEFAULT_REGION
+              value: us-east-1
+            - name: ENDPOINT
+            - name: S3_BUCKET
+              value: operator-testing
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: demand-backup-cloud-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: demand-backup-cloud-ssl-internal
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-vault

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-k129.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-k129.yml
@@ -1,0 +1,101 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    backup-name: on-demand-backup-azure-blob
+    cluster: demand-backup-cloud
+    job-name: xb-on-demand-backup-azure-blob
+    type: xtrabackup
+  name: xb-on-demand-backup-azure-blob
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterBackup
+      name: on-demand-backup-azure-blob
+spec:
+  backoffLimit: 10
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: true
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      backup-name: on-demand-backup-azure-blob
+      cluster: demand-backup-cloud
+      job-name: xb-on-demand-backup-azure-blob
+      type: xtrabackup
+  suspend: false
+  template:
+    metadata:
+      labels:
+        backup-name: on-demand-backup-azure-blob
+        cluster: demand-backup-cloud
+        job-name: xb-on-demand-backup-azure-blob
+        type: xtrabackup
+    spec:
+      containers:
+        - command:
+            - bash
+            - /usr/bin/backup.sh
+          env:
+            - name: BACKUP_DIR
+              value: /backup
+            - name: PXC_SERVICE
+              value: demand-backup-cloud-pxc
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: VERIFY_TLS
+              value: "true"
+            - name: AZURE_STORAGE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_ACCOUNT_NAME
+                  name: azure-secret
+            - name: AZURE_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_ACCOUNT_KEY
+                  name: azure-secret
+            - name: AZURE_ENDPOINT
+            - name: AZURE_STORAGE_CLASS
+              value: Cool
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: demand-backup-cloud-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: demand-backup-cloud-ssl-internal
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-vault

--- a/e2e-tests/demand-backup/compare/job_restore-job-on-demand-backup-minio-demand-backup-k129.yml
+++ b/e2e-tests/demand-backup/compare/job_restore-job-on-demand-backup-minio-demand-backup-k129.yml
@@ -1,0 +1,99 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    batch.kubernetes.io/job-name: restore-job-on-demand-backup-minio-demand-backup
+    job-name: restore-job-on-demand-backup-minio-demand-backup
+  name: restore-job-on-demand-backup-minio-demand-backup
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterRestore
+      name: on-demand-backup-minio
+spec:
+  backoffLimit: 4
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels: {}
+  suspend: false
+  template:
+    metadata:
+      labels:
+        batch.kubernetes.io/job-name: restore-job-on-demand-backup-minio-demand-backup
+        job-name: restore-job-on-demand-backup-minio-demand-backup
+    spec:
+      containers:
+        - command:
+            - recovery-cloud.sh
+          env:
+            - name: PXC_SERVICE
+              value: demand-backup-pxc
+            - name: PXC_USER
+              value: xtrabackup
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: VERIFY_TLS
+              value: "false"
+            - name: ENDPOINT
+              value: https://minio-service.namespace:9000/
+            - name: DEFAULT_REGION
+              value: us-east-1
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_ACCESS_KEY_ID
+                  name: minio-secret
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_SECRET_ACCESS_KEY
+                  name: minio-secret
+            - name: XB_EXTRA_ARGS
+              value: --parallel=3
+            - name: XBCLOUD_EXTRA_ARGS
+              value: --parallel=3
+            - name: XBSTREAM_EXTRA_ARGS
+              value: --parallel=3
+            - name: XB_USE_MEMORY
+              value: "1500000000"
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2G
+            requests:
+              memory: 2G
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /datadir
+              name: datadir
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir-demand-backup-pxc-0
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-vault

--- a/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-k129.yml
+++ b/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-k129.yml
@@ -1,0 +1,114 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    backup-name: on-demand-backup-minio
+    cluster: demand-backup
+    job-name: xb-on-demand-backup-minio
+    type: xtrabackup
+  name: xb-on-demand-backup-minio
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterBackup
+      name: on-demand-backup-minio
+spec:
+  backoffLimit: 10
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: true
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      backup-name: on-demand-backup-minio
+      cluster: demand-backup
+      job-name: xb-on-demand-backup-minio
+      type: xtrabackup
+  suspend: false
+  template:
+    metadata:
+      labels:
+        backup-name: on-demand-backup-minio
+        cluster: demand-backup
+        job-name: xb-on-demand-backup-minio
+        type: xtrabackup
+    spec:
+      containers:
+        - command:
+            - bash
+            - /usr/bin/backup.sh
+          env:
+            - name: BACKUP_DIR
+              value: /backup
+            - name: PXC_SERVICE
+              value: demand-backup-pxc
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: VERIFY_TLS
+              value: "false"
+            - name: XBCLOUD_EXTRA_ARGS
+              value: --parallel=2 --curl-retriable-errors=8
+            - name: XBSTREAM_EXTRA_ARGS
+              value: --parallel=2
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_ACCESS_KEY_ID
+                  name: minio-secret
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_SECRET_ACCESS_KEY
+                  name: minio-secret
+            - name: DEFAULT_REGION
+              value: us-east-1
+            - name: ENDPOINT
+              value: https://minio-service.namespace:9000/
+            - name: S3_BUCKET
+              value: operator-testing
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2G
+            requests:
+              cpu: 500m
+              memory: 500M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: demand-backup-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: demand-backup-ssl-internal
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-vault

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -401,7 +401,9 @@ compare_kubectl() {
 		expected_result=${expected_result//.yml/-80.yml}
 	fi
 
-	if version_gt "1.27" && [ -f ${expected_result//.yml/-k127.yml} ]; then
+	if version_gt "1.29" && [ -f ${expected_result//.yml/-k129.yml} ]; then
+		expected_result=${expected_result//.yml/-k129.yml}
+	elif version_gt "1.27" && [ -f ${expected_result//.yml/-k127.yml} ]; then
 		expected_result=${expected_result//.yml/-k127.yml}
 	elif version_gt "1.24" && [ -f ${expected_result//.yml/-k124.yml} ]; then
 		expected_result=${expected_result//.yml/-k124.yml}

--- a/e2e-tests/security-context/compare/job.batch_restore-job-restore-pvc-sec-context-k129.yml
+++ b/e2e-tests/security-context/compare/job.batch_restore-job-restore-pvc-sec-context-k129.yml
@@ -1,0 +1,88 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    batch.kubernetes.io/job-name: restore-job-restore-pvc-sec-context
+    job-name: restore-job-restore-pvc-sec-context
+  name: restore-job-restore-pvc-sec-context
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterRestore
+      name: restore-pvc
+spec:
+  backoffLimit: 4
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels: {}
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        openshift.io/scc: privileged
+      labels:
+        batch.kubernetes.io/job-name: restore-job-restore-pvc-sec-context
+        job-name: restore-job-restore-pvc-sec-context
+    spec:
+      containers:
+        - command:
+            - recovery-pvc-joiner.sh
+          env:
+            - name: RESTORE_SRC_SERVICE
+              value: restore-src-restore-pvc-sec-context
+            - name: XB_USE_MEMORY
+              value: 100MB
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /datadir
+              name: datadir
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        supplementalGroups:
+          - 1001
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 30
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir-sec-context-pxc-0
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: sec-context-vault
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: false
+            secretName: some-name-ssl

--- a/e2e-tests/security-context/compare/job.batch_restore-job-restore-s3-sec-context-k129.yml
+++ b/e2e-tests/security-context/compare/job.batch_restore-job-restore-s3-sec-context-k129.yml
@@ -1,0 +1,97 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generation: 1
+  labels:
+    batch.kubernetes.io/job-name: restore-job-restore-s3-sec-context
+    job-name: restore-job-restore-s3-sec-context
+  name: restore-job-restore-s3-sec-context
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterRestore
+      name: restore-s3
+spec:
+  backoffLimit: 4
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels: {}
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        openshift.io/scc: privileged
+      labels:
+        batch.kubernetes.io/job-name: restore-job-restore-s3-sec-context
+        job-name: restore-job-restore-s3-sec-context
+    spec:
+      containers:
+        - command:
+            - recovery-cloud.sh
+          env:
+            - name: PXC_SERVICE
+              value: sec-context-pxc
+            - name: PXC_USER
+              value: xtrabackup
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: VERIFY_TLS
+              value: "true"
+            - name: ENDPOINT
+              value: http://minio-service.namespace:9000/
+            - name: DEFAULT_REGION
+              value: us-east-1
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_ACCESS_KEY_ID
+                  name: minio-secret
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_SECRET_ACCESS_KEY
+                  name: minio-secret
+            - name: XB_USE_MEMORY
+              value: 100MB
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /datadir
+              name: datadir
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        runAsUser: 1001
+        supplementalGroups:
+          - 1001
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 30
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir-sec-context-pxc-0
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: sec-context-vault

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc-k129.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc-k129.yml
@@ -1,0 +1,103 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  generation: 1
+  labels:
+    backup-name: on-demand-backup-pvc
+    cluster: sec-context
+    job-name: xb-on-demand-backup-pvc
+    type: xtrabackup
+  name: xb-on-demand-backup-pvc
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterBackup
+      name: on-demand-backup-pvc
+spec:
+  backoffLimit: 10
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: true
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      backup-name: on-demand-backup-pvc
+      cluster: sec-context
+      job-name: xb-on-demand-backup-pvc
+      type: xtrabackup
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        openshift.io/scc: privileged
+      labels:
+        backup-name: on-demand-backup-pvc
+        cluster: sec-context
+        job-name: xb-on-demand-backup-pvc
+        type: xtrabackup
+    spec:
+      containers:
+        - command:
+            - bash
+            - /usr/bin/backup.sh
+          env:
+            - name: BACKUP_DIR
+              value: /backup
+            - name: PXC_SERVICE
+              value: sec-context-pxc
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: VERIFY_TLS
+              value: "true"
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /backup
+              name: xtrabackup
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+          - 1002
+          - 1003
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: xtrabackup
+          persistentVolumeClaim:
+            claimName: xb-on-demand-backup-pvc
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: sec-context-vault

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3-k129.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3-k129.yml
@@ -1,0 +1,124 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    openshift.io/scc: privileged
+  generation: 1
+  labels:
+    backup-name: on-demand-backup-s3
+    cluster: sec-context
+    job-name: xb-on-demand-backup-s3
+    type: xtrabackup
+  name: xb-on-demand-backup-s3
+  ownerReferences:
+    - controller: true
+      kind: PerconaXtraDBClusterBackup
+      name: on-demand-backup-s3
+spec:
+  backoffLimit: 10
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: true
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      backup-name: on-demand-backup-s3
+      cluster: sec-context
+      job-name: xb-on-demand-backup-s3
+      type: xtrabackup
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        openshift.io/scc: privileged
+      labels:
+        backup-name: on-demand-backup-s3
+        cluster: sec-context
+        job-name: xb-on-demand-backup-s3
+        type: xtrabackup
+    spec:
+      containers:
+        - command:
+            - bash
+            - /usr/bin/backup.sh
+          env:
+            - name: BACKUP_DIR
+              value: /backup
+            - name: PXC_SERVICE
+              value: sec-context-pxc
+            - name: PXC_PASS
+              valueFrom:
+                secretKeyRef:
+                  key: xtrabackup
+                  name: my-cluster-secrets
+            - name: VERIFY_TLS
+              value: "true"
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_ACCESS_KEY_ID
+                  name: minio-secret
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: AWS_SECRET_ACCESS_KEY
+                  name: minio-secret
+            - name: DEFAULT_REGION
+              value: us-east-1
+            - name: ENDPOINT
+              value: http://minio-service.namespace:9000/
+            - name: S3_BUCKET
+              value: operator-testing
+          imagePullPolicy: Always
+          name: xtrabackup
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mysql/ssl
+              name: ssl
+            - mountPath: /etc/mysql/ssl-internal
+              name: ssl-internal
+            - mountPath: /etc/mysql/vault-keyring-secret
+              name: vault-keyring-secret
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+        supplementalGroups:
+          - 1001
+          - 1002
+          - 1003
+      serviceAccount: percona-xtradb-cluster-operator-workload
+      serviceAccountName: percona-xtradb-cluster-operator-workload
+      terminationGracePeriodSeconds: 30
+      topologySpreadConstraints:
+        - labelSelector:
+            matchLabels:
+              backup-name: on-demand-backup-s3
+              cluster: sec-context
+              job-name: xb-on-demand-backup-s3
+              type: xtrabackup
+          maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+      volumes:
+        - name: ssl
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: vault-keyring-secret
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: sec-context-vault


### PR DESCRIPTION
[![K8SPXC-1295](https://badgen.net/badge/JIRA/K8SPXC-1295/green)](https://jira.percona.com/browse/K8SPXC-1295) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
Kubernetes 1.29 has some new fields in Job object:
```
kind: Job
spec:
  manualSelector: false
  podReplacementPolicy: TerminatingOrFailed
```

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1295]: https://perconadev.atlassian.net/browse/K8SPXC-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ