### PR TITLE
K8SPXC-1327: Make jemalloc the default memory allocator

### DIFF
--- a/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
+++ b/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
@@ -1921,6 +1921,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -5349,6 +5351,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -8239,6 +8243,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -2873,6 +2873,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -6301,6 +6303,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -9191,6 +9195,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -60,6 +60,8 @@ spec:
     size: 3
     image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0
     autoRecovery: true
+#    mySqlAllocator: jemalloc
+#    mySqlAllocator: malloc
 #    expose:
 #      enabled: true
 #      type: LoadBalancer

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -2873,6 +2873,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -6301,6 +6303,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -9191,6 +9195,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -2873,6 +2873,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -6301,6 +6303,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -9191,6 +9195,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mySqlAllocator:
+                    type: string
                   nodeSelector:
                     additionalProperties:
                       type: string

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -471,6 +471,7 @@ type PodSpec struct {
 	EnvVarsSecretName             string                        `json:"envVarsSecret,omitempty"`
 	TerminationGracePeriodSeconds *int64                        `json:"gracePeriod,omitempty"`
 	ForceUnsafeBootstrap          bool                          `json:"forceUnsafeBootstrap,omitempty"`
+    MySqlAllocator                string                        `json:"mySqlAllocator,omitempty"`
 
 	// Deprecated: Use ServiceExpose.Type instead
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
@@ -795,7 +796,7 @@ var NoCustomVolumeErr = errors.New("no custom volume found")
 // +kubebuilder:object:generate=false
 type App interface {
 	InitContainers(cr *PerconaXtraDBCluster, initImageName string) []corev1.Container
-	AppContainer(spec *PodSpec, secrets string, cr *PerconaXtraDBCluster, availableVolumes []corev1.Volume) (corev1.Container, error)
+	AppContainer(ctx context.Context, cl client.Client, spec *PodSpec, secrets string, cr *PerconaXtraDBCluster, availableVolumes []corev1.Volume) (corev1.Container, error)
 	SidecarContainers(spec *PodSpec, secrets string, cr *PerconaXtraDBCluster) ([]corev1.Container, error)
 	PMMContainer(ctx context.Context, cl client.Client, spec *PMMSpec, secret *corev1.Secret, cr *PerconaXtraDBCluster) (*corev1.Container, error)
 	LogCollectorContainer(spec *LogCollectorSpec, logPsecrets string, logRsecrets string, cr *PerconaXtraDBCluster) ([]corev1.Container, error)

--- a/pkg/pxc/app/statefulset/haproxy.go
+++ b/pkg/pxc/app/statefulset/haproxy.go
@@ -46,7 +46,7 @@ func (c *HAProxy) InitContainers(cr *api.PerconaXtraDBCluster, initImageName str
 	return inits
 }
 
-func (c *HAProxy) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXtraDBCluster,
+func (c *HAProxy) AppContainer(ctx context.Context, cl client.Client, spec *api.PodSpec, secrets string, cr *api.PerconaXtraDBCluster,
 	_ []corev1.Volume,
 ) (corev1.Container, error) {
 	appc := corev1.Container{

--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -56,7 +56,7 @@ func proxyInitContainers(cr *api.PerconaXtraDBCluster, initImageName string) []c
 	return inits
 }
 
-func (c *Proxy) AppContainer(spec *api.PodSpec, secrets string, cr *api.PerconaXtraDBCluster,
+func (c *Proxy) AppContainer(ctx context.Context, cl client.Client, spec *api.PodSpec, secrets string, cr *api.PerconaXtraDBCluster,
 	availableVolumes []corev1.Volume,
 ) (corev1.Container, error) {
 	appc := corev1.Container{

--- a/pkg/pxc/statefulset.go
+++ b/pkg/pxc/statefulset.go
@@ -52,7 +52,7 @@ func StatefulSet(ctx context.Context, cl client.Client, sfs api.StatefulApp, pod
 		pod.Volumes = sfsVolume.Volumes
 	}
 
-	appC, err := sfs.AppContainer(podSpec, secrets, cr, pod.Volumes)
+	appC, err := sfs.AppContainer(ctx, cl, podSpec, secrets, cr, pod.Volumes)
 	if err != nil {
 		return nil, errors.Wrap(err, "app container")
 	}


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPXC-1327

Problem:
By default, standard libc allocator is used by PXC. It is often desirable to use jemalloc instead. To do so, use has to configure LD_PRELOAD environment variable. The only way to do this is through k8s secret.

Solution:
Extended PodSpec object with MySqlAllocator property. If it is empty, omitted or set to 'jemalloc', LD_PRELOAD env variable pointing to jemalloc library will be exported.
Otherwise the default allocator will be used.

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
