### PR TITLE
K8SPXC-1448: use custom storageclass for EKS in pvc-resize test

### DIFF
--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -33,12 +33,16 @@ function ensure_default_sc_allows_expansion() {
 
 function apply_resourcequota() {
 	local quota=$1
-	local default_sc=$(get_default_storageclass)
+	if [ "$EKS" == 1 -o -n "$OPENSHIFT" ]; then
+		local sc='gp2-resizable'
+	else
+		local sc=$(get_default_storageclass)
+	fi
 
-	echo "Applying resourcequota for default storageclass ${default_sc} with quota ${quota}"
+	echo "Applying resourcequota for default storageclass ${sc} with quota ${quota}"
 
 	cat ${test_dir}/conf/resourcequota.yml |
-		sed "s/STORAGECLASS/${default_sc}/" |
+		sed "s/STORAGECLASS/${sc}/" |
 		sed "s/QUOTA/${quota}/" |
 		kubectl_bin apply -f -
 }


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
resourcequota is not used for EKS|OPENSHIFT in pvc-resize test

**Cause:**
For EKS default Storage Class does not support PVC resize so we create a separate storage class for it and use it for cluster. When we create resourcequota for EKS we use default storage class which is not the one used for resize and thus quota limits are not applied.

**Solution:**
Use EKS storageclass in test

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
