### PR TITLE
K8SPXC-1544: Add basic Prometheus metrics for binlog-collector

### DIFF
--- a/pkg/pxc/app/deployment/binlog-collector.go
+++ b/pkg/pxc/app/deployment/binlog-collector.go
@@ -91,6 +91,16 @@ func GetBinlogCollectorDeployment(cr *api.PerconaXtraDBCluster, initImage string
 			},
 		},
 	}
+
+	if cr.CompareVersionWith("1.17.0") >= 0 {
+		container.Ports = []corev1.ContainerPort{
+			{
+				ContainerPort: 8080,
+				Name:          "metrics",
+			},
+		}
+	}
+
 	replicas := int32(1)
 
 	var initContainers []corev1.Container


### PR DESCRIPTION
The following metrics have been added:
- `pxc_binlog_collector_success_total`
- `pxc_binlog_collector_failure_total`
- `pxc_binlog_collector_last_processing_timestamp`
- `pxc_binlog_collector_last_upload_timestamp`
- `pxc_binlog_collector_gap_detected_total`

Additionally, a simple /health endpoint has been added

**CHANGE DESCRIPTION**
---
**Problem:**
We don't have any prometheus metrics from pitr deployment, so the observability of binlog backups is quite limited.

**Cause:**
No prometheus metrics in binlog-collector application.

**Solution:**
Add prometheus metrics to binlog-collector application.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?