### PR TITLE
K8SPXC-1466 default container annotation

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -478,6 +478,7 @@ compare_kubectl() {
 			del(.. | select(has("percona.com/env-secret-config-hash"))."percona.com/env-secret-config-hash") |
 			del(.. | select(has("percona.com/ssl-hash"))."percona.com/ssl-hash") |
 			del(.. | select(has("percona.com/ssl-internal-hash"))."percona.com/ssl-internal-hash") |
+			del(.. | select(has("kubectl.kubernetes.io/default-container"))."kubectl.kubernetes.io/default-container") |
 			del(.spec.volumeClaimTemplates[].spec.volumeMode | select(. == "Filesystem")) |
 			del(.. | select(has("healthCheckNodePort")).healthCheckNodePort) |
 			del(.. | select(has("nodePort")).nodePort) |

--- a/pkg/pxc/statefulset.go
+++ b/pkg/pxc/statefulset.go
@@ -119,8 +119,8 @@ func StatefulSet(ctx context.Context, cl client.Client, sfs api.StatefulApp, pod
 		}
 	}
 
-	annotations := make(map[string]string)
-	annotations["kubectl.kubernetes.io/default-container"] = sfs.Labels()[naming.LabelAppKubernetesComponent]
+	customAnnotations := make(map[string]string)
+	customAnnotations["kubectl.kubernetes.io/default-container"] = sfs.Labels()[naming.LabelAppKubernetesComponent]
 
 	obj := sfs.StatefulSet()
 	obj.Spec = appsv1.StatefulSetSpec{
@@ -132,7 +132,7 @@ func StatefulSet(ctx context.Context, cl client.Client, sfs api.StatefulApp, pod
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:      customLabels,
-				Annotations: annotations,
+				Annotations: customAnnotations,
 			},
 			Spec: pod,
 		},

--- a/pkg/pxc/statefulset.go
+++ b/pkg/pxc/statefulset.go
@@ -119,8 +119,12 @@ func StatefulSet(ctx context.Context, cl client.Client, sfs api.StatefulApp, pod
 		}
 	}
 
-	customAnnotations := make(map[string]string)
-	customAnnotations["kubectl.kubernetes.io/default-container"] = sfs.Labels()[naming.LabelAppKubernetesComponent]
+	customAnnotations := podSpec.Annotations
+	if cr.CompareVersionWith("1.17.0") >= 0 {
+		customAnnotations = map[string]string{
+			"kubectl.kubernetes.io/default-container": sfs.Labels()[naming.LabelAppKubernetesComponent],
+		}
+	}
 
 	obj := sfs.StatefulSet()
 	obj.Spec = appsv1.StatefulSetSpec{

--- a/pkg/pxc/statefulset.go
+++ b/pkg/pxc/statefulset.go
@@ -121,9 +121,10 @@ func StatefulSet(ctx context.Context, cl client.Client, sfs api.StatefulApp, pod
 
 	customAnnotations := podSpec.Annotations
 	if cr.CompareVersionWith("1.17.0") >= 0 {
-		customAnnotations = map[string]string{
-			"kubectl.kubernetes.io/default-container": sfs.Labels()[naming.LabelAppKubernetesComponent],
+		if customAnnotations == nil {
+			customAnnotations = make(map[string]string)
 		}
+		customAnnotations["kubectl.kubernetes.io/default-container"] = sfs.Labels()[naming.LabelAppKubernetesComponent]
 	}
 
 	obj := sfs.StatefulSet()


### PR DESCRIPTION
[![K8SPXC-1466](https://badgen.net/badge/JIRA/K8SPXC-1466/green)](https://jira.percona.com/browse/K8SPXC-1466) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*
If don't use -c option we login to random container of the pod.
**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*
Need to specify annotation with default container. 
**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1466]: https://perconadev.atlassian.net/browse/K8SPXC-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ