### PR TITLE
K8SPXC-1636 Fixed incorrect quoting in env command for copy_files_xbc…

### DIFF
--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -185,7 +185,7 @@ copy_files_xbcloud() {
 
 	echo ""
 	echo "Downloading started"
-	env -i "${CREDENTIALS} ${xbcloud} get ${backup_path} --parallel=10" 1>"$dest_dir/xtrabackup.stream" 2>"$dest_dir/transfer.log"
+	env -i ${CREDENTIALS} "${xbcloud} get ${backup_path} --parallel=10" 1>"$dest_dir/xtrabackup.stream" 2>"$dest_dir/transfer.log"
 	echo "Downloading finished"
 }
 


### PR DESCRIPTION
Pull Request is related to Issue
https://github.com/percona/percona-xtradb-cluster-operator/issues/1727

Jira Issue:
https://perconadev.atlassian.net/browse/K8SPXC-1636

This Pull Request addresses incorrect quoting in the env command within the copy_files_xbcloud() function. The original implementation mishandled variable separation, leading to potential issues during execution. The updated code ensures proper handling of CREDENTIALS and xbcloud variables, improving compatibility and reliability.

Changes Made:

Fixed the quoting in the env command to prevent errors with variable interpretation.

Adjusted the structure of the copy_files_xbcloud() function for better execution consistency.

Impact: This fix improves the stability of the function and resolves issues related to incorrect variable handling during file downloading processes.