### PR TITLE
K8SPXC-1535: update pxc config for 5.7 in backup tests

### DIFF
--- a/e2e-tests/demand-backup-flow-control/run
+++ b/e2e-tests/demand-backup-flow-control/run
@@ -38,7 +38,14 @@ log "creating cluster secrets"
 kubectl_bin apply -f ${conf_dir}/secrets.yml
 
 log "create PXC cluster: ${cluster}"
-apply_config ${test_dir}/conf/cr.yml
+if [[ $IMAGE_PXC =~ 5\.7 ]]; then
+	cat_config ${test_dir}/conf/cr.yml \
+		| $sed '/\[sst\]/,+1d' \
+		| $sed 's|compress=lz4|compress|' \
+		| kubectl_bin apply -f -
+else
+	apply_config ${test_dir}/conf/cr.yml
+fi
 wait_cluster_consistency ${cluster} 3 2
 
 desc "CASE 1: startingDeadlineSeconds"

--- a/e2e-tests/demand-backup-parallel/run
+++ b/e2e-tests/demand-backup-parallel/run
@@ -35,7 +35,14 @@ kubectl_bin apply -f ${conf_dir}/secrets.yml
 
 cluster="demand-backup-parallel"
 log "create PXC cluster: ${cluster}"
-apply_config ${test_dir}/conf/cr.yml
+if [[ $IMAGE_PXC =~ 5\.7 ]]; then
+	cat_config ${test_dir}/conf/cr.yml \
+		| $sed '/\[sst\]/,+1d' \
+		| $sed 's|compress=lz4|compress|' \
+		| kubectl_bin apply -f -
+else
+	apply_config ${test_dir}/conf/cr.yml
+fi
 
 desc 'creating backups'
 run_backup backup1


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
PXC 5.7 does not start with `SST` & `xtrabackup` configuration from cr as not supported.

**Solution:**
Update test to use correct config for 5.7.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
