### PR TITLE
K8SPXC-1535: Update container image versions back to main after 1.17.0

### DIFF
--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -11743,7 +11743,7 @@ spec:
           value: percona-xtradb-cluster-operator
         - name: DISABLE_TELEMETRY
           value: "false"
-        image: percona/percona-xtradb-cluster-operator:1.17.0
+        image: perconalab/percona-xtradb-cluster-operator:main
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3

--- a/deploy/cr-minimal.yaml
+++ b/deploy/cr-minimal.yaml
@@ -3,7 +3,7 @@ kind: PerconaXtraDBCluster
 metadata:
   name: minimal-cluster
 spec:
-  crVersion: 1.17.0
+  crVersion: 1.18.0
   secretsName: minimal-cluster-secrets
   unsafeFlags:
     tls: true
@@ -16,7 +16,7 @@ spec:
     enabled: false
   pxc:
     size: 1
-    image: percona/percona-xtradb-cluster:8.0.41-32.1
+    image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0
     volumeSpec:
       persistentVolumeClaim:
         resources:
@@ -25,7 +25,7 @@ spec:
   haproxy:
     enabled: true
     size: 1
-    image: percona/haproxy:2.8.14
+    image: perconalab/percona-xtradb-cluster-operator:main-haproxy
   logcollector:
     enabled: true
-    image: percona/percona-xtradb-cluster-operator:1.17.0-logcollector-fluentbit4.0.0
+    image: perconalab/percona-xtradb-cluster-operator:main-logcollector

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -10,7 +10,7 @@ metadata:
 #  annotations:
 #    percona.com/issue-vault-token: "true"
 spec:
-  crVersion: 1.17.0
+  crVersion: 1.18.0
 #  enableVolumeExpansion: false
 #  ignoreAnnotations:
 #    - iam.amazonaws.com/role
@@ -22,7 +22,7 @@ spec:
 #  sslInternalSecretName: cluster1-ssl-internal
 #  logCollectorSecretName: cluster1-log-collector-secrets
 #  initContainer:
-#    image: percona/percona-xtradb-cluster-operator:1.17.0
+#    image: perconalab/percona-xtradb-cluster-operator:main
 #    containerSecurityContext:
 #      privileged: false
 #      runAsUser: 1001
@@ -58,7 +58,7 @@ spec:
     schedule: "0 4 * * *"
   pxc:
     size: 3
-    image: percona/percona-xtradb-cluster:8.0.41-32.1
+    image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0
     autoRecovery: true
 #    expose:
 #      enabled: true
@@ -207,7 +207,7 @@ spec:
   haproxy:
     enabled: true
     size: 3
-    image: percona/haproxy:2.8.14
+    image: perconalab/percona-xtradb-cluster-operator:main-haproxy
 #    imagePullPolicy: Always
 #    schedulerName: mycustom-scheduler
 #    readinessDelaySec: 15
@@ -381,7 +381,7 @@ spec:
   proxysql:
     enabled: false
     size: 3
-    image: percona/proxysql2:2.7.1
+    image: perconalab/percona-xtradb-cluster-operator:main-proxysql
 #    imagePullPolicy: Always
 #    configuration: |
 #      datadir="/var/lib/proxysql"
@@ -543,7 +543,7 @@ spec:
 #     - 10.0.0.0/8
   logcollector:
     enabled: true
-    image: percona/percona-xtradb-cluster-operator:1.17.0-logcollector-fluentbit4.0.0
+    image: perconalab/percona-xtradb-cluster-operator:main-logcollector
 #    configuration: |
 #      [OUTPUT]
 #           Name  es
@@ -576,7 +576,7 @@ spec:
 
   pmm:
     enabled: false
-    image: percona/pmm-client:2.44.0
+    image: perconalab/pmm-client:dev-latest
     serverHost: monitoring-service
 #    serverUser: admin
 #    pxcParams: "--disable-tablestats-limit=2000"
@@ -601,7 +601,7 @@ spec:
         cpu: 300m
   backup:
 #    allowParallel: true
-    image: percona/percona-xtradb-cluster-operator:1.17.0-pxc8.0-backup-pxb8.0.35
+    image: perconalab/percona-xtradb-cluster-operator:main-pxc8.0-backup
 #    backoffLimit: 6
 #    activeDeadlineSeconds: 3600
 #    startingDeadlineSeconds: 300

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -11753,7 +11753,7 @@ spec:
           value: percona-xtradb-cluster-operator
         - name: DISABLE_TELEMETRY
           value: "false"
-        image: percona/percona-xtradb-cluster-operator:1.17.0
+        image: perconalab/percona-xtradb-cluster-operator:main
         imagePullPolicy: Always
         resources:
           limits:

--- a/deploy/cw-operator.yaml
+++ b/deploy/cw-operator.yaml
@@ -42,7 +42,7 @@ spec:
           value: percona-xtradb-cluster-operator
         - name: DISABLE_TELEMETRY
           value: "false"
-        image: percona/percona-xtradb-cluster-operator:1.17.0
+        image: perconalab/percona-xtradb-cluster-operator:main
         imagePullPolicy: Always
         resources:
           limits:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -45,7 +45,7 @@ spec:
           value: percona-xtradb-cluster-operator
         - name: DISABLE_TELEMETRY
           value: "false"
-        image: percona/percona-xtradb-cluster-operator:1.17.0
+        image: perconalab/percona-xtradb-cluster-operator:main
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 3

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-1180.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-proxysql-1180.yml
@@ -23,9 +23,15 @@ spec:
       port: 33062
       protocol: TCP
       targetPort: 33062
+    - name: stats
+      port: 6070
+      protocol: TCP
+      targetPort: 6070
   selector:
     app.kubernetes.io/component: proxysql
     app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
     app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
   sessionAffinity: None
   type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-1180.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-pxc-1180.yml
@@ -30,6 +30,8 @@ spec:
   selector:
     app.kubernetes.io/component: pxc
     app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
     app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster
   sessionAffinity: None
   type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1161-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1161-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 2
+  generation: 1
   name: some-name-proxysql
   ownerReferences:
     - controller: true
@@ -229,6 +229,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: proxysql
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: proxydata
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1161.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1161.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 2
+  generation: 1
   name: some-name-proxysql
   ownerReferences:
     - controller: true
@@ -230,6 +230,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: proxysql
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: proxydata
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1170-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1170-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 3
+  generation: 2
   name: some-name-proxysql
   ownerReferences:
     - controller: true
@@ -232,6 +232,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: proxysql
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: proxydata
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1170.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1170.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 3
+  generation: 2
   name: some-name-proxysql
   ownerReferences:
     - controller: true
@@ -233,6 +233,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: proxysql
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: proxydata
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1180-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1180-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 1
+  generation: 3
   name: some-name-proxysql
   ownerReferences:
     - controller: true
@@ -83,6 +83,9 @@ spec:
               protocol: TCP
             - containerPort: 6032
               name: proxyadm
+              protocol: TCP
+            - containerPort: 6070
+              name: stats
               protocol: TCP
           resources:
             limits:
@@ -229,6 +232,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: proxysql
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: proxydata
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1180.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-proxysql-1180.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 1
+  generation: 3
   name: some-name-proxysql
   ownerReferences:
     - controller: true
@@ -83,6 +83,9 @@ spec:
               protocol: TCP
             - containerPort: 6032
               name: proxyadm
+              protocol: TCP
+            - containerPort: 6070
+              name: stats
               protocol: TCP
           resources:
             limits:
@@ -230,6 +233,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: proxysql
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: proxydata
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1161-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1161-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 2
+  generation: 1
   name: some-name-pxc
   ownerReferences:
     - controller: true
@@ -267,6 +267,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: pxc
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: datadir
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1161.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1161.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 2
+  generation: 1
   name: some-name-pxc
   ownerReferences:
     - controller: true
@@ -268,6 +268,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: pxc
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: datadir
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1170-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1170-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 3
+  generation: 2
   name: some-name-pxc
   ownerReferences:
     - controller: true
@@ -267,6 +267,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: pxc
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: datadir
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1170.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1170.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 3
+  generation: 2
   name: some-name-pxc
   ownerReferences:
     - controller: true
@@ -268,6 +268,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: pxc
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: datadir
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1180-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1180-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 1
+  generation: 3
   name: some-name-pxc
   ownerReferences:
     - controller: true
@@ -125,6 +125,10 @@ spec:
               value: "15"
             - name: DEFAULT_AUTHENTICATION_PLUGIN
               value: mysql_native_password
+            - name: MYSQL_NOTIFY_SOCKET
+              value: /var/lib/mysql/notify.sock
+            - name: MYSQL_STATE_FILE
+              value: /var/lib/mysql/mysql.state
           envFrom:
             - secretRef:
                 name: some-name-env-vars-pxc
@@ -214,7 +218,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        fsGroup: 1001
         supplementalGroups:
           - 1001
       serviceAccount: default
@@ -264,6 +267,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: pxc
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: datadir
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1180.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-pxc-1180.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 1
+  generation: 3
   name: some-name-pxc
   ownerReferences:
     - controller: true
@@ -125,6 +125,10 @@ spec:
               value: "15"
             - name: DEFAULT_AUTHENTICATION_PLUGIN
               value: mysql_native_password
+            - name: MYSQL_NOTIFY_SOCKET
+              value: /var/lib/mysql/notify.sock
+            - name: MYSQL_STATE_FILE
+              value: /var/lib/mysql/mysql.state
           envFrom:
             - secretRef:
                 name: some-name-env-vars-pxc
@@ -214,6 +218,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
+        fsGroup: 1001
         supplementalGroups:
           - 1001
       serviceAccount: default
@@ -263,6 +268,12 @@ spec:
     type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
+        labels:
+          app.kubernetes.io/component: pxc
+          app.kubernetes.io/instance: some-name
+          app.kubernetes.io/managed-by: percona-xtradb-cluster-operator
+          app.kubernetes.io/name: percona-xtradb-cluster
+          app.kubernetes.io/part-of: percona-xtradb-cluster
         name: datadir
       spec:
         accessModes:

--- a/e2e-tests/upgrade-consistency/run
+++ b/e2e-tests/upgrade-consistency/run
@@ -37,27 +37,15 @@ main() {
 	apply_config "$conf_dir/client.yml"
 	kubectl_bin apply -f "$test_dir/conf/secrets.yml"
 	cat_config "$conf_dir/$cluster.yml" \
-		| yq eval '.spec.crVersion = "1.15.1"' - \
+		| yq eval '.spec.crVersion = "1.16.1"' - \
 		| kubectl_bin apply -f -
-
-	desc "test 1.15.1"
-	kubectl_bin patch pxc "$cluster" --type=merge --patch '{
-        "spec": {"crVersion":"1.15.1"}
-    }'
-	wait_cluster_consistency "$cluster" 3 2
-	wait_for_sts_generation "$cluster-pxc" "1" "1"
-	desc "compare k8s objects"
-	compare_kubectl service/$cluster-pxc "-1151"
-	compare_kubectl service/$cluster-proxysql "-1151"
-	compare_kubectl statefulset/$cluster-pxc "-1151"
-	compare_kubectl statefulset/$cluster-proxysql "-1151"
 
 	desc "test 1.16.1"
 	kubectl_bin patch pxc "$cluster" --type=merge --patch '{
         "spec": {"crVersion":"1.16.1"}
     }'
 	wait_cluster_consistency "$cluster" 3 2
-	wait_for_sts_generation "$cluster-pxc" "2" "1"
+	wait_for_sts_generation "$cluster-pxc" "1" "1"
 	desc "compare k8s objects"
 	compare_kubectl service/$cluster-pxc "-1161"
 	compare_kubectl service/$cluster-proxysql "-1161"
@@ -69,12 +57,24 @@ main() {
         "spec": {"crVersion":"1.17.0"}
     }'
 	wait_cluster_consistency "$cluster" 3 2
-	wait_for_sts_generation "$cluster-pxc" "3" "1"
+	wait_for_sts_generation "$cluster-pxc" "2" "1"
 	desc "compare k8s objects"
 	compare_kubectl service/$cluster-pxc "-1170"
 	compare_kubectl service/$cluster-proxysql "-1170"
 	compare_kubectl statefulset/$cluster-pxc "-1170"
 	compare_kubectl statefulset/$cluster-proxysql "-1170"
+
+	desc "test 1.18.0"
+	kubectl_bin patch pxc "$cluster" --type=merge --patch '{
+        "spec": {"crVersion":"1.18.0"}
+    }'
+	wait_cluster_consistency "$cluster" 3 2
+	wait_for_sts_generation "$cluster-pxc" "3" "1"
+	desc "compare k8s objects"
+	compare_kubectl service/$cluster-pxc "-1180"
+	compare_kubectl service/$cluster-proxysql "-1180"
+	compare_kubectl statefulset/$cluster-pxc "-1180"
+	compare_kubectl statefulset/$cluster-proxysql "-1180"
 
 	destroy "${namespace}"
 	desc "test passed"

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.17.0"
+	Version = "1.18.0"
 )


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
