### PR TITLE
K8SPXC-1428: Fix converting to volume size to GiB

### DIFF
--- a/e2e-tests/pvc-resize/conf/some-name-eks.yml
+++ b/e2e-tests/pvc-resize/conf/some-name-eks.yml
@@ -60,7 +60,7 @@ spec:
             accessModes: [ "ReadWriteOnce" ]
             resources:
               requests:
-                storage: 1Gi
+                storage: 1G
       aws-s3:
         type: s3
         s3:

--- a/e2e-tests/pvc-resize/conf/some-name.yml
+++ b/e2e-tests/pvc-resize/conf/some-name.yml
@@ -58,7 +58,7 @@ spec:
             accessModes: [ "ReadWriteOnce" ]
             resources:
               requests:
-                storage: 1Gi
+                storage: 1G
       aws-s3:
         type: s3
         s3:

--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -86,7 +86,7 @@ fi
 
 desc "test scaling"
 
-patch_pvc_request "${cluster}" "3Gi"
+patch_pvc_request "${cluster}" "3G"
 wait_cluster_consistency "$cluster" 3 2
 
 for pvc in $(kubectl_bin get pvc -l app.kubernetes.io/component=pxc -o name); do
@@ -122,7 +122,7 @@ desc 'create resourcequota'
 # the others should fail to resize due to the exceeded quota but operator should
 # handle the error and keep the cluster ready
 apply_resourcequota 10Gi
-patch_pvc_request "${cluster}" "4Gi"
+patch_pvc_request "${cluster}" "4G"
 wait_cluster_consistency "$cluster" 3 2
 echo
 
@@ -143,7 +143,7 @@ echo "pvc/datadir-some-name-pxc-0 was resized"
 
 # We're setting the quota to 16Gi, so we can resize all PVCs to 4Gi
 apply_resourcequota 12Gi
-patch_pvc_request "${cluster}" "4Gi"
+patch_pvc_request "${cluster}" "4G"
 wait_cluster_consistency "$cluster" 3 2
 echo
 for pvc in $(kubectl_bin get pvc -l app.kubernetes.io/component=pxc -o name); do
@@ -167,11 +167,11 @@ done
 desc "test downscale"
 
 # operator shouldn't try to downscale the PVCs and set status to error
-patch_pvc_request "${cluster}" "1Gi"
+patch_pvc_request "${cluster}" "1G"
 wait_cluster_status ${cluster} "error"
 
 # user should be able to restore to the previous size and make the cluster ready
-patch_pvc_request "${cluster}" "4Gi"
+patch_pvc_request "${cluster}" "4G"
 wait_cluster_status ${cluster} "ready"
 
 destroy "${namespace}"

--- a/pkg/controller/pxc/volumes.go
+++ b/pkg/controller/pxc/volumes.go
@@ -2,7 +2,6 @@ package pxc
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"slices"
 	"strings"
@@ -131,11 +130,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcilePersistentVolumes(ctx context.C
 		return errors.Wrap(err, "round GiB value")
 	}
 
-	requestedQuantity := fmt.Sprintf("%dGi", gib)
-	requested, err = resource.ParseQuantity(requestedQuantity)
-	if err != nil {
-		return errors.Wrapf(err, "parse quantity (%s)", requestedQuantity)
-	}
+	requested = *resource.NewQuantity(gib*GiB, resource.BinarySI)
 
 	if cr.PVCResizeInProgress() {
 		resizeStartedAt, err := time.Parse(time.RFC3339, cr.GetAnnotations()[pxcv1.AnnotationPVCResizeInProgress])

--- a/pkg/controller/pxc/volumes.go
+++ b/pkg/controller/pxc/volumes.go
@@ -222,7 +222,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcilePersistentVolumes(ctx context.C
 		return errors.Errorf("requested storage (%s) is less than actual storage (%s)", requested.String(), actual.String())
 	}
 
-	if requested.Cmp(configured) == 0 || requested.Cmp(actual) == 0 {
+	if requested.Cmp(actual) == 0 {
 		return nil
 	}
 

--- a/pkg/controller/pxc/volumes.go
+++ b/pkg/controller/pxc/volumes.go
@@ -64,6 +64,11 @@ func (r *ReconcilePerconaXtraDBCluster) reconcilePersistentVolumes(ctx context.C
 		return errors.Wrap(err, "list pods")
 	}
 
+	if len(podList.Items) < int(cr.Spec.PXC.Size) {
+		log.Info("Waiting for all pods to be running")
+		return nil
+	}
+
 	podNames := make([]string, 0, len(podList.Items))
 	for _, pod := range podList.Items {
 		podNames = append(podNames, pod.Name)
@@ -216,6 +221,8 @@ func (r *ReconcilePerconaXtraDBCluster) reconcilePersistentVolumes(ctx context.C
 
 			return nil
 		}
+
+		log.Info("PVC resize in progress", "updated", updatedPVCs, "remaining", len(pvcsToUpdate)-updatedPVCs)
 	}
 
 	if requested.Cmp(actual) < 0 {


### PR DESCRIPTION
[![K8SPXC-1428](https://badgen.net/badge/JIRA/K8SPXC-1428/green)](https://jira.percona.com/browse/K8SPXC-1428) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem**:
We weren't properly converting GB to GiB.

**Solution**:
Convert properly.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1428]: https://perconadev.atlassian.net/browse/K8SPXC-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ