### PR TITLE
Fix reconciliation of replicationChannels without proxy pods

### DIFF
--- a/pkg/controller/pxc/replication.go
+++ b/pkg/controller/pxc/replication.go
@@ -126,7 +126,9 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileReplication(ctx context.Context
 	}
 
 	primary, err := r.getPrimaryPod(cr)
-	if err != nil {
+	if len(podList) == 1 && errors.Is(err, NoProxyDetectedError) {
+		primary = podList[0].Status.PodIP
+	} else if err != nil {
 		return errors.Wrap(err, "get primary pxc pod")
 	}
 

--- a/pkg/controller/pxc/replication.go
+++ b/pkg/controller/pxc/replication.go
@@ -126,7 +126,7 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileReplication(ctx context.Context
 	}
 
 	primary, err := r.getPrimaryPod(cr)
-	if len(podList) == 1 && errors.Is(err, NoProxyDetectedError) {
+	if len(podList) == 1 && cr.Spec.PXC.Size == 1 && errors.Is(err, NoProxyDetectedError) {
 		primary = podList[0].Status.PodIP
 	} else if err != nil {
 		return errors.Wrap(err, "get primary pxc pod")

--- a/pkg/controller/pxc/upgrade.go
+++ b/pkg/controller/pxc/upgrade.go
@@ -29,6 +29,8 @@ import (
 	"github.com/percona/percona-xtradb-cluster-operator/pkg/util"
 )
 
+var NoProxyDetectedError = errors.New("can't detect enabled proxy, please enable HAProxy or ProxySQL")
+
 func (r *ReconcilePerconaXtraDBCluster) updatePod(ctx context.Context, sfs api.StatefulApp, podSpec *api.PodSpec, cr *api.PerconaXtraDBCluster, newAnnotations map[string]string, smartUpdate bool) error {
 	log := logf.FromContext(ctx)
 
@@ -430,7 +432,7 @@ func (r *ReconcilePerconaXtraDBCluster) connectProxy(cr *api.PerconaXtraDBCluste
 			port = 33062
 		}
 	} else {
-		return database, errors.New("can't detect enabled proxy, please enable HAProxy or ProxySQL")
+		return database, NoProxyDetectedError
 	}
 
 	secrets := cr.Spec.SecretsName


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
If you're running a single replica without proxysql or haproxy, you get an error trying to reconcile replicationChannels:
```
get primary pxc pod: failed to get proxy connection: can't detect enabled proxy, please enable HAProxy or ProxySQL
```

**Cause:**
Running with more than one replica with proxysql/haproxy the replication code tries to find the primary pod to ensure the proper replicationChannels are set on the primary pod.

**Solution:**
This PR check if we can't get a proxy pod and if there's only 1 desired replica available, we use it for the primary replication channel logic.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
