### PR TITLE
K8SPXC-1330: Remove debug log

### DIFF
--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -519,7 +519,6 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileHAProxy(ctx context.Context, cr
 		}
 	}
 
-	log := logf.FromContext(ctx)
 	if cr.HAProxyReplicasServiceEnabled() {
 		svc := pxc.NewServiceHAProxyReplicas(cr)
 		err := setControllerReference(cr, svc, r.scheme)
@@ -529,7 +528,6 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileHAProxy(ctx context.Context, cr
 
 		if cr.CompareVersionWith("1.14.0") >= 0 {
 			e := cr.Spec.HAProxy.ExposeReplicas
-			log.Info("HAProxy replicas service", "service", svc.Name, "expose", e)
 			err = r.createOrUpdateService(ctx, cr, svc, len(e.ServiceExpose.Labels) == 0 && len(e.ServiceExpose.Annotations) == 0)
 			if err != nil {
 				return errors.Wrapf(err, "%s upgrade error", svc.Name)


### PR DESCRIPTION
[![K8SPXC-1330](https://badgen.net/badge/JIRA/K8SPXC-1330/green)](https://jira.percona.com/browse/K8SPXC-1330) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Log left from development.

**Cause:**
It happens y'know.

**Solution:**
Remove.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1330]: https://perconadev.atlassian.net/browse/K8SPXC-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ