### PR TITLE
fix #1961, first char of a proxyadmin user password must not be a * 

### DIFF
--- a/pkg/controller/pxc/secrets.go
+++ b/pkg/controller/pxc/secrets.go
@@ -126,6 +126,9 @@ func validatePasswords(secret *corev1.Secret) error {
 			if strings.ContainsAny(string(pass), ";:") {
 				return errors.New("invalid proxyadmin password, don't use ';' or ':'")
 			}
+			if string(pass)[0:1] == "*" {
+				return errors.New("invalid proxyadmin password, first character must not be '*'")
+			}
 		default:
 			continue
 		}


### PR DESCRIPTION


**CHANGE DESCRIPTION**
---
**Problem:** 

proxysqladmin generated password might start with a `*` character, which proxysql does not like. It assumes it's a hashed password if it begins with a `*`.

See https://github.com/percona/percona-xtradb-cluster-operator/issues/1961


**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

Since it's using the operator/controller paradigm, we simply return an error (following the same convention as already set) if the `proxyadmin` password starts with a `*` character. Presumably this will fail a reconciliation, causing it to try again until the password does NOT start with a `*` character.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
