### PR TITLE
K8SPXC-1473 expose ha and proxysql stats. 

### DIFF
--- a/build/proxysql.cnf
+++ b/build/proxysql.cnf
@@ -6,8 +6,8 @@ admin_variables =
 	mysql_ifaces="0.0.0.0:6032"
 	refresh_interval=2000
 
-	restapi_enabled=true
-    restapi_port=6070
+    restapi_enabled=true
+	restapi_port=6070
 
 	cluster_username="admin"
 	cluster_password="admin"

--- a/build/proxysql.cnf
+++ b/build/proxysql.cnf
@@ -6,6 +6,9 @@ admin_variables =
 	mysql_ifaces="0.0.0.0:6032"
 	refresh_interval=2000
 
+	restapi_enabled=true
+    restapi_port=6070
+
 	cluster_username="admin"
 	cluster_password="admin"
 	checksum_admin_variables=false

--- a/build/proxysql.cnf
+++ b/build/proxysql.cnf
@@ -5,8 +5,7 @@ admin_variables =
 	admin_credentials="admin:admin"
 	mysql_ifaces="0.0.0.0:6032"
 	refresh_interval=2000
-
-    restapi_enabled=true
+	restapi_enabled=true
 	restapi_port=6070
 
 	cluster_username="admin"

--- a/e2e-tests/affinity/compare/statefulset_custom-proxysql-k127-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-proxysql-k127-oc.yml
@@ -111,6 +111,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_custom-proxysql-k127.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-proxysql-k127.yml
@@ -111,6 +111,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_custom-proxysql-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-proxysql-oc.yml
@@ -108,6 +108,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_custom-proxysql.yml
+++ b/e2e-tests/affinity/compare/statefulset_custom-proxysql.yml
@@ -100,6 +100,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_hostname-proxysql-k127-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-proxysql-k127-oc.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_hostname-proxysql-k127.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-proxysql-k127.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_hostname-proxysql-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-proxysql-oc.yml
@@ -81,6 +81,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_hostname-proxysql.yml
+++ b/e2e-tests/affinity/compare/statefulset_hostname-proxysql.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_region-proxysql-k127-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-proxysql-k127-oc.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_region-proxysql-k127.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-proxysql-k127.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_region-proxysql-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-proxysql-oc.yml
@@ -81,6 +81,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_region-proxysql.yml
+++ b/e2e-tests/affinity/compare/statefulset_region-proxysql.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_zone-proxysql-k127-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-proxysql-k127-oc.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_zone-proxysql-k127.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-proxysql-k127.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_zone-proxysql-oc.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-proxysql-oc.yml
@@ -81,6 +81,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/affinity/compare/statefulset_zone-proxysql.yml
+++ b/e2e-tests/affinity/compare/statefulset_zone-proxysql.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-k127.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-k127.yml
@@ -85,6 +85,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-oc.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-oc.yml
@@ -82,6 +82,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-secret-k127.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-secret-k127.yml
@@ -85,6 +85,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-secret-oc.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy-secret-oc.yml
@@ -82,6 +82,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy.yml
+++ b/e2e-tests/haproxy/compare/statefulset_haproxy-haproxy.yml
@@ -78,6 +78,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/init-deploy/compare/service_some-name-proxysql.yml
+++ b/e2e-tests/init-deploy/compare/service_some-name-proxysql.yml
@@ -23,6 +23,10 @@ spec:
       port: 33062
       protocol: TCP
       targetPort: 33062
+    - name: stats
+      port: 6070
+      protocol: TCP
+      targetPort: 6070
   selector:
     app.kubernetes.io/component: proxysql
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-k127-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-k127-oc.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-k127.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-k127.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql-oc.yml
@@ -81,6 +81,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-proxysql.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127-oc.yml
@@ -207,6 +207,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 600m

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127.yml
@@ -207,6 +207,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 600m

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-oc.yml
@@ -204,6 +204,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 600m

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased.yml
@@ -196,6 +196,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 600m

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127-oc.yml
@@ -207,6 +207,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 300m

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127.yml
@@ -207,6 +207,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 300m

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-oc.yml
@@ -204,6 +204,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 300m

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql.yml
@@ -196,6 +196,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 300m

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-k127-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-k127.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased-oc.yml
@@ -70,6 +70,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-increased.yml
@@ -62,6 +62,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-k127-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-k127.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql-oc.yml
@@ -70,6 +70,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-proxysql.yml
@@ -62,6 +62,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-k127-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 600m

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-k127.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 600m

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased-oc.yml
@@ -70,6 +70,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 600m

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-increased.yml
@@ -62,6 +62,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 600m

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-k127-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 300m

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-k127.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 300m

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql-oc.yml
@@ -70,6 +70,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 300m

--- a/e2e-tests/limits/compare/statefulset_no-requests-proxysql.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-proxysql.yml
@@ -62,6 +62,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 300m

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-k127.yml
@@ -215,6 +215,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-k127.yml
@@ -215,6 +215,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-oc.yml
@@ -212,6 +212,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix.yml
@@ -208,6 +208,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-oc.yml
@@ -212,6 +212,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
@@ -208,6 +208,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/proxy-protocol/compare/service_proxy-protocol-haproxy-k122.yml
+++ b/e2e-tests/proxy-protocol/compare/service_proxy-protocol-haproxy-k122.yml
@@ -35,6 +35,10 @@ spec:
       port: 33060
       protocol: TCP
       targetPort: 33060
+    - name: stats
+      port: 8404
+      protocol: TCP
+      targetPort: 8404
   selector:
     app.kubernetes.io/component: haproxy
     app.kubernetes.io/instance: proxy-protocol

--- a/e2e-tests/proxy-protocol/compare/service_proxy-protocol-haproxy.yml
+++ b/e2e-tests/proxy-protocol/compare/service_proxy-protocol-haproxy.yml
@@ -33,6 +33,10 @@ spec:
       port: 33060
       protocol: TCP
       targetPort: 33060
+    - name: stats
+      port: 8404
+      protocol: TCP
+      targetPort: 8404
   selector:
     app.kubernetes.io/component: haproxy
     app.kubernetes.io/instance: proxy-protocol

--- a/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy-k127.yml
+++ b/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy-k127.yml
@@ -76,6 +76,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy-oc.yml
+++ b/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy.yml
+++ b/e2e-tests/proxy-protocol/compare/statefulset_proxy-protocol-haproxy.yml
@@ -69,6 +69,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/service_side-car-proxysql-k122.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/service_side-car-proxysql-k122.yml
@@ -25,6 +25,10 @@ spec:
       port: 33062
       protocol: TCP
       targetPort: 33062
+    - name: stats
+      port: 6070
+      protocol: TCP
+      targetPort: 6070
   selector:
     app.kubernetes.io/component: proxysql
     app.kubernetes.io/instance: side-car

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/service_side-car-proxysql.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/service_side-car-proxysql.yml
@@ -23,6 +23,10 @@ spec:
       port: 33062
       protocol: TCP
       targetPort: 33062
+    - name: stats
+      port: 6070
+      protocol: TCP
+      targetPort: 6070
   selector:
     app.kubernetes.io/component: proxysql
     app.kubernetes.io/instance: side-car

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-k127-oc.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-k127-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-k127.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-k127.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-oc.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql-oc.yml
@@ -70,6 +70,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql.yml
+++ b/e2e-tests/proxysql-sidecar-res-limits/compare/statefulset_side-car-proxysql.yml
@@ -62,6 +62,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes-oc.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-changes.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-oc.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-proxysql-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/e2e-tests/security-context/compare/statefulset_sec-context-proxysql.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-proxysql.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/e2e-tests/storage/compare/statefulset_emptydir-proxysql-k127-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-proxysql-k127-oc.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               ephemeral-storage: 1G

--- a/e2e-tests/storage/compare/statefulset_emptydir-proxysql-k127.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-proxysql-k127.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               ephemeral-storage: 1G

--- a/e2e-tests/storage/compare/statefulset_emptydir-proxysql-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-proxysql-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               ephemeral-storage: 1G

--- a/e2e-tests/storage/compare/statefulset_emptydir-proxysql.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-proxysql.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               ephemeral-storage: 1G

--- a/e2e-tests/storage/compare/statefulset_hostpath-proxysql-k127-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-proxysql-k127-oc.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/storage/compare/statefulset_hostpath-proxysql-k127.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-proxysql-k127.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/storage/compare/statefulset_hostpath-proxysql-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-proxysql-oc.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/storage/compare/statefulset_hostpath-proxysql.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-proxysql.yml
@@ -73,6 +73,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-1170.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-1170.yml
@@ -23,6 +23,10 @@ spec:
       port: 33062
       protocol: TCP
       targetPort: 33062
+    - name: stats
+      port: 6070
+      protocol: TCP
+      targetPort: 6070
   selector:
     app.kubernetes.io/component: proxysql
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1170-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1170-oc.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1170.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1170.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             limits:
               cpu: 700m

--- a/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-haproxy-oc.yml
+++ b/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-haproxy-oc.yml
@@ -82,6 +82,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-haproxy.yml
+++ b/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-haproxy.yml
@@ -85,6 +85,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql-oc.yml
+++ b/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql-oc.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 600m

--- a/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql.yml
+++ b/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-proxysql.yml
@@ -84,6 +84,9 @@ spec:
             - containerPort: 6032
               name: proxyadm
               protocol: TCP
+            - containerPort: 6070
+              name: stats
+              protocol: TCP
           resources:
             requests:
               cpu: 600m

--- a/pkg/pxc/app/statefulset/haproxy.go
+++ b/pkg/pxc/app/statefulset/haproxy.go
@@ -143,6 +143,16 @@ func (c *HAProxy) AppContainer(spec *api.PodSpec, secrets string, cr *api.Percon
 		},
 	)
 
+	if cr.CompareVersionWith("1.17.0") >= 0 {
+		appc.Ports = append(
+			appc.Ports,
+			corev1.ContainerPort{
+				ContainerPort: 8404,
+				Name:          "stats",
+			},
+		)
+	}
+
 	rsCmd := "/opt/percona/haproxy_readiness_check.sh"
 	lsCmd := "/opt/percona/haproxy_liveness_check.sh"
 	if cr.CompareVersionWith("1.15.0") < 0 {

--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -119,6 +119,16 @@ func (c *Proxy) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaX
 		Resources:       spec.Resources,
 	}
 
+	if cr.CompareVersionWith("1.17.0") >= 0 {
+		appc.Ports = append(
+			appc.Ports,
+			corev1.ContainerPort{
+				ContainerPort: 6070,
+				Name:          "stats",
+			},
+		)
+	}
+
 	fvar := true
 	appc.EnvFrom = []corev1.EnvFromSource{
 		{

--- a/pkg/pxc/service.go
+++ b/pkg/pxc/service.go
@@ -224,6 +224,10 @@ func NewServiceProxySQL(cr *api.PerconaXtraDBCluster) *corev1.Service {
 					Port: 3306,
 					Name: "mysql",
 				},
+				{
+					Port: 33062,
+					Name: "mysql-admin",
+				},
 			},
 			Selector:                 naming.SelectorProxySQL(cr),
 			LoadBalancerSourceRanges: loadBalancerSourceRanges,
@@ -259,12 +263,12 @@ func NewServiceProxySQL(cr *api.PerconaXtraDBCluster) *corev1.Service {
 		}
 	}
 
-	if cr.CompareVersionWith("1.6.0") >= 0 {
+	if cr.CompareVersionWith("1.17.0") >= 0 {
 		obj.Spec.Ports = append(
 			obj.Spec.Ports,
 			corev1.ServicePort{
-				Port: 33062,
-				Name: "mysql-admin",
+				Port: 6070,
+				Name: "stats",
 			},
 		)
 	}
@@ -326,6 +330,16 @@ func NewServiceHAProxy(cr *api.PerconaXtraDBCluster) *corev1.Service {
 					TargetPort: intstr.FromInt(3309),
 					Name:       "proxy-protocol",
 				},
+				{
+					Port:       33062,
+					TargetPort: intstr.FromInt(33062),
+					Name:       "mysql-admin",
+				},
+				{
+					Port:       33060,
+					TargetPort: intstr.FromInt(33060),
+					Name:       "mysqlx",
+				},
 			},
 			Selector:                 naming.SelectorHAProxy(cr),
 			LoadBalancerSourceRanges: loadBalancerSourceRanges,
@@ -347,24 +361,13 @@ func NewServiceHAProxy(cr *api.PerconaXtraDBCluster) *corev1.Service {
 		obj.Spec.ExternalTrafficPolicy = svcTrafficPolicyType
 	}
 
-	if cr.CompareVersionWith("1.6.0") >= 0 {
+	if cr.CompareVersionWith("1.17.0") >= 0 {
 		obj.Spec.Ports = append(
 			obj.Spec.Ports,
 			corev1.ServicePort{
-				Port:       33062,
-				TargetPort: intstr.FromInt(33062),
-				Name:       "mysql-admin",
-			},
-		)
-	}
-
-	if cr.CompareVersionWith("1.9.0") >= 0 {
-		obj.Spec.Ports = append(
-			obj.Spec.Ports,
-			corev1.ServicePort{
-				Port:       33060,
-				TargetPort: intstr.FromInt(33060),
-				Name:       "mysqlx",
+				Port:       8404,
+				TargetPort: intstr.FromInt(8404),
+				Name:       "stats",
 			},
 		)
 	}


### PR DESCRIPTION
[![K8SPXC-1473](https://badgen.net/badge/JIRA/K8SPXC-1473/green)](https://jira.percona.com/browse/K8SPXC-1473) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*
Expose metrics ports for haproxy and proxysql
**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1473]: https://perconadev.atlassian.net/browse/K8SPXC-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ