### PR TITLE
K8SPXC-1222: assign MYSQL_VERSION variable in liveness and readiness

### DIFF
--- a/build/liveness-check.sh
+++ b/build/liveness-check.sh
@@ -22,6 +22,7 @@ NODE_IP=$(hostname -I | awk ' { print $1 } ')
 #Timeout exists for instances where mysqld may be hung
 TIMEOUT=$((${LIVENESS_CHECK_TIMEOUT:-5} - 1))
 MYSQL_STATE=ready
+MYSQL_VERSION=$(mysqld -V | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 if [[ ${MYSQL_VERSION} == '8.0' ]]; then
 	MYSQL_STATE=$(tr -d '\0' < ${MYSQL_STATE_FILE})
 fi

--- a/build/readiness-check.sh
+++ b/build/readiness-check.sh
@@ -17,6 +17,7 @@ DEFAULTS_EXTRA_FILE=${DEFAULTS_EXTRA_FILE:-/etc/my.cnf}
 AVAILABLE_WHEN_DONOR=${AVAILABLE_WHEN_DONOR:-1}
 NODE_IP=$(hostname -I | awk ' { print $1 } ')
 MYSQL_STATE=ready
+MYSQL_VERSION=$(mysqld -V | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 if [[ ${MYSQL_VERSION} == '8.0' ]]; then
 	MYSQL_STATE=$(tr -d '\0' < ${MYSQL_STATE_FILE})
 fi


### PR DESCRIPTION


**CHANGE DESCRIPTION**
---
**Problem:**
The liveness-check.sh and readiness-check.sh did not use /var/lib/mysql/mysql.state because  MYSQL_VERSION was not set.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Define MYSQL_VERSION for readiness-check.sh did not use /var/lib/mysql/mysql.state

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
