### PR TITLE
K8SPXC-1222: Handle new statuses added in 8.4

### DIFF
--- a/cmd/mysql-state-monitor/main.go
+++ b/cmd/mysql-state-monitor/main.go
@@ -33,20 +33,58 @@ func parseDatum(datum string) MySQLState {
 		switch status {
 		case "Server is operational":
 			return MySQLReady
-		case "Server shutdown in progress":
+		case "Server shutdown in progress",
+			"Forceful shutdown of connections in progress",
+			"Graceful shutdown of connections in progress",
+			"Components initialization unsuccessful",
+			"Execution of SQL Commands from Init-file unsuccessful",
+			"Initialization of dynamic plugins unsuccessful",
+			"Initialization of MySQL system tables unsuccessful",
+			"InnoDB crash recovery unsuccessful",
+			"InnoDB initialization unsuccessful":
 			return MySQLDown
 		case "Server startup in progress",
-			"Data Dictionary upgrade in progress",
-			"Data Dictionary upgrade complete",
+			"Server initialization in progress",
 			"Server upgrade in progress",
 			"Server upgrade complete",
 			"Server downgrade in progress",
 			"Server downgrade complete",
+			"Data Dictionary upgrade in progress",
+			"Data Dictionary upgrade complete",
 			"Data Dictionary upgrade from MySQL 5.7 in progress",
 			"Data Dictionary upgrade from MySQL 5.7 complete",
+			"Components initialization in progress",
+			"Components initialization successful",
+			"Connection shutdown complete",
+			"Execution of SQL Commands from Init-file successful",
+			"Initialization of dynamic plugins in progress",
+			"Initialization of dynamic plugins successful",
+			"Initialization of MySQL system tables in progress",
+			"Initialization of MySQL system tables successful",
+			"InnoDB crash recovery in progress",
+			"InnoDB crash recovery successful",
+			"InnoDB initialization in progress",
+			"InnoDB initialization successful",
+			"Shutdown of plugins complete",
+			"Shutdown of components in progress",
+			"Shutdown of components successful",
+			"Shutdown of plugins in progress",
+			"Shutdown of replica threads in progress",
 			"Server shutdown complete": // we treat this as startup because during init, MySQL notifies this even if it's up
 			return MySQLStartup
 		}
+
+		// these statuses have variables in it
+		// that's why we're handling them separately
+		switch {
+		case strings.HasPrefix(status, "Pre DD shutdown of MySQL SE plugin"):
+			return MySQLStartup
+		case strings.HasPrefix(status, "Server shutdown complete"):
+			return MySQLStartup
+		case strings.HasPrefix(status, "Server initialization complete"):
+			return MySQLStartup
+		}
+
 	}
 
 	return MySQLUnknown


### PR DESCRIPTION
[![K8SPXC-1222](https://badgen.net/badge/JIRA/K8SPXC-1222/green)](https://jira.percona.com/browse/K8SPXC-1222) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
MySQL 8.4 added new status notifications, this PR adds necessary changes to handle them.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1222]: https://perconadev.atlassian.net/browse/K8SPXC-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ