### PR TITLE
K8SPXC-1544: Add prometheus counter for uploaded binlogs

### DIFF
--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -31,13 +31,19 @@ var (
 	pxcBinlogCollectorBackupSuccess = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "pxc_binlog_collector_success_total",
-			Help: "Total number of successful binlog backups",
+			Help: "Total number of successful binlog collection cycles",
 		},
 	)
 	pxcBinlogCollectorBackupFailure = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "pxc_binlog_collector_failure_total",
-			Help: "Total number of failed binlog backups",
+			Help: "Total number of failed binlog collection cycles",
+		},
+	)
+	pxcBinlogCollectorUploadedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "pxc_binlog_collector_uploaded_total",
+			Help: "Total number of successfully uploaded binlogs",
 		},
 	)
 	pxcBinlogCollectorLastProcessingTime = prometheus.NewGauge(
@@ -66,6 +72,7 @@ func init() {
 	prometheus.MustRegister(pxcBinlogCollectorLastProcessingTime)
 	prometheus.MustRegister(pxcBinlogCollectorLastUploadTime)
 	prometheus.MustRegister(pxcBinlogCollectorGapDetected)
+	prometheus.MustRegister(pxcBinlogCollectorUploadedTotal)
 }
 
 type Collector struct {
@@ -577,6 +584,7 @@ func (c *Collector) CollectBinLogs(ctx context.Context) error {
 			return errors.Wrap(err, "manage binlog")
 		}
 
+		pxcBinlogCollectorUploadedTotal.Inc()
 		pxcBinlogCollectorLastUploadTime.SetToCurrentTime()
 
 		lastTs, err := c.db.GetBinLogLastTimestamp(ctx, binlog.Name)


### PR DESCRIPTION
[![K8SPXC-1544](https://badgen.net/badge/JIRA/K8SPXC-1544/green)](https://jira.percona.com/browse/K8SPXC-1544) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
Add a new metric to count successfully uploaded binlogs.

```
bash-5.1$ curl --silent localhost:8080/metrics | grep -E '^pxc_binlog'
pxc_binlog_collector_failure_total 0
pxc_binlog_collector_gap_detected_total 0
pxc_binlog_collector_last_processing_timestamp 1.742998486453379e+09
pxc_binlog_collector_last_upload_timestamp 1.7429981182245624e+09
pxc_binlog_collector_success_total 38
pxc_binlog_collector_uploaded_total 14
```

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1544]: https://perconadev.atlassian.net/browse/K8SPXC-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ