### PR TITLE
K8SPXC-1366: Fix releasing backup lock if backup is failed due to deadlines

### DIFF
--- a/e2e-tests/demand-backup-flow-control/conf/backup.yml
+++ b/e2e-tests/demand-backup-flow-control/conf/backup.yml
@@ -1,0 +1,7 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBClusterBackup
+metadata:
+  name:
+spec:
+  pxcCluster: some-name
+  storageName: minio

--- a/e2e-tests/demand-backup-flow-control/conf/cr.yml
+++ b/e2e-tests/demand-backup-flow-control/conf/cr.yml
@@ -1,0 +1,86 @@
+apiVersion: pxc.percona.com/v1
+kind: PerconaXtraDBCluster
+metadata:
+  name: some-name
+  finalizers:
+    - percona.com/delete-pxc-pods-in-order
+spec:
+  tls:
+    SANs:
+      - "minio-service.#namespace"
+  secretsName: my-cluster-secrets
+  vaultSecretName: some-name-vault
+  pause: false
+  pxc:
+    size: 3
+    image: -pxc
+    configuration: |
+      [mysqld]
+      wsrep_log_conflicts
+      log_error_verbosity=3
+      wsrep_debug=1
+      [sst]
+      xbstream-opts=--decompress
+      [xtrabackup]
+      compress=lz4
+    resources:
+      requests:
+        memory: 0.1G
+        cpu: 100m
+      limits:
+        memory: "2G"
+        cpu: "1"
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 2Gi
+    affinity:
+      antiAffinityTopologyKey: "kubernetes.io/hostname"
+  haproxy:
+    enabled: true
+    size: 2
+    image: -haproxy
+    resources:
+      requests:
+        memory: 0.1G
+        cpu: 100m
+      limits:
+        memory: 1G
+        cpu: 700m
+    affinity:
+      antiAffinityTopologyKey: "kubernetes.io/hostname"
+  pmm:
+    enabled: false
+    image: perconalab/pmm-client:1.17.1
+    serverHost: monitoring-service
+    serverUser: pmm
+  backup:
+    activeDeadlineSeconds: 3600
+    allowParallel: false
+    backoffLimit: 3
+    image: -backup
+    storages:
+      pvc:
+        type: filesystem
+        volume:
+          persistentVolumeClaim:
+            accessModes: [ "ReadWriteOnce" ]
+            resources:
+              requests:
+                storage: 1Gi
+      minio:
+        type: s3
+        resources:
+          requests:
+            memory: 0.5G
+            cpu: 500m
+          limits:
+            memory: "2G"
+            cpu: "1"
+        s3:
+          credentialsSecret: minio-secret
+          region: us-east-1
+          bucket: operator-testing/prefix/subfolder
+          endpointUrl: http://minio-service.#namespace:9000/
+        verifyTLS: false

--- a/e2e-tests/demand-backup-flow-control/conf/lease.yaml
+++ b/e2e-tests/demand-backup-flow-control/conf/lease.yaml
@@ -1,0 +1,7 @@
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: pxc-some-name-backup-lock
+spec:
+  acquireTime: "2025-03-18T16:47:25.407800Z"
+  holderIdentity: dummy-backup

--- a/e2e-tests/demand-backup-flow-control/run
+++ b/e2e-tests/demand-backup-flow-control/run
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# This test checks startingDeadlineSeconds and suspendedDeadlineSeconds
+
+set -o errexit
+
+test_dir=$(realpath $(dirname $0))
+. ${test_dir}/../functions
+
+set_debug
+
+cluster="some-name"
+
+function run_backup() {
+	local name=$1
+	yq eval ".metadata.name = \"${name}\"" ${test_dir}/conf/backup.yml \
+		| kubectl_bin apply -f -
+}
+
+function check_backup_error() {
+	local name=$1
+	local expected=$2
+
+	if ! kubectl_bin get pxc-backup ${name} -o yaml | yq .status.error | grep "${expected}"; then
+		log "asserting backup error failed name: ${name} expected: ${expected}, got: $(kubectl_bin get pxc-backup ${name} -o yaml | yq .status.error)"
+		exit 1
+	fi
+}
+
+create_infra ${namespace}
+
+start_minio
+
+log "creating PXC client"
+kubectl_bin apply -f ${conf_dir}/client.yml
+
+log "creating cluster secrets"
+kubectl_bin apply -f ${conf_dir}/secrets.yml
+
+log "create PXC cluster: ${cluster}"
+apply_config ${test_dir}/conf/cr.yml
+wait_cluster_consistency ${cluster} 3 2
+
+desc "CASE 1: startingDeadlineSeconds"
+
+log "setting startingDeadlineSeconds to 20"
+kubectl_bin patch pxc ${cluster} --type=merge -p '{"spec": {"backup": {"startingDeadlineSeconds": 20}}}'
+
+log "create dummy lock to block backup"
+kubectl_bin apply -f ${test_dir}/conf/lease.yaml
+
+log "creating pxc-backup/backup1"
+run_backup backup1
+wait_backup backup1 Failed
+
+log "operator should fail backup"
+check_backup_error backup1 "starting deadline seconds exceeded"
+
+log "operator successfully failed the backup job"
+
+kubectl_bin delete -f ${test_dir}/conf/lease.yaml
+
+desc "CASE 1: startingDeadlineSeconds PASSED"
+
+desc "CASE 2: suspend and resume"
+
+log "setting suspendedDeadlineSeconds to 300"
+kubectl_bin patch pxc ${cluster} --type=merge -p '{"spec": {"backup": {"startingDeadlineSeconds": 1800, "suspendedDeadlineSeconds": 300}}}'
+
+log "creating pxc-backup/backup2"
+run_backup backup2
+wait_backup backup2 Running
+
+log "deleting pod/${cluster}-pxc-2"
+kubectl_bin delete pod ${cluster}-pxc-2 --force
+
+wait_backup backup2 Suspended
+
+wait_cluster_consistency ${cluster} 3 2
+
+wait_backup backup2 Succeeded
+
+desc "CASE 2: suspend and resume PASSED"
+
+desc "CASE 3: suspendedDeadlineSeconds"
+
+log "setting suspendedDeadlineSeconds to 10"
+kubectl_bin patch pxc ${cluster} --type=merge -p '{"spec": {"backup": {"startingDeadlineSeconds": 1800, "suspendedDeadlineSeconds": 10}}}'
+
+log "creating pxc-backup/backup3"
+run_backup backup3
+wait_backup backup3 Running
+
+log "deleting pod/${cluster}-pxc-2"
+kubectl_bin delete pod ${cluster}-pxc-2 --force
+
+wait_backup backup3 Suspended
+
+wait_cluster_consistency ${cluster} 3 2
+
+wait_backup backup3 Failed
+
+log "operator should fail backup"
+check_backup_error backup3 "suspended deadline seconds exceeded"
+
+desc "CASE 3: suspendedDeadlineSeconds PASSED"
+
+log "test passed"
+
+destroy $namespace

--- a/e2e-tests/demand-backup-parallel/run
+++ b/e2e-tests/demand-backup-parallel/run
@@ -62,3 +62,5 @@ wait_backup backup3
 wait_backup backup4
 
 log "test passed"
+
+destroy $namespace

--- a/e2e-tests/demand-backup-parallel/run
+++ b/e2e-tests/demand-backup-parallel/run
@@ -50,7 +50,7 @@ check_active_backup_count
 for i in $(seq 0 3); do
 	sleep 5
 	check_active_backup_count
-	holder=$(kubectl_bin get lease pxc-${cluster}-backup-lock -o jsonpath={.spec.holderIdentity})
+	holder=$(kubectl_bin get lease pxc-${cluster}-backup-lock -o jsonpath={.spec.holderIdentity} | cut -d'-' -f1)
 	log "Backup lock holder: ${holder}"
 	wait_backup ${holder}
 done

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -247,7 +247,7 @@ wait_backup() {
 		sleep 0.5
 		echo -n .
 		let retry+=1
-		if [ $retry -ge 120 ]; then
+		if [ $retry -ge 360 ]; then
 			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod)
 			echo max retry count $retry reached. something went wrong with operator or kubernetes cluster
 			exit 1

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -101,14 +101,14 @@ wait_cluster_consistency() {
 	fi
 	desc "wait cluster consistency"
 	local i=0
-	local max=36
+	local max=300
 	sleep 7 # wait for two reconcile loops ;)  3 sec x 2 times + 1 sec = 7 seconds
 	echo -n "waiting for pxc/${cluster_name} to be ready"
 	until [[ "$(kubectl_bin get pxc "${cluster_name}" -o jsonpath='{.status.state}')" == "ready" &&
 	"$(kubectl_bin get pxc "${cluster_name}" -o jsonpath='{.status.pxc.ready}')" == "${cluster_size}" &&
 	"$(kubectl_bin get pxc "${cluster_name}" -o jsonpath='{.status.'$(get_proxy_engine ${cluster_name})'.ready}')" == "${proxy_size}" ]]; do
 		echo -n .
-		sleep 20
+		sleep 5
 		if [[ $i -ge $max ]]; then
 			echo "Something went wrong waiting for cluster consistency!"
 			exit 1
@@ -244,7 +244,7 @@ wait_backup() {
 	retry=0
 	echo -n "waiting for pxc-backup/${backup} to reach ${status} state"
 	until kubectl_bin get pxc-backup/$backup -o jsonpath='{.status.state}' 2>/dev/null | grep $status; do
-		sleep 1
+		sleep 0.5
 		echo -n .
 		let retry+=1
 		if [ $retry -ge 120 ]; then

--- a/e2e-tests/run-pr.csv
+++ b/e2e-tests/run-pr.csv
@@ -5,6 +5,7 @@ custom-users,8.0
 demand-backup-cloud,8.0
 demand-backup-encrypted-with-tls,8.0
 demand-backup,8.0
+demand-backup-flow-control,8.0
 demand-backup-parallel,8.0
 haproxy,5.7
 haproxy,8.0

--- a/e2e-tests/run-release.csv
+++ b/e2e-tests/run-release.csv
@@ -5,6 +5,7 @@ cross-site
 custom-users
 default-cr
 demand-backup
+demand-backup-flow-control
 demand-backup-parallel
 demand-backup-cloud
 demand-backup-encrypted-with-tls

--- a/pkg/controller/pxc/backup.go
+++ b/pkg/controller/pxc/backup.go
@@ -99,7 +99,8 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileBackups(ctx context.Context, cr
 				}
 
 				for _, todel := range oldjobs {
-					err = r.client.Delete(context.TODO(), &todel)
+					log.Info("deleting outdated backup", "backup", todel.Name)
+					err = r.client.Delete(ctx, &todel)
 					if err != nil {
 						log.Error(err, "failed to delete old backup", "name", todel.Name)
 					}

--- a/pkg/k8s/lease_test.go
+++ b/pkg/k8s/lease_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Lease", func() {
 
 		name := "backup-lock"
 		namespace := "test"
-		holder := "backup1"
+		holder := "backup1-a96b4d1c-c0ea-424a-b13c-2e1f351c6e61"
 
 		lease, err := k8s.AcquireLease(ctx, cl, name, namespace, holder)
 		Expect(err).ToNot(HaveOccurred())
@@ -43,7 +43,7 @@ var _ = Describe("Lease", func() {
 
 		name := "backup-lock"
 		namespace := "test"
-		holder := "backup1"
+		holder := "backup1-a96b4d1c-c0ea-424a-b13c-2e1f351c6e61"
 
 		lease := &coordv1.Lease{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/k8s/lease_test.go
+++ b/pkg/k8s/lease_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Lease", func() {
 
 		cl := fake.NewFakeClient(lease)
 
-		err := k8s.ReleaseLease(ctx, cl, name, namespace)
+		err := k8s.ReleaseLease(ctx, cl, name, namespace, holder)
 		Expect(err).ToNot(HaveOccurred())
 
 		freshLease := new(coordv1.Lease)

--- a/pkg/naming/backup.go
+++ b/pkg/naming/backup.go
@@ -7,10 +7,16 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/validation"
+
+	pxcv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
 )
 
 func BackupLeaseName(clusterName string) string {
 	return "pxc-" + clusterName + "-backup-lock"
+}
+
+func BackupHolderId(cr *pxcv1.PerconaXtraDBClusterBackup) string {
+	return fmt.Sprintf("%s-%s", cr.Name, cr.UID)
 }
 
 // BackupJobName generates legit name for backup resources.


### PR DESCRIPTION
[![K8SPXC-1366](https://badgen.net/badge/JIRA/K8SPXC-1366/green)](https://jira.percona.com/browse/K8SPXC-1366) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---

Locks are not released if reconciliation finishes early, so this issue should also happen with other reconciliation errors.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1366]: https://perconadev.atlassian.net/browse/K8SPXC-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ