### PR TITLE
K8SPXC-1363: fix scheduled-backup and demand-backup tests

### DIFF
--- a/e2e-tests/demand-backup/run
+++ b/e2e-tests/demand-backup/run
@@ -65,7 +65,7 @@ main() {
 	kubectl logs "$restore_job_name" | grep "xtrabackup --use-memory=1500000000 --prepare --parallel=3"
 	kubectl logs "$restore_job_name" | egrep "xbcloud get --parallel=[0-9]+ --insecure (--curl-retriable-errors=7 )?--parallel=3"
 	kubectl logs "$restore_job_name" | egrep "xbstream -x -C .* --parallel=[0-9]+ --parallel=3"
-	kubectl logs "$restore_job_name" | egrep "(xbstream --decompress -x -C .* --parallel=[0-9]+ --parallel=3|xbstream -x -C .* --parallel=4 --parallel=3)"
+	kubectl logs "$restore_job_name" | egrep "(xbstream --decompress -x -C .* --parallel=[0-9]+ --parallel=3|xbstream -x -C .* --parallel=[0-9]+ --parallel=3)"
 
 	desc "Check backup deletion"
 	kubectl_bin delete pxc-backup --all

--- a/e2e-tests/scheduled-backup/run
+++ b/e2e-tests/scheduled-backup/run
@@ -62,10 +62,30 @@ get_running_backups_amount() {
 		| wc -l
 }
 
+get_successful_backups_amount() {
+	local storage="$1"
+	kubectl_bin get pxc-backup -o=jsonpath='{range .items[*]}{.metadata.name}{":"}{.spec.storageName}{":"}{.status.state}{"\n"}{end}' \
+		| grep $storage \
+		| grep -E ":Succeeded" \
+		| wc -l
+}
+
 get_failed_backups_amount() {
 	kubectl_bin get pxc-backup -o=jsonpath='{range .items[*]}{.metadata.name}{":"}{.spec.storageName}{":"}{.status.state}{"\n"}{end}' \
 		| grep ":Failed" \
 		| wc -l
+}
+
+wait_num_backups() {
+	local storage="$1"
+	local num="$2"
+    local timer=0
+	echo "Starting to check number $num of backups for $storage"
+	while [[ "$(get_successful_backups_amount $storage)" -ne $num  && $timer -le 400 ]]; do
+		sleep 2
+        ((timer+=1))
+	done
+	echo "Finished to check number $num of backups for $storage. Timer: $timer"
 }
 
 wait_all_backups() {
@@ -236,17 +256,29 @@ main() {
 
 		desc 'add backups schedule for gcs storage'
 		apply_config "${test_dir}/conf/${cluster}-gcs.yml"
-		sleep 110
+		sleep 50
+		wait_num_backups 'gcp-cs' 2
+		echo "Patch backup for yearly backup for gcs storage"
+		kubectl patch pxc ${cluster} --type="merge" -p '{"spec":{"backup":{"schedule":[{"name":"each-min-gcp-cs","storageName":"gcp-cs","keep":1,"schedule":"0 0 1 * *"}]}}}'
+		wait_num_backups 'gcp-cs' 1
 		apply_config "${test_dir}/conf/${cluster}-disable.yml"
 		wait_all_backups
 		desc 'add backups schedule for azure storage'
 		apply_config "${test_dir}/conf/${cluster}-azure.yml"
-		sleep 110
+		sleep 50
+		wait_num_backups 'azure-blob' 2
+		echo "Patch backup for yearly backup for azure storag"
+		kubectl patch pxc ${cluster} --type="merge" -p '{"spec":{"backup":{"schedule":[{"name":"each-min-azure-every","storageName":"azure-blob","keep":1,"schedule":"0 0 1 * *"}]}}}'
+		wait_num_backups 'azure-blob' 1
 		apply_config "${test_dir}/conf/${cluster}-disable.yml"
 		wait_all_backups
 		desc 'add backups schedule for aws s3 storage'
 		apply_config "${test_dir}/conf/${cluster}-aws.yml"
-		sleep 110
+		sleep 50
+		wait_num_backups 'aws-s3' 2
+		echo "Patch backup for yearly backup for aws s3 storage"
+		kubectl patch pxc ${cluster} --type="merge" -p '{"spec":{"backup":{"schedule":[{"name":"each-min-aws-s3","storageName":"aws-s3","keep":1,"schedule":"0 0 1 * *"}]}}}'
+		wait_num_backups 'aws-s3' 1
 		apply_config "${test_dir}/conf/${cluster}-disable.yml"
 		wait_all_backups
 		sleep 30

--- a/e2e-tests/scheduled-backup/run
+++ b/e2e-tests/scheduled-backup/run
@@ -83,7 +83,7 @@ wait_num_backups() {
 	echo "Starting to check number $num of backups for $storage"
 	while [[ "$(get_successful_backups_amount $storage)" -ne $num  && $timer -le 400 ]]; do
 		sleep 2
-        ((timer+=1))
+		((timer += 1))
 	done
 	echo "Finished to check number $num of backups for $storage. Timer: $timer"
 }


### PR DESCRIPTION
[![K8SPXC-1363](https://badgen.net/badge/JIRA/K8SPXC-1363/green)](https://jira.percona.com/browse/K8SPXC-1363) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
demand-backup and scheduled backup tests failed. 

**Cause:**
demand-backup: xbstream parallel option value is dynamically calculated based on available  resources. So depending on platform may differ. We had static value in `grep` for it.

scheduled-backup: to check whether the second backup was removed based on the 'spec.backup.schedule.keep' we have waited fixed 110 sec. Sometimes this time was not enough to delete the 1st backup and tests failed on diff. 

**Solution:**
demand-backup: use pattern for the xbstrem parallel option in grep

scheduled-backup: after the 1st backup, wait for 50 sec, check whether there is 2nd backup evry 2 sec, reapply the same storage with 1 year period, wait till there is 1 backup, disable backup. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1363]: https://perconadev.atlassian.net/browse/K8SPXC-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ