### PR TITLE
K8SPXC-1620: update cleanup test according to retry changes

### DIFF
--- a/e2e-tests/demand-backup-cloud/run
+++ b/e2e-tests/demand-backup-cloud/run
@@ -104,13 +104,13 @@ check_cloud_storage_cleanup() {
 		if [[ ${deletes_num} -ge '2' ]]; then
 			echo "Bucket cleanup was successful"
 		else
-			echo "Smth went wrong. Delete was performed for $deletes_num. Expected: 2."
+			echo "Something went wrong. Delete was performed for $deletes_num. Expected: 2."
 			kubectl_bin logs ${backup_pod}
 			exit 1
 		fi
 	else
 		if kubectl_bin logs ${backup_pod} | grep 'Object deleted successfully before attempt 1. Exiting.'; then
-			echo "Smth went wrong. Delete was not performed."
+			echo "Something went wrong. Delete was not performed."
 			kubectl_bin logs ${backup_pod}
 			exit 1
 		else

--- a/e2e-tests/demand-backup-cloud/run
+++ b/e2e-tests/demand-backup-cloud/run
@@ -98,14 +98,24 @@ check_cloud_storage_cleanup() {
 		exit 1
 	fi
 	local backup_pod=$(kubectl_bin get pods --selector=percona.com/backup-job-name=xb-${backup_name} -o jsonpath='{.items[].metadata.name}')
-	# There are 2 deletes during backup: $backup_dir_sst_info & $backup_dir
-	deletes_num=$(kubectl_bin logs ${backup_pod} | grep -c 'Delete completed.')
-	if [[ ${deletes_num} -eq '2' ]]; then
-		echo "Bucket cleanup was successful"
+	if [[ $IMAGE_PXC =~ 5\.7 ]]; then
+		# There are 2 deletes during backup: $backup_dir_sst_info & $backup_dir
+		deletes_num=$(kubectl_bin logs ${backup_pod} | grep -c 'Delete completed.')
+		if [[ ${deletes_num} -ge '2' ]]; then
+			echo "Bucket cleanup was successful"
+		else
+			echo "Smth went wrong. Delete was performed for $deletes_num. Expected: 2."
+			kubectl_bin logs ${backup_pod}
+			exit 1
+		fi
 	else
-		echo "Smth went wrong. Delete was performed for $deletes_num. Expected: 2."
-		kubectl_bin logs ${backup_pod}
-		exit 1
+		if kubectl_bin logs ${backup_pod} | grep 'Object deleted successfully before attempt 1. Exiting.'; then
+			echo "Smth went wrong. Delete was not performed."
+			kubectl_bin logs ${backup_pod}
+			exit 1
+		else
+			echo "Clenup was performed."
+		fi
 	fi
 }
 


### PR DESCRIPTION
[![K8SPXC-1620](https://badgen.net/badge/JIRA/K8SPXC-1620/green)](https://jira.percona.com/browse/K8SPXC-1620) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1620]: https://perconadev.atlassian.net/browse/K8SPXC-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ