### PR TITLE
K8SPXC-1337: add initContainer to backup job

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -52,6 +52,7 @@ COPY --from=go_builder /usr/local/bin/pitr /pitr
 COPY build/pxc-entrypoint.sh /pxc-entrypoint.sh
 COPY build/pxc-init-entrypoint.sh /pxc-init-entrypoint.sh
 COPY build/pitr-init-entrypoint.sh /pitr-init-entrypoint.sh
+COPY build/backup-init-entrypoint.sh /backup-init-entrypoint.sh
 COPY build/unsafe-bootstrap.sh /unsafe-bootstrap.sh
 COPY build/pxc-configure-pxc.sh /pxc-configure-pxc.sh
 COPY build/liveness-check.sh /liveness-check.sh

--- a/build/backup-init-entrypoint.sh
+++ b/build/backup-init-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -o errexit
+set -o xtrace
+
+install -o "$(id -u)" -g "$(id -g)" -m 0755 -D /peer-list /opt/percona/peer-list

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-k129.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-k129.yml
@@ -75,6 +75,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -82,6 +84,17 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -90,6 +103,8 @@ spec:
           - 1001
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-oc.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-oc.yml
@@ -74,6 +74,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -81,6 +83,17 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -88,6 +101,8 @@ spec:
           - 1001
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3.yml
@@ -74,6 +74,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -81,6 +83,17 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -89,6 +102,8 @@ spec:
           - 1001
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-k129.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-k129.yml
@@ -69,6 +69,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -76,6 +78,17 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -84,6 +97,8 @@ spec:
           - 1001
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-oc.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-oc.yml
@@ -68,6 +68,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -75,6 +77,17 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -82,6 +95,8 @@ spec:
           - 1001
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob.yml
@@ -68,6 +68,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -75,6 +77,17 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -83,6 +96,8 @@ spec:
           - 1001
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-k129.yml
+++ b/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-k129.yml
@@ -82,6 +82,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -89,6 +91,23 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2G
+            requests:
+              cpu: 500m
+              memory: 500M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -97,6 +116,8 @@ spec:
           - 1001
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-oc.yml
+++ b/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-oc.yml
@@ -81,6 +81,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -88,6 +90,23 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2G
+            requests:
+              cpu: 500m
+              memory: 500M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -95,6 +114,8 @@ spec:
           - 1001
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio.yml
+++ b/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio.yml
@@ -81,6 +81,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -88,6 +90,23 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2G
+            requests:
+              cpu: 500m
+              memory: 500M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -96,6 +115,8 @@ spec:
           - 1001
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc-k129.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc-k129.yml
@@ -62,6 +62,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /backup
               name: xtrabackup
             - mountPath: /etc/mysql/ssl
@@ -71,6 +73,19 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -83,6 +98,8 @@ spec:
       serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: xtrabackup
           persistentVolumeClaim:
             claimName: xb-on-demand-backup-pvc

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc.yml
@@ -61,6 +61,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /backup
               name: xtrabackup
             - mountPath: /etc/mysql/ssl
@@ -70,6 +72,19 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -82,6 +97,8 @@ spec:
       serviceAccountName: percona-xtradb-cluster-operator-workload
       terminationGracePeriodSeconds: 30
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: xtrabackup
           persistentVolumeClaim:
             claimName: xb-on-demand-backup-pvc

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3-k129.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3-k129.yml
@@ -78,6 +78,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -85,6 +87,19 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -107,6 +122,8 @@ spec:
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3.yml
@@ -77,6 +77,8 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mysql/ssl
               name: ssl
             - mountPath: /etc/mysql/ssl-internal
@@ -84,6 +86,19 @@ spec:
             - mountPath: /etc/mysql/vault-keyring-secret
               name: vault-keyring-secret
       dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /backup-init-entrypoint.sh
+          imagePullPolicy: Always
+          name: backup-init
+          resources: {}
+          securityContext:
+            privileged: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Never
       schedulerName: default-scheduler
       securityContext:
@@ -106,6 +121,8 @@ spec:
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
       volumes:
+        - emptyDir: {}
+          name: bin
         - name: ssl
           secret:
             defaultMode: 420

--- a/pkg/pxc/app/statefulset/init.go
+++ b/pkg/pxc/app/statefulset/init.go
@@ -41,7 +41,7 @@ func PitrInitContainer(cluster *api.PerconaXtraDBCluster, resources corev1.Resou
 	}
 }
 
-func BackupInitContainer(cluster *api.PerconaXtraDBCluster, resources corev1.ResourceRequirements, initImageName string) corev1.Container {
+func BackupInitContainer(cluster *api.PerconaXtraDBCluster, resources corev1.ResourceRequirements, initImageName string, securityContext *corev1.SecurityContext) corev1.Container {
 	return corev1.Container{
 		VolumeMounts: []corev1.VolumeMount{
 			{
@@ -53,7 +53,7 @@ func BackupInitContainer(cluster *api.PerconaXtraDBCluster, resources corev1.Res
 		ImagePullPolicy: cluster.Spec.Backup.ImagePullPolicy,
 		Name:            "backup-init",
 		Command:         []string{"/backup-init-entrypoint.sh"},
-		SecurityContext: cluster.Spec.PXC.ContainerSecurityContext,
+		SecurityContext: securityContext,
 		Resources:       resources,
 	}
 }

--- a/pkg/pxc/app/statefulset/init.go
+++ b/pkg/pxc/app/statefulset/init.go
@@ -40,3 +40,20 @@ func PitrInitContainer(cluster *api.PerconaXtraDBCluster, resources corev1.Resou
 		Resources:       resources,
 	}
 }
+
+func BackupInitContainer(cluster *api.PerconaXtraDBCluster, resources corev1.ResourceRequirements, initImageName string) corev1.Container {
+	return corev1.Container{
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      app.BinVolumeName,
+				MountPath: app.BinVolumeMountPath,
+			},
+		},
+		Image:           initImageName,
+		ImagePullPolicy: cluster.Spec.Backup.ImagePullPolicy,
+		Name:            "backup-init",
+		Command:         []string{"/backup-init-entrypoint.sh"},
+		SecurityContext: cluster.Spec.PXC.ContainerSecurityContext,
+		Resources:       resources,
+	}
+}

--- a/pkg/pxc/backup/job.go
+++ b/pkg/pxc/backup/job.go
@@ -12,6 +12,7 @@ import (
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app/statefulset"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/util"
 )
@@ -90,6 +91,9 @@ func (bcp *Backup) JobSpec(spec api.PXCBackupSpec, cluster *api.PerconaXtraDBClu
 				ImagePullSecrets:   bcp.imagePullSecrets,
 				RestartPolicy:      corev1.RestartPolicyNever,
 				ServiceAccountName: cluster.Spec.Backup.ServiceAccountName,
+				InitContainers: []corev1.Container{
+					statefulset.BackupInitContainer(cluster, storage.Resources, initImage),
+				},
 				Containers: []corev1.Container{
 					{
 						Name:            "xtrabackup",

--- a/pkg/pxc/backup/job.go
+++ b/pkg/pxc/backup/job.go
@@ -75,6 +75,29 @@ func (bcp *Backup) JobSpec(spec api.PXCBackupSpec, cluster *api.PerconaXtraDBClu
 	}
 	envs = util.MergeEnvLists(envs, spec.ContainerOptions.GetEnvVar(cluster, spec.StorageName))
 
+	var volumeMounts []corev1.VolumeMount
+	var volumes []corev1.Volume
+	var initContainers []corev1.Container
+	if cluster.CompareVersionWith("1.15.0") >= 0 {
+		volumes = append(volumes,
+			corev1.Volume{
+				Name: app.BinVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		)
+
+		volumeMounts = append(volumeMounts,
+			corev1.VolumeMount{
+				Name:      app.BinVolumeName,
+				MountPath: app.BinVolumeMountPath,
+			},
+		)
+
+		initContainers = append(initContainers, statefulset.BackupInitContainer(cluster, storage.Resources, initImage))
+	}
+
 	return batchv1.JobSpec{
 		BackoffLimit:   &backoffLimit,
 		ManualSelector: &manualSelector,
@@ -91,9 +114,7 @@ func (bcp *Backup) JobSpec(spec api.PXCBackupSpec, cluster *api.PerconaXtraDBClu
 				ImagePullSecrets:   bcp.imagePullSecrets,
 				RestartPolicy:      corev1.RestartPolicyNever,
 				ServiceAccountName: cluster.Spec.Backup.ServiceAccountName,
-				InitContainers: []corev1.Container{
-					statefulset.BackupInitContainer(cluster, storage.Resources, initImage),
-				},
+				InitContainers:     initContainers,
 				Containers: []corev1.Container{
 					{
 						Name:            "xtrabackup",
@@ -103,6 +124,7 @@ func (bcp *Backup) JobSpec(spec api.PXCBackupSpec, cluster *api.PerconaXtraDBClu
 						Command:         []string{"bash", "/usr/bin/backup.sh"},
 						Env:             envs,
 						Resources:       storage.Resources,
+						VolumeMounts:    volumeMounts,
 					},
 				},
 				Affinity:                  storage.Affinity,
@@ -112,6 +134,7 @@ func (bcp *Backup) JobSpec(spec api.PXCBackupSpec, cluster *api.PerconaXtraDBClu
 				SchedulerName:             storage.SchedulerName,
 				PriorityClassName:         storage.PriorityClassName,
 				RuntimeClassName:          storage.RuntimeClassName,
+				Volumes:                   volumes,
 			},
 		},
 	}, nil

--- a/pkg/pxc/backup/job.go
+++ b/pkg/pxc/backup/job.go
@@ -95,7 +95,7 @@ func (bcp *Backup) JobSpec(spec api.PXCBackupSpec, cluster *api.PerconaXtraDBClu
 			},
 		)
 
-		initContainers = append(initContainers, statefulset.BackupInitContainer(cluster, storage.Resources, initImage))
+		initContainers = append(initContainers, statefulset.BackupInitContainer(cluster, storage.Resources, initImage, storage.ContainerSecurityContext))
 	}
 
 	return batchv1.JobSpec{

--- a/pkg/pxc/backup/restore.go
+++ b/pkg/pxc/backup/restore.go
@@ -226,8 +226,8 @@ func RestoreJob(cr *api.PerconaXtraDBClusterRestore, bcp *api.PerconaXtraDBClust
 
 	var initContainers []corev1.Container
 	if pitr {
-		initContainers = []corev1.Container{statefulset.PitrInitContainer(cluster, cr.Spec.Resources, initImage)}
 		if cluster.CompareVersionWith("1.15.0") >= 0 {
+			initContainers = []corev1.Container{statefulset.PitrInitContainer(cluster, cr.Spec.Resources, initImage)}
 			volumes = append(volumes,
 				corev1.Volume{
 					Name: app.BinVolumeName,


### PR DESCRIPTION
[![K8SPXC-1337](https://badgen.net/badge/JIRA/K8SPXC-1337/green)](https://jira.percona.com/browse/K8SPXC-1337) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPXC-1337

**DESCRIPTION**
---
This PR makes the operator inject `peer-list` binary in the backup job to the` /opt/percona` directory.

It will work only with images from this PR: https://github.com/percona/percona-docker/pull/990

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1337]: https://perconadev.atlassian.net/browse/K8SPXC-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ