### PR TITLE
K8SPXC-1295 Skip test for EKS in pvc-resize script

### DIFF
--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -7,6 +7,11 @@ test_dir=$(realpath $(dirname $0))
 
 set_debug
 
+if [[ $EKS == 1 ]]; then
+	echo "Skip the test. We don't run it for EKS."
+	exit 0
+fi
+
 create_infra ${namespace}
 
 desc 'create first PXC cluster'


### PR DESCRIPTION
[![K8SPXC-1295](https://badgen.net/badge/JIRA/K8SPXC-1295/green)](https://jira.percona.com/browse/K8SPXC-1295) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
pvc resizing is not supported for EKS v 1.29

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1295]: https://perconadev.atlassian.net/browse/K8SPXC-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ