### PR TITLE
fix: don't add the storage name twice to the scheduled backup name

### DIFF
--- a/pkg/naming/backup.go
+++ b/pkg/naming/backup.go
@@ -52,23 +52,22 @@ func trimJobName(name string) string {
 }
 
 func ScheduledBackupName(crName, storageName, schedule string) string {
-	result := "cron-"
+	result := "cron"
 
 	if len(crName) > 16 {
-		result += crName[:16]
+		result += "-" + crName[:16]
 	} else {
-		result += crName
+		result += "-" + crName
 	}
 
 	if len(storageName) > 16 {
-		result += storageName[:16]
+		result += "-" + storageName[:16]
 	} else {
-		result += storageName
+		result += "-" + storageName
 	}
 
-	result += "-" + storageName + "-"
 	tnow := time.Now()
-	result += fmt.Sprintf("%d%d%d%d%d%d", tnow.Year(), tnow.Month(), tnow.Day(), tnow.Hour(), tnow.Minute(), tnow.Second())
+	result += "-" + fmt.Sprintf("%d%d%d%d%d%d", tnow.Year(), tnow.Month(), tnow.Day(), tnow.Hour(), tnow.Minute(), tnow.Second())
 	result += "-" + strconv.FormatUint(uint64(crc32.ChecksumIEEE([]byte(schedule))), 32)[:5]
 	return result
 }


### PR DESCRIPTION
Don't add the storage name twice to the scheduled backup name

Adding a storage name twice might make a job name longer than 63 characters and break backup creation

**CHANGE DESCRIPTION**
---
**Problem:**
Scheduled backups are not being created after v1.16.0 in some situations when the storage name is not short.

**Cause:**
After v1.16.0 storage name is added to the scheduled backup name twice, see [PR#1823](https://github.com/percona/percona-xtradb-cluster-operator/pull/1823).
The example of generated `pxc-backup` name before: `cron-dev-1-db-s3-backups-daily-20241220005-372f8`
The example of generated `pxc-backup` name after: `cron-dev-1-dbs3-backups-daily-s3-backups-daily-202412230055-372f8`

**Solution:**
Don't add the backup storage name twice to the scheduled backup name.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?