### PR TITLE
K8SPXC-1259: Copy proxysql-admin.cnf to correct location

### DIFF
--- a/build/proxysql-entrypoint.sh
+++ b/build/proxysql-entrypoint.sh
@@ -3,7 +3,7 @@
 set -o xtrace
 
 cp /opt/percona/proxysql.cnf /etc/proxysql
-cp /opt/percona/proxysql-admin.cnf /etc/proxysql
+cp /opt/percona/proxysql-admin.cnf /etc
 
 PROXY_CFG=/etc/proxysql/proxysql.cnf
 PROXY_ADMIN_CFG=/etc/proxysql-admin.cnf


### PR DESCRIPTION
[![K8SPXC-1259](https://badgen.net/badge/JIRA/K8SPXC-1259/green)](https://jira.percona.com/browse/K8SPXC-1259) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
proxysql-admin.cnf is not copied to the right location and because of that, we get `Permission denied` error in the proxysql entrypoint script.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1259]: https://perconadev.atlassian.net/browse/K8SPXC-1259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ