### PR TITLE
K8SPXC-1446: use kubectl in wait_for_delete function

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -381,7 +381,7 @@ wait_for_delete() {
 	echo -n "waiting for $res to be deleted"
 	set +o xtrace
 	retry=0
-	until (kubectl_bin get $res || :) 2>&1 | grep NotFound; do
+	until (kubectl get $res || :) 2>&1 | grep NotFound; do
 		sleep 1
 		echo -n .
 		let retry+=1


### PR DESCRIPTION
[![K8SPXC-1446](https://badgen.net/badge/JIRA/K8SPXC-1446/green)](https://jira.percona.com/browse/K8SPXC-1446) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
In pitr test a check whether all the proxy pods were removed during restore was added. `until` in `wait_for_delete` function "hangs" for 2+ mins while checking `pod/pitr-proxysql-0` deletion.  During this time the restore finishes and  when `pod/pitr-proxysql-1` is checked, the restore is finished and all the pods are up and running again.

**Cause:**
kubectl_bin usage instead of kubectl

**Solution:**
Use kubectl in  `wait_for_delete`

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1446]: https://perconadev.atlassian.net/browse/K8SPXC-1446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ