### PR TITLE
K8SPXC-1411: Fix disabling TLS without unsafe flag

### DIFF
--- a/e2e-tests/tls-issue-self/compare/pxc_some-name-enabled.yml
+++ b/e2e-tests/tls-issue-self/compare/pxc_some-name-enabled.yml
@@ -1,7 +1,7 @@
 apiVersion: pxc.percona.com/v1
 kind: PerconaXtraDBCluster
 metadata:
-  generation: 10
+  generation: 9
   name: some-name
 spec:
   backup:

--- a/e2e-tests/tls-issue-self/compare/pxc_some-name.yml
+++ b/e2e-tests/tls-issue-self/compare/pxc_some-name.yml
@@ -1,7 +1,7 @@
 apiVersion: pxc.percona.com/v1
 kind: PerconaXtraDBCluster
 metadata:
-  generation: 6
+  generation: 5
   name: some-name
 spec:
   backup:

--- a/e2e-tests/tls-issue-self/run
+++ b/e2e-tests/tls-issue-self/run
@@ -32,8 +32,7 @@ main() {
 	sleep 10
 	# operator performs:
 	# - patch .spec.pause to true (generation = 4)
-	# - patch spec.unsafeFlags.tls to true (generation = 5)
-	# - patch .spec.pause to false (generation = 6)
+	# - patch .spec.pause to false (generation = 5)
 	wait_cluster_consistency "$cluster" 3 2
 	desc 'secrets should be deleted'
 	if kubectl get secret "$cluster-ssl" &>/dev/null; then
@@ -47,12 +46,12 @@ main() {
 	compare_kubectl "pxc/$cluster"
 
 	desc 'check enabling tls'
-	kubectl_bin patch pxc "$cluster" --type=merge --patch '{"spec": {"tls":{"enabled": true}}}' # generation + 1 (total = 7)
+	kubectl_bin patch pxc "$cluster" --type=merge --patch '{"spec": {"tls":{"enabled": true}}}' # generation + 1 (total = 6)
 	sleep 10
 	# operator performs:
-	# - patch .spec.pause to true (generation = 8)
-	# - patch spec.unsafeFlags.tls to false (generation = 9)
-	# - patch .spec.pause to false (generation = 10)
+	# - patch .spec.pause to true (generation = 7)
+	# - patch spec.unsafeFlags.tls to false (generation = 8)
+	# - patch .spec.pause to false (generation = 9)
 	wait_cluster_consistency "$cluster" 3 2
 	compare_kubectl "pxc/$cluster" "-enabled"
 	desc 'secrets should be recreated'

--- a/e2e-tests/tls-issue-self/run
+++ b/e2e-tests/tls-issue-self/run
@@ -28,7 +28,7 @@ main() {
 
 	# generation = 2 on this step
 	desc 'check disabling tls'
-	kubectl_bin patch pxc "$cluster" --type=merge --patch '{"spec": {"tls":{"enabled": false}}}' # generation + 1 (total 3)
+	kubectl_bin patch pxc "$cluster" --type=merge --patch '{"spec": {"tls":{"enabled": false}, "unsafeFlags": {"tls": true}}}' # generation + 1 (total 3)
 	sleep 10
 	# operator performs:
 	# - patch .spec.pause to true (generation = 4)

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -1238,7 +1238,7 @@ func (cr *PerconaXtraDBCluster) setProbesDefaults() {
 }
 
 func (cr *PerconaXtraDBCluster) checkSafeDefaults() error {
-	if !cr.Spec.Unsafe.TLS && !cr.TLSEnabled() {
+	if !cr.Spec.Unsafe.TLS && !*cr.Spec.TLS.Enabled {
 		return errors.New("TLS must be enabled. Set spec.unsafeFlags.tls to true to disable this check")
 	}
 


### PR DESCRIPTION
[![K8SPXC-1411](https://badgen.net/badge/JIRA/K8SPXC-1411/green)](https://jira.percona.com/browse/K8SPXC-1411) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
`cr.TLSEnabled()` checks both `spec.unsafeFlags.tls` and `spec.tls.enabled` and mistakenly used in `CheckNSetDefaults`. We need to use only `spec.tls.enabled` to check if TLS is enabled for safe configuration.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1411]: https://perconadev.atlassian.net/browse/K8SPXC-1411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ