### PR TITLE
K8SPXC-1337: fix initContainer resources

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -208,7 +208,7 @@ spec:
 #    livenessDelaySec: 600
 #    configuration: |
 #
-#    the actual default configuration file can be found here https://github.com/percona/percona-docker/blob/main/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
+#    the actual default configuration file can be found here https://raw.githubusercontent.com/percona/percona-xtradb-cluster-operator/main/build/haproxy-global.cfg
 #
 #      global
 #        maxconn 2048

--- a/e2e-tests/affinity/compare/statefulset_custom-proxysql-k127-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-proxysql-k127-oc.yml
@@ -222,11 +222,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_custom-proxysql-k127.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-proxysql-k127.yml
@@ -222,11 +222,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_custom-proxysql-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-proxysql-oc.yml
@@ -211,11 +211,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_custom-proxysql.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-proxysql.yml
@@ -211,11 +211,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_hostname-proxysql-k127-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-proxysql-k127-oc.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_hostname-proxysql-k127.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-proxysql-k127.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_hostname-proxysql-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-proxysql-oc.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_hostname-proxysql.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-proxysql.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_region-proxysql-k127-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-proxysql-k127-oc.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_region-proxysql-k127.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-proxysql-k127.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_region-proxysql-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-proxysql-oc.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_region-proxysql.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-proxysql.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_zone-proxysql-k127-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-proxysql-k127-oc.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_zone-proxysql-k127.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-proxysql-k127.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_zone-proxysql-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-proxysql-oc.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/affinity/compare/statefulset_zone-proxysql.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-proxysql.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/default-cr/compare/statefulset_cluster1-haproxy-k127.yml
+++ b/e2e-tests/default-cr/compare/statefulset_cluster1-haproxy-k127.yml
@@ -162,9 +162,9 @@ spec:
           imagePullPolicy: Always
           name: haproxy-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/default-cr/compare/statefulset_cluster1-haproxy.yml
+++ b/e2e-tests/default-cr/compare/statefulset_cluster1-haproxy.yml
@@ -159,9 +159,9 @@ spec:
           imagePullPolicy: Always
           name: haproxy-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-haproxy-k127.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-haproxy-k127.yml
@@ -158,7 +158,10 @@ spec:
             - /haproxy-init-entrypoint.sh
           imagePullPolicy: Always
           name: haproxy-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-haproxy.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-haproxy.yml
@@ -155,7 +155,10 @@ spec:
             - /haproxy-init-entrypoint.sh
           imagePullPolicy: Always
           name: haproxy-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-k129.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-k129.yml
@@ -89,7 +89,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-oc.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3-oc.yml
@@ -88,7 +88,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-aws-s3.yml
@@ -88,7 +88,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-k129.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-k129.yml
@@ -83,7 +83,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-oc.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob-oc.yml
@@ -82,7 +82,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob.yml
+++ b/e2e-tests/demand-backup-cloud/compare/job.batch_xb-on-demand-backup-azure-blob.yml
@@ -82,7 +82,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-k129.yml
+++ b/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-k129.yml
@@ -98,11 +98,8 @@ spec:
           name: backup-init
           resources:
             limits:
-              cpu: "1"
-              memory: 2G
-            requests:
-              cpu: 500m
-              memory: 500M
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-oc.yml
+++ b/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio-oc.yml
@@ -97,11 +97,8 @@ spec:
           name: backup-init
           resources:
             limits:
-              cpu: "1"
-              memory: 2G
-            requests:
-              cpu: 500m
-              memory: 500M
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio.yml
+++ b/e2e-tests/demand-backup/compare/job_xb-on-demand-backup-minio.yml
@@ -97,11 +97,8 @@ spec:
           name: backup-init
           resources:
             limits:
-              cpu: "1"
-              memory: 2G
-            requests:
-              cpu: 500m
-              memory: 500M
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-k127.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-k127.yml
@@ -171,7 +171,13 @@ spec:
             - /haproxy-init-entrypoint.sh
           imagePullPolicy: Always
           name: haproxy-init
-          resources: {}
+          resources:
+            limits:
+              cpu: "1"
+              memory: 500M
+            requests:
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-secret-k127.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-secret-k127.yml
@@ -171,7 +171,13 @@ spec:
             - /haproxy-init-entrypoint.sh
           imagePullPolicy: Always
           name: haproxy-init
-          resources: {}
+          resources:
+            limits:
+              cpu: "1"
+              memory: 500M
+            requests:
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-secret.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-secret.yml
@@ -162,7 +162,13 @@ spec:
             - /haproxy-init-entrypoint.sh
           imagePullPolicy: Always
           name: haproxy-init
-          resources: {}
+          resources:
+            limits:
+              cpu: "1"
+              memory: 500M
+            requests:
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy.yml
@@ -162,7 +162,13 @@ spec:
             - /haproxy-init-entrypoint.sh
           imagePullPolicy: Always
           name: haproxy-init
-          resources: {}
+          resources:
+            limits:
+              cpu: "1"
+              memory: 500M
+            requests:
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-k127-oc.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-k127-oc.yml
@@ -207,11 +207,11 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
+              cpu: "1"
+              memory: 500M
             requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-k127.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-k127.yml
@@ -212,11 +212,11 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
+              cpu: "1"
+              memory: 500M
             requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-oc.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-oc.yml
@@ -209,11 +209,11 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
+              cpu: "1"
+              memory: 500M
             requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-secret-k127-oc.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-secret-k127-oc.yml
@@ -212,11 +212,11 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
+              cpu: "1"
+              memory: 500M
             requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-secret-k127.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-secret-k127.yml
@@ -212,11 +212,11 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
+              cpu: "1"
+              memory: 500M
             requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-secret-oc.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-secret-oc.yml
@@ -209,11 +209,11 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
+              cpu: "1"
+              memory: 500M
             requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-secret.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql-secret.yml
@@ -209,11 +209,11 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
+              cpu: "1"
+              memory: 500M
             requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-proxysql.yml
@@ -209,11 +209,11 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
+              cpu: "1"
+              memory: 500M
             requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 300m
+              memory: 200M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-k127-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-k127-oc.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 100m
-              memory: 100M
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-k127.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-k127.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 100m
-              memory: 100M
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-oc.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 100m
-              memory: 100m
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 100m
-              memory: 100m
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127-oc.yml
@@ -314,9 +314,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127.yml
@@ -314,9 +314,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-oc.yml
@@ -303,9 +303,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased.yml
@@ -303,9 +303,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127-oc.yml
@@ -314,9 +314,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127.yml
@@ -314,9 +314,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: proxysql-init
           resources:
-            requests:
-              cpu: 300m
-              memory: 500M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-oc.yml
@@ -303,9 +303,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql.yml
@@ -303,9 +303,9 @@ spec:
           imagePullPolicy: IfNotPresent
           name: proxysql-init
           resources:
-            requests:
-              cpu: 300m
-              memory: 500M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-k127-oc.yml
@@ -178,11 +178,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-k127.yml
@@ -176,7 +176,10 @@ spec:
             - /proxysql-init-entrypoint.sh
           imagePullPolicy: Always
           name: proxysql-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-oc.yml
@@ -167,11 +167,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased.yml
@@ -167,11 +167,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-k127-oc.yml
@@ -178,11 +178,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-k127.yml
@@ -176,7 +176,10 @@ spec:
             - /proxysql-init-entrypoint.sh
           imagePullPolicy: Always
           name: proxysql-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-oc.yml
@@ -167,11 +167,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql.yml
@@ -167,11 +167,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-k127-oc.yml
@@ -181,11 +181,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-k127.yml
@@ -181,8 +181,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-oc.yml
@@ -170,11 +170,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased.yml
@@ -170,11 +170,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-k127-oc.yml
@@ -181,11 +181,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-k127.yml
@@ -181,8 +181,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 300m
-              memory: 600M
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-oc.yml
@@ -170,11 +170,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql.yml
@@ -170,11 +170,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-k127.yml
@@ -292,9 +292,9 @@ spec:
           imagePullPolicy: Always
           name: haproxy-init
           resources:
-            requests:
-              cpu: 300m
-              memory: 500M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-k127.yml
@@ -292,9 +292,9 @@ spec:
           imagePullPolicy: Always
           name: haproxy-init
           resources:
-            requests:
-              cpu: 300m
-              memory: 500M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix.yml
@@ -283,9 +283,9 @@ spec:
           imagePullPolicy: Always
           name: haproxy-init
           resources:
-            requests:
-              cpu: 300m
-              memory: 500M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
@@ -282,7 +282,10 @@ spec:
             - /haproxy-init-entrypoint.sh
           imagePullPolicy: Always
           name: haproxy-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy-k127.yml
+++ b/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy-k127.yml
@@ -155,9 +155,9 @@ spec:
           imagePullPolicy: Always
           name: haproxy-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 500M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy.yml
+++ b/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy.yml
@@ -146,9 +146,9 @@ spec:
           imagePullPolicy: Always
           name: haproxy-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 500M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-k127-oc.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-k127-oc.yml
@@ -192,9 +192,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 100m
-              memory: 100M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-k127.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-k127.yml
@@ -192,9 +192,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 100m
-              memory: 100M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-oc.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-oc.yml
@@ -181,9 +181,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 100m
-              memory: 100M
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql.yml
@@ -181,9 +181,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 100m
-              memory: 100m
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc-k129.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc-k129.yml
@@ -78,7 +78,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           securityContext:
             privileged: true
           terminationMessagePath: /dev/termination-log

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-pvc.yml
@@ -77,7 +77,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           securityContext:
             privileged: true
           terminationMessagePath: /dev/termination-log

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3-k129.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3-k129.yml
@@ -92,7 +92,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           securityContext:
             privileged: true
           terminationMessagePath: /dev/termination-log

--- a/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3.yml
+++ b/e2e-tests/security-context/compare/job.batch_xb-on-demand-backup-s3.yml
@@ -91,7 +91,10 @@ spec:
             - /backup-init-entrypoint.sh
           imagePullPolicy: Always
           name: backup-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           securityContext:
             privileged: true
           terminationMessagePath: /dev/termination-log

--- a/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes-k127.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes-k127.yml
@@ -184,9 +184,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 100m
-              memory: 100M
+            limits:
+              cpu: 50m
+              memory: 50M
           securityContext:
             privileged: true
           terminationMessagePath: /dev/termination-log

--- a/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes.yml
@@ -174,11 +174,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 100m
-              memory: 100M
+              cpu: 50m
+              memory: 50M
           securityContext:
             privileged: false
           terminationMessagePath: /dev/termination-log

--- a/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-k127.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-k127.yml
@@ -184,9 +184,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 100m
-              memory: 100M
+            limits:
+              cpu: 50m
+              memory: 50M
           securityContext:
             privileged: false
           terminationMessagePath: /dev/termination-log

--- a/e2e-tests/security-context/compare/statefulset_sec-context-proxysql.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-proxysql.yml
@@ -173,9 +173,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 100m
-              memory: 100m
+            limits:
+              cpu: 50m
+              memory: 50M
           securityContext:
             privileged: false
           terminationMessagePath: /dev/termination-log

--- a/e2e-tests/storage/compare/statefulset_emptydir-proxysql-k127-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-proxysql-k127-oc.yml
@@ -178,8 +178,7 @@ spec:
           name: pxc-init
           resources:
             limits:
-              cpu: 50m
-              memory: 50M
+              ephemeral-storage: 1G
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_emptydir-proxysql-k127.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-proxysql-k127.yml
@@ -178,8 +178,7 @@ spec:
           name: pxc-init
           resources:
             limits:
-              cpu: 50m
-              memory: 50M
+              ephemeral-storage: 1G
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_emptydir-proxysql-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-proxysql-oc.yml
@@ -167,8 +167,7 @@ spec:
           name: pxc-init
           resources:
             limits:
-              cpu: 50m
-              memory: 50M
+              ephemeral-storage: 1G
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_emptydir-proxysql.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-proxysql.yml
@@ -167,8 +167,7 @@ spec:
           name: pxc-init
           resources:
             limits:
-              cpu: 50m
-              memory: 50M
+              ephemeral-storage: 1G
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_emptydir-pxc-k127-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-pxc-k127-oc.yml
@@ -153,8 +153,7 @@ spec:
           name: pxc-init
           resources:
             limits:
-              cpu: 50m
-              memory: 50M
+              ephemeral-storage: 1G
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_emptydir-pxc-k127.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-pxc-k127.yml
@@ -153,8 +153,7 @@ spec:
           name: pxc-init
           resources:
             limits:
-              cpu: 50m
-              memory: 50M
+              ephemeral-storage: 1G
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_emptydir-pxc-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-pxc-oc.yml
@@ -150,8 +150,7 @@ spec:
           name: pxc-init
           resources:
             limits:
-              cpu: 50m
-              memory: 50M
+              ephemeral-storage: 1G
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_emptydir-pxc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-pxc.yml
@@ -150,8 +150,7 @@ spec:
           name: pxc-init
           resources:
             limits:
-              cpu: 50m
-              memory: 50M
+              ephemeral-storage: 1G
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_hostpath-proxysql-k127-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-proxysql-k127-oc.yml
@@ -189,7 +189,10 @@ spec:
             - /proxysql-init-entrypoint.sh
           imagePullPolicy: Always
           name: proxysql-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_hostpath-proxysql-k127.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-proxysql-k127.yml
@@ -189,7 +189,10 @@ spec:
             - /proxysql-init-entrypoint.sh
           imagePullPolicy: Always
           name: proxysql-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_hostpath-proxysql-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-proxysql-oc.yml
@@ -178,7 +178,10 @@ spec:
             - /proxysql-init-entrypoint.sh
           imagePullPolicy: Always
           name: proxysql-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/compare/statefulset_hostpath-proxysql.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-proxysql.yml
@@ -180,11 +180,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 600m
-              memory: 1G
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/storage/conf/emptydir.yml
+++ b/e2e-tests/storage/conf/emptydir.yml
@@ -5,6 +5,10 @@ metadata:
 spec:
   secretsName: my-cluster-secrets
   sslSecretName: some-name-ssl
+  initContainer:
+    resources:
+      limits:
+        ephemeral-storage: 1G
   pxc:
     size: 3
     image: -pxc

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1150-k127-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1150-k127-oc.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 100m
-              memory: 100M
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1150-k127.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1150-k127.yml
@@ -195,11 +195,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 100m
-              memory: 100M
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1150-oc.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 100m
-              memory: 100m
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1150.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1150.yml
@@ -184,11 +184,8 @@ spec:
           name: proxysql-init
           resources:
             limits:
-              cpu: 700m
-              memory: 1G
-            requests:
-              cpu: 100m
-              memory: 100m
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-haproxy-k127.yml
+++ b/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-haproxy-k127.yml
@@ -162,9 +162,9 @@ spec:
           imagePullPolicy: Always
           name: haproxy-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-haproxy.yml
+++ b/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-haproxy.yml
@@ -150,7 +150,10 @@ spec:
             - /haproxy-init-entrypoint.sh
           imagePullPolicy: Always
           name: haproxy-init
-          resources: {}
+          resources:
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql-k127-oc.yml
+++ b/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql-k127-oc.yml
@@ -191,9 +191,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql-k127.yml
+++ b/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql-k127.yml
@@ -191,9 +191,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql-oc.yml
+++ b/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql-oc.yml
@@ -180,9 +180,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql.yml
+++ b/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql.yml
@@ -180,9 +180,9 @@ spec:
           imagePullPolicy: Always
           name: proxysql-init
           resources:
-            requests:
-              cpu: 600m
-              memory: 1G
+            limits:
+              cpu: 50m
+              memory: 50M
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:

--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -550,14 +550,7 @@ func (r *ReconcilePerconaXtraDBCluster) deploy(ctx context.Context, cr *api.Perc
 	}
 	inits := []corev1.Container{}
 	if cr.CompareVersionWith("1.5.0") >= 0 {
-		var initResources corev1.ResourceRequirements
-		if cr.CompareVersionWith("1.6.0") >= 0 {
-			initResources = cr.Spec.PXC.Resources
-		}
-		if cr.Spec.InitContainer.Resources != nil {
-			initResources = *cr.Spec.InitContainer.Resources
-		}
-		initC := statefulset.EntrypointInitContainer(initImageName, app.DataVolumeName, initResources, cr.Spec.PXC.ContainerSecurityContext, cr.Spec.PXC.ImagePullPolicy)
+		initC := statefulset.EntrypointInitContainer(cr, initImageName, app.DataVolumeName)
 		inits = append(inits, initC)
 	}
 

--- a/pkg/pxc/app/deployment/binlog-collector.go
+++ b/pkg/pxc/app/deployment/binlog-collector.go
@@ -104,7 +104,7 @@ func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster, initImage string
 	}
 	if cr.CompareVersionWith("1.15.0") >= 0 {
 		container.Command = []string{"/opt/percona/pitr"}
-		initContainers = []corev1.Container{statefulset.PitrInitContainer(cr, cr.Spec.Backup.PITR.Resources, initImage)}
+		initContainers = []corev1.Container{statefulset.PitrInitContainer(cr, initImage)}
 		volumes = append(volumes,
 			corev1.Volume{
 				Name: app.BinVolumeName,

--- a/pkg/pxc/app/statefulset/node.go
+++ b/pkg/pxc/app/statefulset/node.go
@@ -60,13 +60,8 @@ func (c *Node) Name() string {
 }
 
 func (c *Node) InitContainers(cr *api.PerconaXtraDBCluster, initImageName string) []corev1.Container {
-	initResources := cr.Spec.PXC.Resources
-	if cr.Spec.InitContainer.Resources != nil {
-		initResources = *cr.Spec.InitContainer.Resources
-	}
-
 	inits := []corev1.Container{
-		EntrypointInitContainer(initImageName, app.DataVolumeName, initResources, cr.Spec.PXC.ContainerSecurityContext, cr.Spec.PXC.ImagePullPolicy),
+		EntrypointInitContainer(cr, initImageName, app.DataVolumeName),
 	}
 	return inits
 }

--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -71,12 +71,8 @@ func (c *Proxy) InitContainers(cr *api.PerconaXtraDBCluster, initImageName strin
 func proxyInitContainers(cr *api.PerconaXtraDBCluster, initImageName string) []corev1.Container {
 	inits := []corev1.Container{}
 	if cr.CompareVersionWith("1.13.0") >= 0 {
-		initResources := cr.Spec.PXC.Resources
-		if cr.Spec.InitContainer.Resources != nil {
-			initResources = *cr.Spec.InitContainer.Resources
-		}
 		inits = []corev1.Container{
-			EntrypointInitContainer(initImageName, app.BinVolumeName, initResources, cr.Spec.PXC.ContainerSecurityContext, cr.Spec.PXC.ImagePullPolicy),
+			EntrypointInitContainer(cr, initImageName, app.BinVolumeName),
 		}
 	}
 

--- a/pkg/pxc/backup/job.go
+++ b/pkg/pxc/backup/job.go
@@ -95,7 +95,7 @@ func (bcp *Backup) JobSpec(spec api.PXCBackupSpec, cluster *api.PerconaXtraDBClu
 			},
 		)
 
-		initContainers = append(initContainers, statefulset.BackupInitContainer(cluster, storage.Resources, initImage, storage.ContainerSecurityContext))
+		initContainers = append(initContainers, statefulset.BackupInitContainer(cluster, initImage, storage.ContainerSecurityContext))
 	}
 
 	return batchv1.JobSpec{

--- a/pkg/pxc/backup/restore.go
+++ b/pkg/pxc/backup/restore.go
@@ -227,7 +227,7 @@ func RestoreJob(cr *api.PerconaXtraDBClusterRestore, bcp *api.PerconaXtraDBClust
 	var initContainers []corev1.Container
 	if pitr {
 		if cluster.CompareVersionWith("1.15.0") >= 0 {
-			initContainers = []corev1.Container{statefulset.PitrInitContainer(cluster, cr.Spec.Resources, initImage)}
+			initContainers = []corev1.Container{statefulset.PitrInitContainer(cluster, initImage)}
 			volumes = append(volumes,
 				corev1.Volume{
 					Name: app.BinVolumeName,


### PR DESCRIPTION
[![K8SPXC-1337](https://badgen.net/badge/JIRA/K8SPXC-1337/green)](https://jira.percona.com/browse/K8SPXC-1337) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPXC-1337

**DESCRIPTION**
---
This PR makes init containers `proxysql-init`, `haproxy-init`, `backup-init`, `pitr-init` use resources from `.spec.initContainer.resources`.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1337]: https://perconadev.atlassian.net/browse/K8SPXC-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ