### PR TITLE
replace typo NAMESPASE with NAMESPACE

### DIFF
--- a/e2e-tests/default-cr/compare/statefulset_cluster1-pxc-k127-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_cluster1-pxc-k127-oc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/default-cr/compare/statefulset_cluster1-pxc-k127.yml
+++ b/e2e-tests/default-cr/compare/statefulset_cluster1-pxc-k127.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/default-cr/compare/statefulset_cluster1-pxc-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_cluster1-pxc-oc.yml
@@ -43,7 +43,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/default-cr/compare/statefulset_cluster1-pxc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_cluster1-pxc.yml
@@ -43,7 +43,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-pxc-k127-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-pxc-k127-oc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-pxc-k127.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-pxc-k127.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-pxc-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-pxc-oc.yml
@@ -43,7 +43,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-pxc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-pxc.yml
@@ -43,7 +43,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-pxc-k127-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-pxc-k127-oc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-pxc-k127.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-pxc-k127.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-pxc-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-pxc-oc.yml
@@ -43,7 +43,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-pxc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-pxc.yml
@@ -43,7 +43,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127-oc.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: proxysql
             - name: MONITOR_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-k127.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: proxysql
             - name: MONITOR_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased-oc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: proxysql
             - name: MONITOR_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-increased.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: proxysql
             - name: MONITOR_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127-oc.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: proxysql
             - name: MONITOR_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-k127.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: proxysql
             - name: MONITOR_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql-oc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: proxysql
             - name: MONITOR_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-proxysql.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-proxysql.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: proxysql
             - name: MONITOR_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-k127-oc.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-k127.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased-oc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-increased.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-k127-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-k127-oc.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-k127.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-k127.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc-oc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/limits/compare/statefulset_no-limits-pxc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-pxc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-k127.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(PMM_PREFIX)$(POD_NAMESPASE)-$(POD_NAME)
+              value: $(PMM_PREFIX)$(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: haproxy
             - name: MONITOR_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-k127.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: haproxy
             - name: MONITOR_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix-oc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: haproxy
             - name: MONITOR_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-no-prefix.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: haproxy
             - name: MONITOR_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy-oc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(PMM_PREFIX)$(POD_NAMESPASE)-$(POD_NAME)
+              value: $(PMM_PREFIX)$(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: haproxy
             - name: MONITOR_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-haproxy.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(PMM_PREFIX)$(POD_NAMESPASE)-$(POD_NAME)
+              value: $(PMM_PREFIX)$(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: haproxy
             - name: MONITOR_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-k127-no-prefix-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-k127-no-prefix-oc.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-k127-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-k127-oc.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(PMM_PREFIX)$(POD_NAMESPASE)-$(POD_NAME)
+              value: $(PMM_PREFIX)$(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-k127.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(PMM_PREFIX)$(POD_NAMESPASE)-$(POD_NAME)
+              value: $(PMM_PREFIX)$(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-no-prefix-k127-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-no-prefix-k127-oc.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-no-prefix-k127.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-no-prefix-k127.yml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -88,7 +88,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-no-prefix-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-no-prefix-oc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-no-prefix.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-no-prefix.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(POD_NAMESPASE)-$(POD_NAME)
+              value: $(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc-oc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(PMM_PREFIX)$(POD_NAMESPASE)-$(POD_NAME)
+              value: $(PMM_PREFIX)$(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-pxc.yml
@@ -50,7 +50,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1
@@ -85,7 +85,7 @@ spec:
             - name: PMM_AGENT_SETUP_NODE_TYPE
               value: container
             - name: PMM_AGENT_SETUP_NODE_NAME
-              value: $(PMM_PREFIX)$(POD_NAMESPASE)-$(POD_NAME)
+              value: $(PMM_PREFIX)$(POD_NAMESPACE)-$(POD_NAME)
             - name: DB_TYPE
               value: mysql
             - name: DB_USER

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1151-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1151-oc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1151.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1151.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1161-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1161-oc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1161.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1161.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1170-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1170-oc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1170.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1170.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-pxc-oc.yml
+++ b/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-pxc-oc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-pxc.yml
+++ b/e2e-tests/upgrade-haproxy/compare/statefulset_upgrade-haproxy-pxc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-pxc-oc.yml
+++ b/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-pxc-oc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-pxc.yml
+++ b/e2e-tests/upgrade-proxysql/compare/statefulset_upgrade-proxysql-pxc.yml
@@ -46,7 +46,7 @@ spec:
         - env:
             - name: LOG_DATA_DIR
               value: /var/lib/mysql
-            - name: POD_NAMESPASE
+            - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   apiVersion: v1

--- a/pkg/pxc/app/pmm.go
+++ b/pkg/pxc/app/pmm.go
@@ -69,9 +69,9 @@ func PMMClient(cr *api.PerconaXtraDBCluster, spec *api.PMMSpec, secret *corev1.S
 
 		pmmAgentEnvs := pmmAgentEnvs(spec.ServerHost, spec.ServerUser, secret.Name, spec.UseAPI(secret))
 		if cr.CompareVersionWith("1.14.0") >= 0 {
-			val := "$(POD_NAMESPASE)-$(POD_NAME)"
+			val := "$(POD_NAMESPACE)-$(POD_NAME)"
 			if len(envVarsSecret.Data["PMM_PREFIX"]) > 0 {
-				val = "$(PMM_PREFIX)$(POD_NAMESPASE)-$(POD_NAME)"
+				val = "$(PMM_PREFIX)$(POD_NAMESPACE)-$(POD_NAME)"
 			}
 			pmmAgentEnvs = append(pmmAgentEnvs, corev1.EnvVar{
 				Name:  "PMM_AGENT_SETUP_NODE_NAME",
@@ -80,7 +80,7 @@ func PMMClient(cr *api.PerconaXtraDBCluster, spec *api.PMMSpec, secret *corev1.S
 		} else {
 			pmmAgentEnvs = append(pmmAgentEnvs, corev1.EnvVar{
 				Name:  "PMM_AGENT_SETUP_NODE_NAME",
-				Value: "$(POD_NAMESPASE)-$(POD_NAME)",
+				Value: "$(POD_NAMESPACE)-$(POD_NAME)",
 			})
 		}
 
@@ -137,7 +137,7 @@ func pmmAgentEnvs(pmmServerHost, pmmServerUser, secrets string, useAPI bool) []c
 			},
 		},
 		{
-			Name: "POD_NAMESPASE",
+			Name: "POD_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "metadata.namespace",

--- a/pkg/pxc/app/statefulset/node.go
+++ b/pkg/pxc/app/statefulset/node.go
@@ -279,7 +279,7 @@ func (c *Node) LogCollectorContainer(spec *api.LogCollectorSpec, logPsecrets str
 			Value: "/var/lib/mysql",
 		},
 		{
-			Name: "POD_NAMESPASE",
+			Name: "POD_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "metadata.namespace",


### PR DESCRIPTION
**replace typo NAMESPASE with NAMESPACE**
---
**Problem:**
One of the ENVVARs set by the operator is the POD_NAMESPASE envvar, which contains the namespace the pod is deployed to.

For correct spelling and consistency, this should be POD_NAMESPACE instead

Closes #1865 

**Cause:**
Likely a typo.

**Solution:**
Fix the typo.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
