### PR TITLE
CLOUD-868: Remove monitoring-2.0 from pxc distro tests

### DIFF
--- a/e2e-tests/run-distro.csv
+++ b/e2e-tests/run-distro.csv
@@ -3,7 +3,6 @@ default-cr
 demand-backup-encrypted-with-tls
 haproxy
 init-deploy
-monitoring-2-0
 one-pod
 pitr
 pitr-gap-errors


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
run-distro.csv is used for integration testing before PXC distro components release. PMM is not a part of PXC distro and this test is flaky so may result in not related failures.

**Cause:**
---

**Solution:**
Remove this test from suite .

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?