### PR TITLE
K8SPXC-1535: add ports for default-cr tests

### DIFF
--- a/e2e-tests/default-cr/compare/service_cluster1-haproxy-k122.yml
+++ b/e2e-tests/default-cr/compare/service_cluster1-haproxy-k122.yml
@@ -31,6 +31,10 @@ spec:
       port: 33060
       protocol: TCP
       targetPort: 33060
+    - name: stats
+      port: 8404
+      protocol: TCP
+      targetPort: 8404
   selector:
     app.kubernetes.io/component: haproxy
     app.kubernetes.io/instance: cluster1

--- a/e2e-tests/default-cr/compare/service_cluster1-haproxy.yml
+++ b/e2e-tests/default-cr/compare/service_cluster1-haproxy.yml
@@ -30,6 +30,10 @@ spec:
       port: 33060
       protocol: TCP
       targetPort: 33060
+    - name: stats
+      port: 8404
+      protocol: TCP
+      targetPort: 8404
   selector:
     app.kubernetes.io/component: haproxy
     app.kubernetes.io/instance: cluster1

--- a/e2e-tests/default-cr/compare/service_minimal-cluster-haproxy-k122.yml
+++ b/e2e-tests/default-cr/compare/service_minimal-cluster-haproxy-k122.yml
@@ -31,6 +31,10 @@ spec:
       port: 33060
       protocol: TCP
       targetPort: 33060
+    - name: stats
+      port: 8404
+      protocol: TCP
+      targetPort: 8404
   selector:
     app.kubernetes.io/component: haproxy
     app.kubernetes.io/instance: minimal-cluster

--- a/e2e-tests/default-cr/compare/service_minimal-cluster-haproxy.yml
+++ b/e2e-tests/default-cr/compare/service_minimal-cluster-haproxy.yml
@@ -30,6 +30,10 @@ spec:
       port: 33060
       protocol: TCP
       targetPort: 33060
+    - name: stats
+      port: 8404
+      protocol: TCP
+      targetPort: 8404
   selector:
     app.kubernetes.io/component: haproxy
     app.kubernetes.io/instance: minimal-cluster

--- a/e2e-tests/default-cr/compare/statefulset_cluster1-haproxy-k127.yml
+++ b/e2e-tests/default-cr/compare/statefulset_cluster1-haproxy-k127.yml
@@ -85,6 +85,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/default-cr/compare/statefulset_cluster1-haproxy.yml
+++ b/e2e-tests/default-cr/compare/statefulset_cluster1-haproxy.yml
@@ -82,6 +82,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-haproxy-k127.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-haproxy-k127.yml
@@ -85,6 +85,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-haproxy.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-haproxy.yml
@@ -82,6 +82,9 @@ spec:
             - containerPort: 33060
               name: mysqlx
               protocol: TCP
+            - containerPort: 8404
+              name: stats
+              protocol: TCP
           readinessProbe:
             exec:
               command:


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
