### PR TITLE
K8SPXC-1295 - Add max wait in upgrade tests and add version_info file into exclude list for SST

### DIFF
--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -515,10 +515,12 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 			exit 1
 		fi
 
-		mysql_upgrade --force "${mysql[@]:1}"
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
-			echo >&2 'MySQL init process failed.'
-			exit 1
+		if [[ $MYSQL_VERSION == '5.7' ]]; then
+			mysql_upgrade --force "${mysql[@]:1}"
+			if ! kill -s TERM "$pid" || ! wait "$pid"; then
+				echo >&2 'MySQL init process failed.'
+				exit 1
+			fi
 		fi
 	fi
 	"$@" --version | sed 's/-ps//' >"$DATADIR/version_info"

--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -188,7 +188,7 @@ fi
 # add sst.cpat to exclude pxc-entrypoint, unsafe-bootstrap, pxc-configure-pxc from SST cleanup
 grep -q "^progress=" $CFG && sed -i "s|^progress=.*|progress=1|" $CFG
 grep -q "^\[sst\]" "$CFG" || printf '[sst]\n' >>"$CFG"
-grep -q "^cpat=" "$CFG" || sed '/^\[sst\]/a cpat=.*\\.pem$\\|.*init\\.ok$\\|.*galera\\.cache$\\|.*wsrep_recovery_verbose\\.log$\\|.*readiness-check\\.sh$\\|.*liveness-check\\.sh$\\|.*get-pxc-state$\\|.*sst_in_progress$\\|.*sleep-forever$\\|.*pmm-prerun\\.sh$\\|.*sst-xb-tmpdir$\\|.*\\.sst$\\|.*gvwstate\\.dat$\\|.*grastate\\.dat$\\|.*\\.err$\\|.*\\.log$\\|.*RPM_UPGRADE_MARKER$\\|.*RPM_UPGRADE_HISTORY$\\|.*pxc-entrypoint\\.sh$\\|.*unsafe-bootstrap\\.sh$\\|.*pxc-configure-pxc\\.sh\\|.*peer-list$\\|.*auth_plugin$' "$CFG" 1<>"$CFG"
+grep -q "^cpat=" "$CFG" || sed '/^\[sst\]/a cpat=.*\\.pem$\\|.*init\\.ok$\\|.*galera\\.cache$\\|.*wsrep_recovery_verbose\\.log$\\|.*readiness-check\\.sh$\\|.*liveness-check\\.sh$\\|.*get-pxc-state$\\|.*sst_in_progress$\\|.*sleep-forever$\\|.*pmm-prerun\\.sh$\\|.*sst-xb-tmpdir$\\|.*\\.sst$\\|.*gvwstate\\.dat$\\|.*grastate\\.dat$\\|.*\\.err$\\|.*\\.log$\\|.*RPM_UPGRADE_MARKER$\\|.*RPM_UPGRADE_HISTORY$\\|.*pxc-entrypoint\\.sh$\\|.*unsafe-bootstrap\\.sh$\\|.*pxc-configure-pxc\\.sh\\|.*peer-list$\\|.*auth_plugin$\\|.*version_info$' "$CFG" 1<>"$CFG"
 if [[ $MYSQL_VERSION == '8.0' ]]; then
 	if [[ $MYSQL_PATCH_VERSION -ge 26 ]]; then
 		grep -q "^skip_replica_start=ON" "$CFG" || sed -i "/\[mysqld\]/a skip_replica_start=ON" $CFG

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -96,12 +96,19 @@ wait_cluster_consistency() {
 		proxy_size="$(get_proxy_size "$cluster_name")"
 	fi
 	desc "wait cluster consistency"
+	local i=0
+	local max=36
 	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
 	until [[ "$(kubectl_bin get pxc "${cluster_name}" -o jsonpath='{.status.state}')" == "ready" &&
 	"$(kubectl_bin get pxc "${cluster_name}" -o jsonpath='{.status.pxc.ready}')" == "${cluster_size}" &&
 	"$(kubectl_bin get pxc "${cluster_name}" -o jsonpath='{.status.'$(get_proxy_engine ${cluster_name})'.ready}')" == "${proxy_size}" ]]; do
 		echo 'waiting for cluster readyness'
 		sleep 20
+		if [[ $i -ge $max ]]; then
+			echo "Something went wrong waiting for cluster consistency!"
+			exit 1
+		fi
+		((i++))
 	done
 }
 

--- a/e2e-tests/run-pr.csv
+++ b/e2e-tests/run-pr.csv
@@ -32,7 +32,9 @@ tls-issue-cert-manager-ref,8.0
 tls-issue-cert-manager,8.0
 tls-issue-self,8.0
 upgrade-consistency,8.0
+upgrade-haproxy,5.7
 upgrade-haproxy,8.0
+upgrade-proxysql,5.7
 upgrade-proxysql,8.0
 users,5.7
 users,8.0

--- a/e2e-tests/smart-update1/run
+++ b/e2e-tests/smart-update1/run
@@ -43,6 +43,8 @@ function check_last_pod_to_update {
 
 	set +x
 	echo -n "Waiting for the last pod to update"
+	local i=0
+	local max=720
 	until [[ "$(kubectl_bin get pxc "${cluster}" -o jsonpath='{.status.state}')" == "ready" ]]; do
 		echo -n "."
 		updated_pods_count=0
@@ -62,6 +64,11 @@ function check_last_pod_to_update {
 				exit 1
 			fi
 		fi
+		if [[ $i -ge $max ]]; then
+			echo "Something went wrong waiting for the last pod to update!"
+			exit 1
+		fi
+		((i++))
 		sleep 1
 	done
 	set -x

--- a/e2e-tests/smart-update2/run
+++ b/e2e-tests/smart-update2/run
@@ -47,6 +47,8 @@ function check_last_pod_to_update {
 
 	set +x
 	echo -n "Waiting for the last pod to update"
+	local i=0
+	local max=720
 	until [[ "$(kubectl_bin get pxc "${cluster}" -o jsonpath='{.status.state}')" == "ready" ]]; do
 		echo -n "."
 		updated_pods_count=0
@@ -66,6 +68,11 @@ function check_last_pod_to_update {
 				exit 1
 			fi
 		fi
+		if [[ $i -ge $max ]]; then
+			echo "Something went wrong waiting for the last pod to update!"
+			exit 1
+		fi
+		((i++))
 		sleep 1
 	done
 	set -x

--- a/e2e-tests/upgrade-haproxy/run
+++ b/e2e-tests/upgrade-haproxy/run
@@ -77,9 +77,16 @@ function main() {
 	sleep 10
 
 	desc 'wait for operator upgrade'
+	local i=0
+	local max=60
 	until [[ $(kubectl_bin get pods --selector=app.kubernetes.io/name=${OPERATOR_NAME} \
 		-o custom-columns='NAME:.metadata.name,IMAGE:.spec.containers[0].image' ${OPERATOR_NS:+-n $OPERATOR_NS} \
 		| grep -vc 'NAME' | awk '{print $1}') -eq 1 ]]; do
+		if [[ $i -ge $max ]]; then
+			echo "Something went wrong waiting for operator upgrade!"
+			exit 1
+		fi
+		((i++))
 		sleep 5
 	done
 

--- a/e2e-tests/upgrade-proxysql/run
+++ b/e2e-tests/upgrade-proxysql/run
@@ -73,9 +73,16 @@ function main() {
 	sleep 10
 
 	desc 'wait for operator upgrade'
+	local i=0
+	local max=60
 	until [[ $(kubectl_bin get pods --selector=app.kubernetes.io/name=${OPERATOR_NAME} \
 		-o custom-columns='NAME:.metadata.name,IMAGE:.spec.containers[0].image' ${OPERATOR_NS:+-n $OPERATOR_NS} \
 		| grep -vc 'NAME' | awk '{print $1}') -eq 1 ]]; do
+		if [[ $i -ge $max ]]; then
+			echo "Something went wrong waiting for operator upgrade!"
+			exit 1
+		fi
+		((i++))
 		sleep 5
 	done
 


### PR DESCRIPTION
[![K8SPXC-1295](https://badgen.net/badge/JIRA/K8SPXC-1295/green)](https://jira.percona.com/browse/K8SPXC-1295) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*1. If there's an issue with the cluster the smart-update tests can run until Jenkins kills it.
2. version_info file gets deleted on SST so we don't run mysql_upgrade on upgrade when we start new mysql version*

**Solution:**
*1. Add max wait time for `smart-update`,`upgrade-haproxy` and `upgrade-proxysql` tests and in `wait_cluster_consistency` function
2. Put `version_info` file into exclude list for SST wipeout. Also add 5.7 upgrade tests for PR test runs.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1295]: https://perconadev.atlassian.net/browse/K8SPXC-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ