### PR TITLE
K8SPXC-1410: set memory in custom-users test to 2

### DIFF
--- a/e2e-tests/custom-users/conf/some-name.yml
+++ b/e2e-tests/custom-users/conf/some-name.yml
@@ -41,7 +41,7 @@ spec:
         memory: 0.1G
         cpu: 100m
       limits:
-        memory: "1G"
+        memory: "2G"
         cpu: "1"
     volumeSpec:
       persistentVolumeClaim:


### PR DESCRIPTION
[![K8SPXC-1410](https://badgen.net/badge/JIRA/K8SPXC-1410/green)](https://jira.percona.com/browse/K8SPXC-1410) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
PXC pod is killed by OOM killer in custom-users test

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Increase memory limit in custom-users test

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1410]: https://perconadev.atlassian.net/browse/K8SPXC-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ