### PR TITLE
K8SPXC-1538 deprecate enabled field for primary

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -282,7 +282,6 @@ spec:
 #      successThreshold: 1
 #      failureThreshold: 4
 #    exposePrimary:
-#      enabled: false
 #      type: ClusterIP
 #      annotations:
 #        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -562,7 +562,6 @@ type HAProxySpec struct {
 type ReplicasServiceExpose struct {
 	ServiceExpose `json:",inline"`
 	OnlyReaders   bool `json:"onlyReaders,omitempty"`
-	Enabled       bool `json:"enabled,omitempty"`
 }
 
 type PodDisruptionBudgetSpec struct {

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -95,7 +95,7 @@ type PXCSpec struct {
 }
 
 type ServiceExpose struct {
-	// Deprecated: Use ExposeReplica.Enabled instead, for ExposePrimary you don't need to specify this flag.
+	// Deprecated: for ExposePrimary you don't need to specify this flag.
 	Enabled                  bool                                    `json:"enabled,omitempty"`
 	Type                     corev1.ServiceType                      `json:"type,omitempty"`
 	LoadBalancerSourceRanges []string                                `json:"loadBalancerSourceRanges,omitempty"`

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -95,6 +95,7 @@ type PXCSpec struct {
 }
 
 type ServiceExpose struct {
+	// Deprecated: Use ExposeReplica.Enabled instead, for ExposePrimary you don't need to specify this flag.
 	Enabled                  bool                                    `json:"enabled,omitempty"`
 	Type                     corev1.ServiceType                      `json:"type,omitempty"`
 	LoadBalancerSourceRanges []string                                `json:"loadBalancerSourceRanges,omitempty"`
@@ -561,6 +562,7 @@ type HAProxySpec struct {
 type ReplicasServiceExpose struct {
 	ServiceExpose `json:",inline"`
 	OnlyReaders   bool `json:"onlyReaders,omitempty"`
+	Enabled       bool `json:"enabled,omitempty"`
 }
 
 type PodDisruptionBudgetSpec struct {


### PR DESCRIPTION
[![K8SPXC-1538](https://badgen.net/badge/JIRA/K8SPXC-1538/green)](https://jira.percona.com/browse/K8SPXC-1538) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
We don't use the field enabled for exposePrimary and it should be deprecated. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1538]: https://perconadev.atlassian.net/browse/K8SPXC-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ