### PR TITLE
K8SPXC-1222: Remove state check from readiness probe

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,8 +31,8 @@ RUN GOOS=$GOOS GOARCH=${TARGETARCH} CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFL
     && cp -r build/_output/bin/pitr /usr/local/bin/pitr
 
 RUN GOOS=$GOOS GOARCH=${TARGETARCH} CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
-       go build -o build/_output/bin/mysql-state-monitor \
-               cmd/mysql-state-monitor/main.go \
+       go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH -X main.BuildTime=$BUILD_TIME" \
+            -o build/_output/bin/mysql-state-monitor cmd/mysql-state-monitor/main.go \
     && cp -r build/_output/bin/mysql-state-monitor /usr/local/bin/mysql-state-monitor
 
 # Looking for all possible License/Notice files and copying them to the image

--- a/build/readiness-check.sh
+++ b/build/readiness-check.sh
@@ -16,12 +16,6 @@ MYSQL_PASSWORD="${mysql_pass:-$MONITOR_PASSWORD}"
 DEFAULTS_EXTRA_FILE=${DEFAULTS_EXTRA_FILE:-/etc/my.cnf}
 AVAILABLE_WHEN_DONOR=${AVAILABLE_WHEN_DONOR:-1}
 NODE_IP=$(hostname -I | awk ' { print $1 } ')
-MYSQL_STATE=ready
-MYSQL_VERSION=$(mysqld -V | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
-if [[ ${MYSQL_VERSION} =~ ^(8\.0|8\.4)$ && -f ${MYSQL_STATE_FILE} ]]; then
-	MYSQL_STATE=$(tr -d '\0' < ${MYSQL_STATE_FILE})
-fi
-
 #Timeout exists for instances where mysqld may be hung
 TIMEOUT=$((${READINESS_CHECK_TIMEOUT:-10} - 1))
 
@@ -41,8 +35,7 @@ WSREP_STATUS=($(MYSQL_PWD="${MYSQL_PASSWORD}" $MYSQL_CMDLINE --init-command="SET
 	sed -n -e '2p' -e '5p' | tr '\n' ' '))
 set -x
 
-if [[ "${MYSQL_STATE}" == "ready" && ${WSREP_STATUS[1]} == 'Primary' &&
-	(${WSREP_STATUS[0]} -eq 4 || (${WSREP_STATUS[0]} -eq 2 && $AVAILABLE_WHEN_DONOR -eq 1)) ]]; then
+if [[ ${WSREP_STATUS[1]} == 'Primary' && (${WSREP_STATUS[0]} -eq 4 || (${WSREP_STATUS[0]} -eq 2 && $AVAILABLE_WHEN_DONOR -eq 1)) ]]; then
 	exit 0
 else
 	exit 1

--- a/cmd/mysql-state-monitor/main.go
+++ b/cmd/mysql-state-monitor/main.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+var (
+	GitCommit string
+	GitBranch string
+	BuildTime string
+)
+
 type MySQLState string
 
 const (
@@ -56,6 +62,7 @@ func parseDatum(datum string) MySQLState {
 			"Components initialization in progress",
 			"Components initialization successful",
 			"Connection shutdown complete",
+			"Execution of SQL Commands from Init-file in progress",
 			"Execution of SQL Commands from Init-file successful",
 			"Initialization of dynamic plugins in progress",
 			"Initialization of dynamic plugins successful",
@@ -91,7 +98,8 @@ func parseDatum(datum string) MySQLState {
 }
 
 func main() {
-	log.Println("Starting mysql-state-monitor")
+	log.Println("Starting mysql-state-monitor...")
+	log.Printf("GitCommit=%s GitBranch=%s BuildTime=%s", GitCommit, GitBranch, BuildTime)
 
 	socketPath, ok := os.LookupEnv("NOTIFY_SOCKET")
 	if !ok {


### PR DESCRIPTION
[![K8SPXC-1222](https://badgen.net/badge/JIRA/K8SPXC-1222/green)](https://jira.percona.com/browse/K8SPXC-1222) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
1. Removed state check from readiness probe
2. Added build info to state monitor
3. Add one missing status

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1222]: https://perconadev.atlassian.net/browse/K8SPXC-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ