### PR TITLE
K8SPXC-1222: Fix state check in probes for 8.4

### DIFF
--- a/build/liveness-check.sh
+++ b/build/liveness-check.sh
@@ -23,7 +23,7 @@ NODE_IP=$(hostname -I | awk ' { print $1 } ')
 TIMEOUT=$((${LIVENESS_CHECK_TIMEOUT:-5} - 1))
 MYSQL_STATE=ready
 MYSQL_VERSION=$(mysqld -V | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
-if [[ ${MYSQL_VERSION} == '8.0' ]]; then
+if [[ ${MYSQL_VERSION} =~ ^(8\.0|8\.4)$ && -f ${MYSQL_STATE_FILE} ]]; then
 	MYSQL_STATE=$(tr -d '\0' < ${MYSQL_STATE_FILE})
 fi
 

--- a/build/readiness-check.sh
+++ b/build/readiness-check.sh
@@ -18,7 +18,7 @@ AVAILABLE_WHEN_DONOR=${AVAILABLE_WHEN_DONOR:-1}
 NODE_IP=$(hostname -I | awk ' { print $1 } ')
 MYSQL_STATE=ready
 MYSQL_VERSION=$(mysqld -V | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
-if [[ ${MYSQL_VERSION} == '8.0' ]]; then
+if [[ ${MYSQL_VERSION} =~ ^(8\.0|8\.4)$ && -f ${MYSQL_STATE_FILE} ]]; then
 	MYSQL_STATE=$(tr -d '\0' < ${MYSQL_STATE_FILE})
 fi
 


### PR DESCRIPTION
[![K8SPXC-1222](https://badgen.net/badge/JIRA/K8SPXC-1222/green)](https://jira.percona.com/browse/K8SPXC-1222) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
Version check didn't include 8.4, so I added it. I also added a sanity check for existence of state file.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1222]: https://perconadev.atlassian.net/browse/K8SPXC-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ