### PR TITLE
CLOUD-833 - Add release and after-release targets to Makefile

### DIFF
--- a/deploy/cr-minimal.yaml
+++ b/deploy/cr-minimal.yaml
@@ -3,7 +3,7 @@ kind: PerconaXtraDBCluster
 metadata:
   name: minimal-cluster
 spec:
-  crVersion: 1.14.0
+  crVersion: 1.15.0
   secretsName: minimal-cluster-secrets
   allowUnsafeConfigurations: true
   upgradeOptions:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -10,7 +10,7 @@ metadata:
 #  annotations:
 #    percona.com/issue-vault-token: "true"
 spec:
-  crVersion: 1.14.0
+  crVersion: 1.15.0
 #  ignoreAnnotations:
 #    - iam.amazonaws.com/role
 #  ignoreLabels:


### PR DESCRIPTION
[![CLOUD-833](https://badgen.net/badge/JIRA/CLOUD-833/green)](https://jira.percona.com/browse/CLOUD-833) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Manual steps need to be taken to prepare release branch and also to prepare main branch after release branch is merged.

**Solution:**
With this manifests will be prepared but also next version and main images set in cr.yaml. What we need to still do manually is set specific database/backup and other images before the release since each product has it's own.

Prepare release example:
`make release VERSION=1.15.0 IMAGE_TAG_BASE=percona/percona-xtradb-cluster-operator`

Prepare main branch after release example:
`make after-release VERSION=main IMAGE_TAG_BASE=perconalab/percona-xtradb-cluster-operator`
this above will automatically generate next version.

also works:
`make after-release NEXT_VER=1.16.0 IMAGE=perconalab/percona-xtradb-cluster-operator:main`

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-833]: https://perconadev.atlassian.net/browse/CLOUD-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ