### PR TITLE
K8SPXC-1378: fix `.spec.backup.allowParallel`

### DIFF
--- a/e2e-tests/demand-backup/run
+++ b/e2e-tests/demand-backup/run
@@ -30,18 +30,26 @@ main() {
 
 	kubectl_bin apply -f "$test_dir/conf/$wrong_creds_backup_name.yml"
 
-	sleep 10
-
 	run_backup "$cluster" "$minio_backup_name"
 	compare_kubectl "job/xb-$minio_backup_name"
+
+	sleep 90
 
 	wrong_backup_job_fail_timestamp=$(kubectl_bin get job xb-$wrong_creds_backup_name -o yaml \
 		| yq '.status.conditions[] | select(.type == "Failed").lastTransitionTime' \
 		| xargs -I {} "$date" -d "{}" +%s)
+	if [[ -z $wrong_backup_job_fail_timestamp ]]; then
+		echo 'failed to get wrong_backup_job_fail_timestamp'
+		exit 1
+	fi
 
 	minio_job_creation_timestamp=$(kubectl get job xb-$minio_backup_name -o yaml \
 		| yq '.metadata.creationTimestamp' \
 		| xargs -I {} "$date" -d "{}" +%s)
+	if [[ -z $minio_job_creation_timestamp ]]; then
+		echo 'failed to get minio_job_creation_timestamp'
+		exit 1
+	fi
 
 	if [[ $wrong_backup_job_fail_timestamp > $minio_job_creation_timestamp ]]; then
 		echo "\"allowParallel: false\" doesn't work as expected. $minio_backup_name job was created before $wrong_creds_backup_name backup job failed"

--- a/pkg/controller/pxcbackup/controller.go
+++ b/pkg/controller/pxcbackup/controller.go
@@ -166,7 +166,7 @@ func (r *ReconcilePerconaXtraDBClusterBackup) Reconcile(ctx context.Context, req
 	}
 
 	if !cluster.Spec.Backup.GetAllowParallel() {
-		isRunning, err := r.isOtherBackupRunning(ctx, cr)
+		isRunning, err := r.isOtherBackupRunning(ctx, cr, cluster)
 		if err != nil {
 			return rr, errors.Wrap(err, "failed to check if other backups running")
 		}
@@ -546,21 +546,21 @@ func setControllerReference(cr *api.PerconaXtraDBClusterBackup, obj metav1.Objec
 	return nil
 }
 
-func (r *ReconcilePerconaXtraDBClusterBackup) isOtherBackupRunning(ctx context.Context, cr *api.PerconaXtraDBClusterBackup) (bool, error) {
+func (r *ReconcilePerconaXtraDBClusterBackup) isOtherBackupRunning(ctx context.Context, cr *api.PerconaXtraDBClusterBackup, cluster *api.PerconaXtraDBCluster) (bool, error) {
 	list := new(batchv1.JobList)
-	lbls := map[string]string{
-		"type":    "xtrabackup",
-		"cluster": cr.Spec.PXCCluster,
-	}
 	if err := r.client.List(ctx, list, &client.ListOptions{
-		Namespace:     cr.Namespace,
-		LabelSelector: labels.SelectorFromSet(lbls),
+		Namespace:     cluster.Namespace,
+		LabelSelector: labels.SelectorFromSet(naming.LabelsBackup(cluster)),
 	}); err != nil {
 		return false, errors.Wrap(err, "list jobs")
 	}
 
 	for _, job := range list.Items {
-		if job.Labels["backup-name"] == cr.Name || job.Labels["backup-name"] == "" {
+		backupNameLabelKey := naming.LabelPerconaBackupName
+		if cluster.CompareVersionWith("1.16.0") < 0 {
+			backupNameLabelKey = "backup-name"
+		}
+		if job.Labels[backupNameLabelKey] == cr.Name {
 			continue
 		}
 		if job.Status.Active == 0 && (jobSucceded(&job) || jobFailed(&job)) {


### PR DESCRIPTION
[![K8SPXC-1378](https://badgen.net/badge/JIRA/K8SPXC-1378/green)](https://jira.percona.com/browse/K8SPXC-1378) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPXC-1378

**DESCRIPTION**
---
**Problem:**
*A regression was introduced in https://github.com/percona/percona-xtradb-cluster-operator/pull/1823, causing `.spec.backup.allowParallel` to stop functioning correctly.*

**Cause:**
*PR #1823 added new labels to the `pxc-backup` resource but did not update the `isOtherBackupRunning` method. As a result, this method still looks for `pxc-backup` resources using outdated labels, failing to detect running backups.*

**Solution:**
*Update the `isOtherBackupRunning` method to use the new labels..*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1378]: https://perconadev.atlassian.net/browse/K8SPXC-1378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ