### PR TITLE
K8SPXC-1222: Remove state check for 5.7

### DIFF
--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -522,19 +522,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		fi
 		set -x
 
-		if [[ "$MYSQL_VERSION" =~ ^(8\.0|8\.4)$ ]]; then
-			mysqlState="startup"
-			while [[ "${mysqlState}" != "ready" ]]; do
-				mysqlState=$(tr -d '\0' < ${MYSQL_STATE_FILE})
-				echo >&2 "MySQL upgrade process in progress..."
-				sleep 1
-			done
-		fi
 		for i in {120..0}; do
 			if echo 'SELECT 1' | "${mysql[@]}" &>/dev/null; then
 				break
 			fi
-
+			echo >&2 "MySQL upgrade process in progress..."
 			sleep 1
 		done
 		if [ "$i" = 0 ]; then


### PR DESCRIPTION
[![K8SPXC-1222](https://badgen.net/badge/JIRA/K8SPXC-1222/green)](https://jira.percona.com/browse/K8SPXC-1222) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
Remove unnecessary code.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1222]: https://perconadev.atlassian.net/browse/K8SPXC-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ