### PR TITLE
K8SPXC-377: Check for custom user names uniqueness.

### DIFF
--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -417,6 +417,14 @@ func (cr *PerconaXtraDBCluster) Validate() error {
 		return errors.Errorf("ProxySQL or HAProxy should be enabled if SmartUpdate set")
 	}
 
+	customUsers := make(map[string]int8, len(c.Users))
+	for _, user := range c.Users {
+		customUsers[user.Name]++
+		if customUsers[user.Name] > 1 {
+			return errors.Errorf("user %s is duplicated", user.Name)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
[![K8SPXC-377](https://badgen.net/badge/JIRA/K8SPXC-377/green)](https://jira.percona.com/browse/K8SPXC-377) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
When multiple users with the same name are present, unexpected results occur.

**Solution:**
Validate user for uniqueness. If there are duplicates reject the CR as invalid.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PXC version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-377]: https://perconadev.atlassian.net/browse/K8SPXC-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ