### PR TITLE
K8SPXC-1358: Disable TLS in cr-minimal.yaml

### DIFF
--- a/deploy/cr-minimal.yaml
+++ b/deploy/cr-minimal.yaml
@@ -5,10 +5,15 @@ metadata:
 spec:
   crVersion: 1.15.0
   secretsName: minimal-cluster-secrets
-  allowUnsafeConfigurations: true
+  unsafeFlags:
+    tls: true
+    pxcSize: true
+    proxySize: true
   upgradeOptions:
     apply: disabled
     schedule: "0 4 * * *"
+  tls:
+    enabled: false
   pxc:
     size: 1
     image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0


### PR DESCRIPTION
[![K8SPXC-1358](https://badgen.net/badge/JIRA/K8SPXC-1358/green)](https://jira.percona.com/browse/K8SPXC-1358) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
TLS is enabled in cr-minimal.yaml.

**Cause:**
Before, if cr.yaml doesn't have `spec.tls` section, TLS was disabled. Now the default is enabled.

**Solution:**
Disable TLS explicitly.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1358]: https://perconadev.atlassian.net/browse/K8SPXC-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ