### PR TITLE
CLOUD-869 Inverting the check to test whether the previous build's result is anything other than SUCCESS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -333,7 +333,7 @@ void checkE2EIgnoreFiles() {
     if (needToRunTests) {
         echo "Some changed files are outside of the e2eignore list. Proceeding with execution."
     } else {
-        if (currentBuild.previousBuild?.result in ['FAILURE', 'ABORTED', 'UNSTABLE']) {
+        if (currentBuild.previousBuild?.result != 'SUCCESS') {
             echo "All changed files are e2eignore files, and previous build was unsuccessful. Propagating previous state."
             currentBuild.result = currentBuild.previousBuild?.result
             error "Skipping execution as non-significant changes detected and previous build was unsuccessful."


### PR DESCRIPTION
[![CLOUD-869](https://badgen.net/badge/JIRA/CLOUD-869/green)](https://jira.percona.com/browse/CLOUD-869) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
The previous build can be `NOT_BUILT` for which I do not check.

**Solution:**
Inverting the check to test whether the previous build's result is anything other than `SUCCESS` is a cleaner approach. This way, we don’t need to explicitly list all the non-success states (`FAILURE`, `ABORTED`, `UNSTABLE`, `NOT_BUILT`), and the code remains robust against any additional statuses Jenkins might introduce in the future.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-869]: https://perconadev.atlassian.net/browse/CLOUD-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ