### PR TITLE
K8SPXC-1451: remove comparing version

### DIFF
--- a/pkg/controller/pxc/volumes.go
+++ b/pkg/controller/pxc/volumes.go
@@ -226,7 +226,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcilePersistentVolumes(ctx context.C
 		return nil
 	}
 
-	if cr.CompareVersionWith("1.16.0") >= 0 && !cr.Spec.VolumeExpansionEnabled {
+	if !cr.Spec.VolumeExpansionEnabled {
 		// If expansion is disabled we should keep the old value
 		cr.Spec.PXC.VolumeSpec.PersistentVolumeClaim.Resources.Requests[corev1.ResourceStorage] = configured
 		return nil


### PR DESCRIPTION
[![K8SPXC-1451](https://badgen.net/badge/JIRA/K8SPXC-1451/green)](https://jira.percona.com/browse/K8SPXC-1451) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPXC-1451

**DESCRIPTION**
---
**Problem:**
*Starting from 1.14.0 PVC resize is enabled by default, but it should be disabled. https://github.com/percona/percona-xtradb-cluster-operator/pull/1824 disables the PVC resize by default, but only from versions `1.16.0`*

**Solution:**
*We should disable PVC resize on any version by removing version check.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1451]: https://perconadev.atlassian.net/browse/K8SPXC-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ