### PR TITLE
K8SPXC-1384 - Fix checking backup deletion in demand-backup test

### DIFF
--- a/e2e-tests/demand-backup/run
+++ b/e2e-tests/demand-backup/run
@@ -49,7 +49,7 @@ main() {
 	backup_exists=$(
 		kubectl_bin run -n "${NAMESPACE}" -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
 			/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
-			/usr/bin/aws --endpoint-url https://minio-service:9000 --no-verify-ssl s3 ls operator-testing/ | grep -c "demand-backup" | cat
+			/usr/bin/aws --endpoint-url https://minio-service:9000 --no-verify-ssl s3 ls operator-testing/ | grep -c "prefix" | cat
 		exit "${PIPESTATUS[0]}"
 	)
 	if [[ $backup_exists -ne 0 ]]; then
@@ -59,7 +59,6 @@ main() {
 
 	destroy $namespace
 	desc "test passed"
-
 }
 
 main


### PR DESCRIPTION
[![K8SPXC-1384](https://badgen.net/badge/JIRA/K8SPXC-1384/green)](https://jira.percona.com/browse/K8SPXC-1384) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*We check if the backup doesn't exists, but we look for it in the wrong folder.*

**Cause:**
*We added prefix/folder to test bucket, but didn't update the test correctly.*

**Solution:**
*Update test to check correct path.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1384]: https://perconadev.atlassian.net/browse/K8SPXC-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ