### PR TITLE
K8SPXC-1446 Add environment variables for MySQL state management in StatefulSet

### DIFF
--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1160-k127-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1160-k127-oc.yml
@@ -125,6 +125,10 @@ spec:
               value: "15"
             - name: DEFAULT_AUTHENTICATION_PLUGIN
               value: mysql_native_password
+            - name: NOTIFY_SOCKET
+              value: /var/lib/mysql/notify.sock
+            - name: MYSQL_STATE_FILE
+              value: /var/lib/mysql/mysql.state
           envFrom:
             - secretRef:
                 name: some-name-env-vars-pxc

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1160-k127.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1160-k127.yml
@@ -125,6 +125,10 @@ spec:
               value: "15"
             - name: DEFAULT_AUTHENTICATION_PLUGIN
               value: mysql_native_password
+            - name: NOTIFY_SOCKET
+              value: /var/lib/mysql/notify.sock
+            - name: MYSQL_STATE_FILE
+              value: /var/lib/mysql/mysql.state
           envFrom:
             - secretRef:
                 name: some-name-env-vars-pxc


### PR DESCRIPTION
[![K8SPXC-1446](https://badgen.net/badge/JIRA/K8SPXC-1446/green)](https://jira.percona.com/browse/K8SPXC-1446) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
e2e test `upgrade-consistency` fails

**Cause:**
diff failing in one of the compare files

**Solution:**
Adding the `NOTIFY_SOCKET` and `MYSQL_STATE_FILE` env vars in the compare yaml files.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1446]: https://perconadev.atlassian.net/browse/K8SPXC-1446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ