### PR TITLE
K8SPXC-1454: disable tls by default if `.spec.allowUnsafeConfigurations: true`

### DIFF
--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -850,21 +850,24 @@ func (cr *PerconaXtraDBCluster) CheckNSetDefaults(serverVersion *version.ServerV
 		}
 
 		t := true
+		f := false
 		if c.TLS == nil {
 			c.TLS = &TLSSpec{Enabled: &t}
 		}
 
-		if c.TLS.Enabled == nil {
-			c.TLS.Enabled = &t
-		}
-
 		if c.AllowUnsafeConfig {
+			c.TLS.Enabled = &f
+
 			c.Unsafe = UnsafeFlags{
 				TLS:               true,
 				PXCSize:           true,
 				ProxySize:         true,
 				BackupIfUnhealthy: true,
 			}
+		}
+
+		if c.TLS.Enabled == nil {
+			c.TLS.Enabled = &t
 		}
 
 		if cr.DeletionTimestamp == nil && !cr.Spec.Pause {


### PR DESCRIPTION
[![K8SPXC-1454](https://badgen.net/badge/JIRA/K8SPXC-1454/green)](https://jira.percona.com/browse/K8SPXC-1454) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPXC-1454

**DESCRIPTION**
---
**Problem:**
*After upgrading from 1.14.0, operator starts creating TLS certificates and using them, if `.spec.allowUnsafeConfigurations: true`.*

**Cause:**
*After https://github.com/percona/percona-xtradb-cluster-operator/pull/1744, operator started using TLS certificates when both `.spec.tls.enabled` and `.spec.unsafe.tls` are set to `true`. When `.spec.allowUnsafeConfigurations` is set to `true`, it sets `.spec.unsafe.tls` to true, but doesn't affect `.spec.tls.enabled` which is true by default.*

**Solution:**
*If `.spec.tls.enabled` is not specified, the operator should treat it as disabled if `.spec.allowUnsafeConfigurations: true`.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1454]: https://perconadev.atlassian.net/browse/K8SPXC-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ