### PR TITLE
K8SPXC-1429: reduce error logs on cluster deletion

### DIFF
--- a/pkg/controller/pxc/replication.go
+++ b/pkg/controller/pxc/replication.go
@@ -252,7 +252,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileReplication(ctx context.Context
 		setReplicationChannelStatus(cr, channel)
 	}
 
-	return r.updateStatus(cr, false, nil)
+	return r.updateStatus(ctx, cr, false, nil)
 }
 
 func handleReplicaPasswordChange(db queries.Database, newPass string) error {

--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -498,7 +498,7 @@ func (r *ReconcilePerconaXtraDBCluster) waitPodRestart(ctx context.Context, cr *
 			}
 
 			// We update status in every loop to not wait until the end of smart update
-			if err := r.updateStatus(cr, true, nil); err != nil {
+			if err := r.updateStatus(ctx, cr, true, nil); err != nil {
 				return false, errors.Wrap(err, "update status")
 			}
 


### PR DESCRIPTION
[![K8SPXC-1429](https://badgen.net/badge/JIRA/K8SPXC-1429/green)](https://jira.percona.com/browse/K8SPXC-1429) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPXC-1429

**DESCRIPTION**
---
This PR removes unnecessary error logs generated during the cluster deletion. Specifically, it removes the following error logs:
- `get pxc status: get statefulset: StatefulSet.apps \"cluster1-pxc\" not found`
- `Warning: Reconciler returned both a non-zero result and a non-nil error`
- `Operation cannot be fulfilled on perconaxtradbclusters.pxc.percona.com \"cluster1\": the object has been modified; please apply your changes to the latest version and try again`

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1429]: https://perconadev.atlassian.net/browse/K8SPXC-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ