### PR TITLE
K8SPXC-1366: Backup improvements

### DIFF
--- a/config/crd/bases/pxc.percona.com_perconaxtradbclusterbackups.yaml
+++ b/config/crd/bases/pxc.percona.com_perconaxtradbclusterbackups.yaml
@@ -146,6 +146,9 @@ spec:
                 type: object
               pxcCluster:
                 type: string
+              startingDeadlineSeconds:
+                format: int64
+                type: integer
               storageName:
                 type: string
             type: object
@@ -202,6 +205,8 @@ spec:
                   type: object
                 type: array
               destination:
+                type: string
+              error:
                 type: string
               image:
                 type: string

--- a/config/crd/bases/pxc.percona.com_perconaxtradbclusterrestores.yaml
+++ b/config/crd/bases/pxc.percona.com_perconaxtradbclusterrestores.yaml
@@ -101,6 +101,8 @@ spec:
                     type: array
                   destination:
                     type: string
+                  error:
+                    type: string
                   image:
                     type: string
                   lastscheduled:
@@ -274,6 +276,8 @@ spec:
                           type: object
                         type: array
                       destination:
+                        type: string
+                      error:
                         type: string
                       image:
                         type: string

--- a/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
+++ b/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
@@ -143,6 +143,9 @@ spec:
                     type: array
                   serviceAccountName:
                     type: string
+                  startingDeadlineSeconds:
+                    format: int64
+                    type: integer
                   storages:
                     additionalProperties:
                       properties:

--- a/deploy/backup/backup.yaml
+++ b/deploy/backup/backup.yaml
@@ -8,6 +8,7 @@ spec:
   pxcCluster: cluster1
   storageName: fs-pvc
 #  activeDeadlineSeconds: 3600
+#  startingDeadlineSeconds: 300
 #  containerOptions:
 #    env:
 #    - name: VERIFY_TLS

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -145,6 +145,9 @@ spec:
                 type: object
               pxcCluster:
                 type: string
+              startingDeadlineSeconds:
+                format: int64
+                type: integer
               storageName:
                 type: string
             type: object
@@ -201,6 +204,8 @@ spec:
                   type: object
                 type: array
               destination:
+                type: string
+              error:
                 type: string
               image:
                 type: string
@@ -343,6 +348,8 @@ spec:
                       type: object
                     type: array
                   destination:
+                    type: string
+                  error:
                     type: string
                   image:
                     type: string
@@ -517,6 +524,8 @@ spec:
                           type: object
                         type: array
                       destination:
+                        type: string
+                      error:
                         type: string
                       image:
                         type: string
@@ -1048,6 +1057,9 @@ spec:
                     type: array
                   serviceAccountName:
                     type: string
+                  startingDeadlineSeconds:
+                    format: int64
+                    type: integer
                   storages:
                     additionalProperties:
                       properties:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -605,6 +605,7 @@ spec:
     image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0-backup
 #    backoffLimit: 6
 #    activeDeadlineSeconds: 3600
+#    startingDeadlineSeconds: 300
 #    serviceAccountName: percona-xtradb-cluster-operator
 #    imagePullSecrets:
 #      - name: private-registry-credentials

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -145,6 +145,9 @@ spec:
                 type: object
               pxcCluster:
                 type: string
+              startingDeadlineSeconds:
+                format: int64
+                type: integer
               storageName:
                 type: string
             type: object
@@ -201,6 +204,8 @@ spec:
                   type: object
                 type: array
               destination:
+                type: string
+              error:
                 type: string
               image:
                 type: string
@@ -343,6 +348,8 @@ spec:
                       type: object
                     type: array
                   destination:
+                    type: string
+                  error:
                     type: string
                   image:
                     type: string
@@ -517,6 +524,8 @@ spec:
                           type: object
                         type: array
                       destination:
+                        type: string
+                      error:
                         type: string
                       image:
                         type: string
@@ -1048,6 +1057,9 @@ spec:
                     type: array
                   serviceAccountName:
                     type: string
+                  startingDeadlineSeconds:
+                    format: int64
+                    type: integer
                   storages:
                     additionalProperties:
                       properties:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -145,6 +145,9 @@ spec:
                 type: object
               pxcCluster:
                 type: string
+              startingDeadlineSeconds:
+                format: int64
+                type: integer
               storageName:
                 type: string
             type: object
@@ -201,6 +204,8 @@ spec:
                   type: object
                 type: array
               destination:
+                type: string
+              error:
                 type: string
               image:
                 type: string
@@ -343,6 +348,8 @@ spec:
                       type: object
                     type: array
                   destination:
+                    type: string
+                  error:
                     type: string
                   image:
                     type: string
@@ -517,6 +524,8 @@ spec:
                           type: object
                         type: array
                       destination:
+                        type: string
+                      error:
                         type: string
                       image:
                         type: string
@@ -1048,6 +1057,9 @@ spec:
                     type: array
                   serviceAccountName:
                     type: string
+                  startingDeadlineSeconds:
+                    format: int64
+                    type: integer
                   storages:
                     additionalProperties:
                       properties:

--- a/e2e-tests/demand-backup-parallel/conf/backup.yml
+++ b/e2e-tests/demand-backup-parallel/conf/backup.yml
@@ -1,0 +1,7 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBClusterBackup
+metadata:
+  name:
+spec:
+  pxcCluster: demand-backup-parallel
+  storageName: minio

--- a/e2e-tests/demand-backup-parallel/conf/cr.yml
+++ b/e2e-tests/demand-backup-parallel/conf/cr.yml
@@ -1,0 +1,88 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBCluster
+metadata:
+  name: demand-backup-parallel
+  finalizers:
+    - percona.com/delete-pxc-pods-in-order
+  # annotations:
+  #   percona.com/issue-vault-token: "true"
+spec:
+  tls:
+    SANs:
+      - "minio-service.#namespace"
+  secretsName: my-cluster-secrets
+  vaultSecretName: some-name-vault
+  pause: false
+  pxc:
+    size: 3
+    image: -pxc
+    configuration: |
+      [mysqld]
+      wsrep_log_conflicts
+      log_error_verbosity=3
+      wsrep_debug=1
+      [sst]
+      xbstream-opts=--decompress
+      [xtrabackup]
+      compress=lz4
+    resources:
+      requests:
+        memory: 0.1G
+        cpu: 100m
+      limits:
+        memory: "2G"
+        cpu: "1"
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 2Gi
+    affinity:
+      antiAffinityTopologyKey: "kubernetes.io/hostname"
+  haproxy:
+    enabled: true
+    size: 2
+    image: -haproxy
+    resources:
+      requests:
+        memory: 0.1G
+        cpu: 100m
+      limits:
+        memory: 1G
+        cpu: 700m
+    affinity:
+      antiAffinityTopologyKey: "kubernetes.io/hostname"
+  pmm:
+    enabled: false
+    image: perconalab/pmm-client:1.17.1
+    serverHost: monitoring-service
+    serverUser: pmm
+  backup:
+    activeDeadlineSeconds: 3600
+    allowParallel: false
+    backoffLimit: 3
+    image: -backup
+    storages:
+      pvc:
+        type: filesystem
+        volume:
+          persistentVolumeClaim:
+            accessModes: [ "ReadWriteOnce" ]
+            resources:
+              requests:
+                storage: 1Gi
+      minio:
+        type: s3
+        resources:
+          requests:
+            memory: 0.5G
+            cpu: 500m
+          limits:
+            memory: "2G"
+            cpu: "1"
+        s3:
+          credentialsSecret: minio-secret
+          region: us-east-1
+          bucket: operator-testing/prefix/subfolder
+          endpointUrl: http://minio-service.#namespace:9000/
+        verifyTLS: false

--- a/e2e-tests/demand-backup-parallel/run
+++ b/e2e-tests/demand-backup-parallel/run
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# This test checks if spec.backup.allowParallel=false works as expected.
+
+set -o errexit
+
+test_dir=$(realpath $(dirname $0))
+. ${test_dir}/../functions
+
+set_debug
+
+function run_backup() {
+	local name=$1
+	yq eval ".metadata.name = \"${name}\"" ${test_dir}/conf/backup.yml \
+		| kubectl_bin apply -f -
+}
+
+function check_active_backup_count() {
+	active_backup_count=$(kubectl_bin get pxc-backup | grep -E 'Starting|Running' | wc -l)
+	if [[ ${active_backup_count} -gt 1 ]]; then
+		log "There are ${active_backup_count} active backups. 'allowParallel: false' doesn't work properly"
+		exit 1
+	fi
+}
+
+create_infra ${namespace}
+
+start_minio
+
+log "creating PXC client"
+kubectl_bin apply -f ${conf_dir}/client.yml
+
+log "creating cluster secrets"
+kubectl_bin apply -f ${conf_dir}/secrets.yml
+
+cluster="demand-backup-parallel"
+log "create PXC cluster: ${cluster}"
+apply_config ${test_dir}/conf/cr.yml
+
+desc 'creating backups'
+run_backup backup1
+run_backup backup2
+run_backup backup3
+run_backup backup4
+
+wait_cluster_consistency ${cluster} 3 2
+sleep 5
+check_active_backup_count
+
+for i in $(seq 0 3); do
+	sleep 5
+	check_active_backup_count
+	holder=$(kubectl_bin get lease pxc-${cluster}-backup-lock -o jsonpath={.spec.holderIdentity})
+	log "Backup lock holder: ${holder}"
+	wait_backup ${holder}
+done
+
+# explicitly check all backups to ensure all succeeded
+wait_backup backup1
+wait_backup backup2
+wait_backup backup3
+wait_backup backup4
+
+log "test passed"

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -60,6 +60,11 @@ set_debug() {
 	fi
 }
 
+log() {
+       echo "[$(date +%Y-%m-%dT%H:%M:%S%z)]" $*
+}
+
+
 HELM_VERSION=$(helm version -c | $sed -re 's/.*SemVer:"([^"]+)".*/\1/; s/.*\bVersion:"([^"]+)".*/\1/')
 if [ "${HELM_VERSION:0:2}" == "v2" ]; then
 	HELM_ARGS="--name"
@@ -98,10 +103,11 @@ wait_cluster_consistency() {
 	local i=0
 	local max=36
 	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
+	echo -n "waiting for pxc/${cluster_name} to be ready"
 	until [[ "$(kubectl_bin get pxc "${cluster_name}" -o jsonpath='{.status.state}')" == "ready" &&
 	"$(kubectl_bin get pxc "${cluster_name}" -o jsonpath='{.status.pxc.ready}')" == "${cluster_size}" &&
 	"$(kubectl_bin get pxc "${cluster_name}" -o jsonpath='{.status.'$(get_proxy_engine ${cluster_name})'.ready}')" == "${proxy_size}" ]]; do
-		echo 'waiting for cluster readyness'
+		echo -n .
 		sleep 20
 		if [[ $i -ge $max ]]; then
 			echo "Something went wrong waiting for cluster consistency!"
@@ -109,6 +115,7 @@ wait_cluster_consistency() {
 		fi
 		let i+=1
 	done
+	echo
 }
 
 create_namespace() {
@@ -235,7 +242,7 @@ wait_backup() {
 
 	set +o xtrace
 	retry=0
-	echo -n $backup
+	echo -n "waiting for pxc-backup/${backup} to reach ${status} state"
 	until kubectl_bin get pxc-backup/$backup -o jsonpath='{.status.state}' 2>/dev/null | grep $status; do
 		sleep 1
 		echo -n .

--- a/e2e-tests/run-pr.csv
+++ b/e2e-tests/run-pr.csv
@@ -5,6 +5,7 @@ custom-users,8.0
 demand-backup-cloud,8.0
 demand-backup-encrypted-with-tls,8.0
 demand-backup,8.0
+demand-backup-parallel,8.0
 haproxy,5.7
 haproxy,8.0
 init-deploy,5.7

--- a/e2e-tests/run-release.csv
+++ b/e2e-tests/run-release.csv
@@ -5,6 +5,7 @@ cross-site
 custom-users
 default-cr
 demand-backup
+demand-backup-parallel
 demand-backup-cloud
 demand-backup-encrypted-with-tls
 haproxy

--- a/pkg/apis/pxc/v1/pxc_backup_types.go
+++ b/pkg/apis/pxc/v1/pxc_backup_types.go
@@ -47,14 +47,16 @@ type PerconaXtraDBClusterBackup struct {
 }
 
 type PXCBackupSpec struct {
-	PXCCluster            string                  `json:"pxcCluster"`
-	StorageName           string                  `json:"storageName,omitempty"`
-	ContainerOptions      *BackupContainerOptions `json:"containerOptions,omitempty"`
-	ActiveDeadlineSeconds *int64                  `json:"activeDeadlineSeconds,omitempty"`
+	PXCCluster              string                  `json:"pxcCluster"`
+	StorageName             string                  `json:"storageName,omitempty"`
+	ContainerOptions        *BackupContainerOptions `json:"containerOptions,omitempty"`
+	StartingDeadlineSeconds *int64                  `json:"startingDeadlineSeconds,omitempty"`
+	ActiveDeadlineSeconds   *int64                  `json:"activeDeadlineSeconds,omitempty"`
 }
 
 type PXCBackupStatus struct {
 	State                 PXCBackupState          `json:"state,omitempty"`
+	Error                 string                  `json:"error,omitempty"`
 	CompletedAt           *metav1.Time            `json:"completed,omitempty"`
 	LastScheduled         *metav1.Time            `json:"lastscheduled,omitempty"`
 	Destination           PXCBackupDestination    `json:"destination,omitempty"`
@@ -185,4 +187,9 @@ func (cr *PerconaXtraDBClusterBackup) OwnerRef(scheme *runtime.Scheme) (metav1.O
 		UID:        cr.GetUID(),
 		Controller: &trueVar,
 	}, nil
+}
+
+func (cr *PerconaXtraDBClusterBackup) SetFailedStatusWithError(err error) {
+	cr.Status.State = BackupFailed
+	cr.Status.Error = err.Error()
 }

--- a/pkg/apis/pxc/v1/pxc_backup_types.go
+++ b/pkg/apis/pxc/v1/pxc_backup_types.go
@@ -162,6 +162,7 @@ type PXCBackupState string
 
 const (
 	BackupNew       PXCBackupState = ""
+	BackupWaiting   PXCBackupState = "Waiting"
 	BackupStarting  PXCBackupState = "Starting"
 	BackupRunning   PXCBackupState = "Running"
 	BackupFailed    PXCBackupState = "Failed"

--- a/pkg/apis/pxc/v1/pxc_backup_types.go
+++ b/pkg/apis/pxc/v1/pxc_backup_types.go
@@ -164,7 +164,7 @@ type PXCBackupState string
 
 const (
 	BackupNew       PXCBackupState = ""
-	BackupWaiting   PXCBackupState = "Waiting"
+	BackupSuspended PXCBackupState = "Suspended"
 	BackupStarting  PXCBackupState = "Starting"
 	BackupRunning   PXCBackupState = "Running"
 	BackupFailed    PXCBackupState = "Failed"

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -160,17 +160,18 @@ const (
 )
 
 type PXCScheduledBackup struct {
-	AllowParallel         *bool                         `json:"allowParallel,omitempty"`
-	Image                 string                        `json:"image,omitempty"`
-	ImagePullSecrets      []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
-	ImagePullPolicy       corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
-	Schedule              []PXCScheduledBackupSchedule  `json:"schedule,omitempty"`
-	Storages              map[string]*BackupStorageSpec `json:"storages,omitempty"`
-	ServiceAccountName    string                        `json:"serviceAccountName,omitempty"`
-	Annotations           map[string]string             `json:"annotations,omitempty"`
-	PITR                  PITRSpec                      `json:"pitr,omitempty"`
-	BackoffLimit          *int32                        `json:"backoffLimit,omitempty"`
-	ActiveDeadlineSeconds *int64                        `json:"activeDeadlineSeconds,omitempty"`
+	AllowParallel           *bool                         `json:"allowParallel,omitempty"`
+	Image                   string                        `json:"image,omitempty"`
+	ImagePullSecrets        []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	ImagePullPolicy         corev1.PullPolicy             `json:"imagePullPolicy,omitempty"`
+	Schedule                []PXCScheduledBackupSchedule  `json:"schedule,omitempty"`
+	Storages                map[string]*BackupStorageSpec `json:"storages,omitempty"`
+	ServiceAccountName      string                        `json:"serviceAccountName,omitempty"`
+	Annotations             map[string]string             `json:"annotations,omitempty"`
+	PITR                    PITRSpec                      `json:"pitr,omitempty"`
+	BackoffLimit            *int32                        `json:"backoffLimit,omitempty"`
+	ActiveDeadlineSeconds   *int64                        `json:"activeDeadlineSeconds,omitempty"`
+	StartingDeadlineSeconds *int64                        `json:"startingDeadlineSeconds,omitempty"`
 }
 
 func (b *PXCScheduledBackup) GetAllowParallel() bool {

--- a/pkg/apis/pxc/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pxc/v1/zz_generated.deepcopy.go
@@ -401,6 +401,11 @@ func (in *PXCBackupSpec) DeepCopyInto(out *PXCBackupSpec) {
 		*out = new(BackupContainerOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.StartingDeadlineSeconds != nil {
+		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
 		*out = new(int64)
@@ -516,6 +521,11 @@ func (in *PXCScheduledBackup) DeepCopyInto(out *PXCScheduledBackup) {
 	}
 	if in.ActiveDeadlineSeconds != nil {
 		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
+		*out = new(int64)
+		**out = **in
+	}
+	if in.StartingDeadlineSeconds != nil {
+		in, out := &in.StartingDeadlineSeconds, &out.StartingDeadlineSeconds
 		*out = new(int64)
 		**out = **in
 	}

--- a/pkg/controller/pxc/backup.go
+++ b/pkg/controller/pxc/backup.go
@@ -198,8 +198,9 @@ func (r *ReconcilePerconaXtraDBCluster) createBackupJob(ctx context.Context, cr 
 				Labels:     naming.LabelsScheduledBackup(cr, backupJob.Name),
 			},
 			Spec: api.PXCBackupSpec{
-				PXCCluster:  cr.Name,
-				StorageName: backupJob.StorageName,
+				PXCCluster:              cr.Name,
+				StorageName:             backupJob.StorageName,
+				StartingDeadlineSeconds: cr.Spec.Backup.StartingDeadlineSeconds,
 			},
 		}
 		err = r.client.Create(context.TODO(), bcp)

--- a/pkg/controller/pxc/controller.go
+++ b/pkg/controller/pxc/controller.go
@@ -17,7 +17,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,7 +25,6 @@ import (
 	k8sretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -34,6 +32,7 @@ import (
 
 	"github.com/percona/percona-xtradb-cluster-operator/clientcmd"
 	api "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/k8s"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/naming"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc"
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/app"
@@ -575,7 +574,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileConfigMap(cr *api.PerconaXtraDB
 			return errors.Wrap(err, "new autotune configmap")
 		}
 
-		err = setControllerReference(cr, configMap, r.scheme)
+		err = k8s.SetControllerReference(cr, configMap, r.scheme)
 		if err != nil {
 			return errors.Wrap(err, "set autotune configmap controller ref")
 		}
@@ -593,7 +592,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileConfigMap(cr *api.PerconaXtraDB
 	pxcConfigName := config.CustomConfigMapName(cr.Name, "pxc")
 	if cr.Spec.PXC.Configuration != "" {
 		configMap := config.NewConfigMap(cr, pxcConfigName, "init.cnf", cr.Spec.PXC.Configuration)
-		err := setControllerReference(cr, configMap, r.scheme)
+		err := k8s.SetControllerReference(cr, configMap, r.scheme)
 		if err != nil {
 			return errors.Wrap(err, "set controller ref")
 		}
@@ -660,7 +659,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileConfigMap(cr *api.PerconaXtraDB
 	if cr.Spec.ProxySQLEnabled() {
 		if cr.Spec.ProxySQL.Configuration != "" {
 			configMap := config.NewConfigMap(cr, proxysqlConfigName, "proxysql.cnf", cr.Spec.ProxySQL.Configuration)
-			err := setControllerReference(cr, configMap, r.scheme)
+			err := k8s.SetControllerReference(cr, configMap, r.scheme)
 			if err != nil {
 				return errors.Wrap(err, "set controller ref ProxySQL")
 			}
@@ -679,7 +678,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileConfigMap(cr *api.PerconaXtraDB
 	haproxyConfigName := config.CustomConfigMapName(cr.Name, "haproxy")
 	if cr.HAProxyEnabled() && cr.Spec.HAProxy.Configuration != "" {
 		configMap := config.NewConfigMap(cr, haproxyConfigName, "haproxy-global.cfg", cr.Spec.HAProxy.Configuration)
-		err := setControllerReference(cr, configMap, r.scheme)
+		err := k8s.SetControllerReference(cr, configMap, r.scheme)
 		if err != nil {
 			return errors.Wrap(err, "set controller ref HAProxy")
 		}
@@ -697,7 +696,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileConfigMap(cr *api.PerconaXtraDB
 	logCollectorConfigName := config.CustomConfigMapName(cr.Name, "logcollector")
 	if cr.Spec.LogCollector != nil && cr.Spec.LogCollector.Configuration != "" {
 		configMap := config.NewConfigMap(cr, logCollectorConfigName, "fluentbit_custom.conf", cr.Spec.LogCollector.Configuration)
-		err := setControllerReference(cr, configMap, r.scheme)
+		err := k8s.SetControllerReference(cr, configMap, r.scheme)
 		if err != nil {
 			return errors.Wrap(err, "set controller ref LogCollector")
 		}
@@ -716,7 +715,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileConfigMap(cr *api.PerconaXtraDB
 
 func (r *ReconcilePerconaXtraDBCluster) createHookScriptConfigMap(cr *api.PerconaXtraDBCluster, hookScript string, configMapName string) error {
 	configMap := config.NewConfigMap(cr, configMapName, "hook.sh", hookScript)
-	err := setControllerReference(cr, configMap, r.scheme)
+	err := k8s.SetControllerReference(cr, configMap, r.scheme)
 	if err != nil {
 		return errors.Wrap(err, "set controller ref")
 	}
@@ -742,7 +741,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcilePDB(ctx context.Context, cr *ap
 	}
 
 	pdb := pxc.PodDisruptionBudget(cr, spec, sfs.Labels())
-	if err := setControllerReference(sts, pdb, r.scheme); err != nil {
+	if err := k8s.SetControllerReference(sts, pdb, r.scheme); err != nil {
 		return errors.Wrap(err, "set owner reference")
 	}
 
@@ -984,38 +983,6 @@ func (r *ReconcilePerconaXtraDBCluster) deleteCerts(ctx context.Context, cr *api
 	return nil
 }
 
-func setControllerReference(ro runtime.Object, obj metav1.Object, scheme *runtime.Scheme) error {
-	ownerRef, err := OwnerRef(ro, scheme)
-	if err != nil {
-		return err
-	}
-	obj.SetOwnerReferences(append(obj.GetOwnerReferences(), ownerRef))
-	return nil
-}
-
-// OwnerRef returns OwnerReference to object
-func OwnerRef(ro runtime.Object, scheme *runtime.Scheme) (metav1.OwnerReference, error) {
-	gvk, err := apiutil.GVKForObject(ro, scheme)
-	if err != nil {
-		return metav1.OwnerReference{}, err
-	}
-
-	trueVar := true
-
-	ca, err := meta.Accessor(ro)
-	if err != nil {
-		return metav1.OwnerReference{}, err
-	}
-
-	return metav1.OwnerReference{
-		APIVersion: gvk.GroupVersion().String(),
-		Kind:       gvk.Kind,
-		Name:       ca.GetName(),
-		UID:        ca.GetUID(),
-		Controller: &trueVar,
-	}, nil
-}
-
 // resyncPXCUsersWithProxySQL calls the method of synchronizing users and makes sure that only one Goroutine works at a time
 func (r *ReconcilePerconaXtraDBCluster) resyncPXCUsersWithProxySQL(ctx context.Context, cr *api.PerconaXtraDBCluster) {
 	if !cr.Spec.ProxySQLEnabled() {
@@ -1182,7 +1149,7 @@ func mergeMaps(x, y map[string]string) map[string]string {
 }
 
 func (r *ReconcilePerconaXtraDBCluster) createOrUpdateService(ctx context.Context, cr *api.PerconaXtraDBCluster, svc *corev1.Service, saveOldMeta bool) error {
-	err := setControllerReference(cr, svc, r.scheme)
+	err := k8s.SetControllerReference(cr, svc, r.scheme)
 	if err != nil {
 		return errors.Wrap(err, "set controller reference")
 	}

--- a/pkg/controller/pxc/pitr.go
+++ b/pkg/controller/pxc/pitr.go
@@ -25,7 +25,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileBinlogCollector(ctx context.Con
 		return errors.Wrapf(err, "get binlog collector deployment for cluster '%s'", cr.Name)
 	}
 
-	err = setControllerReference(cr, &collector, r.scheme)
+	err = k8s.SetControllerReference(cr, &collector, r.scheme)
 	if err != nil {
 		return errors.Wrapf(err, "set controller reference for binlog collector deployment '%s'", collector.Name)
 	}

--- a/pkg/controller/pxc/tls.go
+++ b/pkg/controller/pxc/tls.go
@@ -278,7 +278,7 @@ func (r *ReconcilePerconaXtraDBCluster) createSSLManualy(cr *api.PerconaXtraDBCl
 	data["ca.crt"] = caCert
 	data["tls.crt"] = tlsCert
 	data["tls.key"] = key
-	owner, err := OwnerRef(cr, r.scheme)
+	owner, err := k8s.OwnerRef(cr, r.scheme)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -130,7 +130,7 @@ func (r *ReconcilePerconaXtraDBCluster) updatePod(ctx context.Context, sfs api.S
 		sts.Spec.Template.Annotations = annotations
 		sts.Spec.Template.Labels = labels
 
-		if err := setControllerReference(cr, sts, r.scheme); err != nil {
+		if err := k8s.SetControllerReference(cr, sts, r.scheme); err != nil {
 			return errors.Wrap(err, "set controller reference")
 		}
 		err = r.createOrUpdate(ctx, cr, sts)
@@ -168,12 +168,10 @@ func (r *ReconcilePerconaXtraDBCluster) smartUpdate(ctx context.Context, sfs api
 	}
 
 	if cr.HAProxyEnabled() && cr.Status.HAProxy.Status != api.AppStateReady {
-		log.V(1).Info("Waiting for HAProxy to be ready before smart update")
 		return nil
 	}
 
 	if cr.ProxySQLEnabled() && cr.Status.ProxySQL.Status != api.AppStateReady {
-		log.V(1).Info("Waiting for ProxySQL to be ready before smart update")
 		return nil
 	}
 

--- a/pkg/k8s/k8s_suite_test.go
+++ b/pkg/k8s/k8s_suite_test.go
@@ -1,0 +1,13 @@
+package k8s_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestK8s(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8s Suite")
+}

--- a/pkg/k8s/lease.go
+++ b/pkg/k8s/lease.go
@@ -1,0 +1,56 @@
+package k8s
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	coordv1 "k8s.io/api/coordination/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func AcquireLease(ctx context.Context, c client.Client, name, namespace, holder string) (*coordv1.Lease, error) {
+	lease := new(coordv1.Lease)
+
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, lease); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return lease, errors.Wrap(err, "get lease")
+		}
+
+		lease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: coordv1.LeaseSpec{
+				AcquireTime:    &metav1.MicroTime{Time: time.Now()},
+				HolderIdentity: &holder,
+			},
+		}
+
+		if err := c.Create(ctx, lease); err != nil {
+			return lease, errors.Wrap(err, "create lease")
+		}
+
+		return lease, nil
+	}
+
+	return lease, nil
+}
+
+func ReleaseLease(ctx context.Context, c client.Client, name, namespace string) error {
+	lease := new(coordv1.Lease)
+
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, lease); err != nil {
+		return errors.Wrap(err, "get lease")
+	}
+
+	if err := c.Delete(ctx, lease); err != nil {
+		return errors.Wrap(err, "delete lease")
+	}
+
+	return nil
+}

--- a/pkg/k8s/lease_test.go
+++ b/pkg/k8s/lease_test.go
@@ -1,0 +1,73 @@
+package k8s_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/k8s"
+	coordv1 "k8s.io/api/coordination/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake" // nolint
+)
+
+var _ = Describe("Lease", func() {
+	It("should be create a lease", func() {
+		cl := fake.NewFakeClient()
+
+		ctx := context.Background()
+
+		name := "backup-lock"
+		namespace := "test"
+		holder := "backup1"
+
+		lease, err := k8s.AcquireLease(ctx, cl, name, namespace, holder)
+		Expect(err).ToNot(HaveOccurred())
+
+		freshLease := new(coordv1.Lease)
+		nn := types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}
+		err = cl.Get(ctx, nn, freshLease)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(freshLease.Spec.AcquireTime).NotTo(BeNil())
+		Expect(freshLease.Spec.HolderIdentity, lease.Spec.HolderIdentity)
+	})
+
+	It("should be delete a lease", func() {
+		ctx := context.Background()
+
+		name := "backup-lock"
+		namespace := "test"
+		holder := "backup1"
+
+		lease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: coordv1.LeaseSpec{
+				AcquireTime:    &metav1.MicroTime{Time: time.Now()},
+				HolderIdentity: &holder,
+			},
+		}
+
+		cl := fake.NewFakeClient(lease)
+
+		err := k8s.ReleaseLease(ctx, cl, name, namespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		freshLease := new(coordv1.Lease)
+		nn := types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}
+		err = cl.Get(ctx, nn, freshLease)
+		Expect(err).To(HaveOccurred())
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+	})
+})

--- a/pkg/naming/backup.go
+++ b/pkg/naming/backup.go
@@ -9,6 +9,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
+func BackupLeaseName(clusterName string) string {
+	return "pxc-" + clusterName + "-backup-lock"
+}
+
 // BackupJobName generates legit name for backup resources.
 // k8s sets the `job-name` label for the created by job pod.
 // So we have to be sure that job name won't be longer than 63 symbols.

--- a/pkg/naming/labels.go
+++ b/pkg/naming/labels.go
@@ -30,6 +30,14 @@ const (
 	LabelPerconaRestoreJobName     = perconaPrefix + "restore-job-name"
 )
 
+func GetLabelBackupType(cr *api.PerconaXtraDBCluster) string {
+	if cr.CompareVersionWith("1.16.0") < 0 {
+		return "type"
+	}
+
+	return LabelPerconaBackupType
+}
+
 func LabelsCluster(cr *api.PerconaXtraDBCluster) map[string]string {
 	return map[string]string{
 		LabelAppKubernetesName:      "percona-xtradb-cluster",

--- a/pkg/naming/naming.go
+++ b/pkg/naming/naming.go
@@ -1,7 +1,8 @@
 package naming
 
 const (
-	annotationPrefix = "percona.com/"
+	annotationPrefix         = "percona.com/"
+	internalAnnotationPrefix = "internal." + annotationPrefix
 )
 
 const (
@@ -11,6 +12,7 @@ const (
 	FinalizerDeletePxcPvc         = annotationPrefix + "delete-pxc-pvc"
 	FinalizerDeleteBackup         = annotationPrefix + "delete-backup"
 	FinalizerS3DeleteBackup       = "delete-s3-backup"
+	FinalizerReleaseLock          = internalAnnotationPrefix + "release-lock"
 )
 
 const (

--- a/pkg/pxc/app/binlogcollector/binlog-collector.go
+++ b/pkg/pxc/app/binlogcollector/binlog-collector.go
@@ -346,7 +346,7 @@ func GetPod(ctx context.Context, c client.Client, cr *api.PerconaXtraDBCluster) 
 
 var GapFileNotFound = errors.New("gap file not found")
 
-func RemoveGapFile(ctx context.Context, cr *api.PerconaXtraDBCluster, c *clientcmd.Client, pod *corev1.Pod) error {
+func RemoveGapFile(c *clientcmd.Client, pod *corev1.Pod) error {
 	stderrBuf := &bytes.Buffer{}
 	err := c.Exec(pod, "pitr", []string{"/bin/bash", "-c", "rm /tmp/gap-detected"}, nil, nil, stderrBuf, false)
 	if err != nil {
@@ -359,7 +359,7 @@ func RemoveGapFile(ctx context.Context, cr *api.PerconaXtraDBCluster, c *clientc
 	return nil
 }
 
-func RemoveTimelineFile(ctx context.Context, cr *api.PerconaXtraDBCluster, c *clientcmd.Client, pod *corev1.Pod) error {
+func RemoveTimelineFile(c *clientcmd.Client, pod *corev1.Pod) error {
 	stderrBuf := &bytes.Buffer{}
 	err := c.Exec(pod, "pitr", []string{"/bin/bash", "-c", "rm /tmp/pitr-timeline"}, nil, nil, stderrBuf, false)
 	if err != nil {

--- a/pkg/pxc/backup/job.go
+++ b/pkg/pxc/backup/job.go
@@ -19,11 +19,7 @@ import (
 )
 
 func (*Backup) Job(cr *api.PerconaXtraDBClusterBackup, cluster *api.PerconaXtraDBCluster) *batchv1.Job {
-	labelKeyBackupType := "type"
-	if cluster.CompareVersionWith("1.16.0") >= 0 {
-		labelKeyBackupType = naming.LabelPerconaBackupType
-	}
-
+	labelKeyBackupType := naming.GetLabelBackupType(cluster)
 	jobName := naming.BackupJobName(cr.Name, cr.Labels[labelKeyBackupType] == "cron")
 
 	return &batchv1.Job{

--- a/pkg/pxc/backup/pitr.go
+++ b/pkg/pxc/backup/pitr.go
@@ -89,7 +89,7 @@ func CheckPITRErrors(ctx context.Context, cl client.Client, clcmd *clientcmd.Cli
 		return errors.Wrap(err, "update backup status")
 	}
 
-	if err := binlogcollector.RemoveGapFile(ctx, cr, clcmd, collectorPod); err != nil {
+	if err := binlogcollector.RemoveGapFile(clcmd, collectorPod); err != nil {
 		if !errors.Is(err, binlogcollector.GapFileNotFound) {
 			return errors.Wrap(err, "remove gap file")
 		}


### PR DESCRIPTION
[![K8SPXC-1366](https://badgen.net/badge/JIRA/K8SPXC-1366/green)](https://jira.percona.com/browse/K8SPXC-1366) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
This PR contains three commits:

[K8SPXC-1366: Improve parallel backup prevention](https://github.com/percona/percona-xtradb-cluster-operator/pull/1946/commits/511457f6ee5494f891e4db6549c7655df3297aa8)
With these changes, pxcbackup controller will create a lease object for a running backup and no other backup will be able to start until this lease is released (deleted). Lock is released when backup succeeds or fails.

Users can disable this behavior by setting `spec.backup.allowParallel` to true, by default this option is enabled.

Also, we introduce a new finalizer called `internal.percona.com/release-lock` for PerconaXtraDBClusterBackup objects. Operator will automatically add this finalizer to each new backup object if it doesn't exist. This finalizer will release the lock if user deletes a running backup object.

[K8SPXC-1366: Add startingDeadlineSeconds](https://github.com/percona/percona-xtradb-cluster-operator/pull/1946/commits/3a4b8f61a1198649103f7914be5f3731f9d000cc)
We introduce a new field to PerconaXtraDBClusterBackup: `spec.startingDeadlineSeconds`. If this field is set and if backup is not started in configured duration, operator will automatically fail the backup. This duration is checked by comparing the current time with backup job's creation timestamp.

[K8SPXC-1366: Suspend backup job if cluster becomes unready](https://github.com/percona/percona-xtradb-cluster-operator/pull/1946/commits/fd338faa77c72b57da05a5400a9b6af57075987b)
Backups can put pressure on a PXC cluster. With these changes, we introduce a new safety mechanism to pause backups if cluster becomes unhealthy. This mechanism can be disabled by enabling `spec.unsafeFlags.backupIfUnhealthy`.

Operator will periodically check cluster status and ready PXC pods while a backup is running. If ready PXC pods, at any point, becomes less than the desired number of PXC pods, operator will suspend backup job. Suspending the backup job will terminate any running backup pod. Operator will automatically resume the job once ready PXC pods are equal to desired number of PXC pods.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1366]: https://perconadev.atlassian.net/browse/K8SPXC-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ