### PR TITLE
K8SPXC-1446: fix pvc-resize and upgrade-consistency for oc

### DIFF
--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -148,6 +148,9 @@ if [ "$EKS" == 1 -o -n "$OPENSHIFT" ]; then
 	echo "Deleting and recreating PXC cluster ${cluster}"
 	kubectl_bin delete pxc ${cluster}
 	spinup_pxc "${cluster}" "$test_dir/conf/$cluster-eks.yml" "3" "10" "${conf_dir}/secrets.yml"
+	echo "Enabling PVC resize"
+	kubectl_bin patch pxc "${cluster}" --type=json -p='[{"op": "add", "path": "/spec/enableVolumeExpansion", "value":true }]'
+	sleep 10
 fi
 
 desc 'create resourcequota'

--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -148,7 +148,7 @@ if [ "$EKS" == 1 -o -n "$OPENSHIFT" ]; then
 	echo "Deleting and recreating PXC cluster ${cluster}"
 	kubectl_bin delete pxc ${cluster}
 	spinup_pxc "${cluster}" "$test_dir/conf/$cluster-eks.yml" "3" "10" "${conf_dir}/secrets.yml"
-	echo "Enabling PVC resize"
+	echo "Enabling PVC resize for 2nd eks/openshift cluster"
 	kubectl_bin patch pxc "${cluster}" --type=json -p='[{"op": "add", "path": "/spec/enableVolumeExpansion", "value":true }]'
 	sleep 10
 fi

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1141-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1141-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 2
+  generation: 1
   name: some-name-proxysql
   ownerReferences:
     - controller: true

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1151-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1151-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 3
+  generation: 2
   name: some-name-proxysql
   ownerReferences:
     - controller: true

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1141-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1141-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 2
+  generation: 1
   name: some-name-pxc
   ownerReferences:
     - controller: true

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1151-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1151-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 3
+  generation: 2
   name: some-name-pxc
   ownerReferences:
     - controller: true


### PR DESCRIPTION
[![K8SPXC-1446](https://badgen.net/badge/JIRA/K8SPXC-1446/green)](https://jira.percona.com/browse/K8SPXC-1446) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
1) pvc-resize fails on eks and openshift. EKS and openshift allow to resize pvc once per 6 hours so we create 2 pxc clusters for pvc-resize test. 1.16.0 disables pvc-resize by default. For test the resize is enabled only for first cluster so resize fails on after the 2nd cluster creation.
2) upgrade-consistency test fails due to generation.


**Solution:**
1) Enable PVC resize on the second cluster. 
2) Fix generation.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1446]: https://perconadev.atlassian.net/browse/K8SPXC-1446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ