### PR TITLE
K8SPXC-1615 add custom name

### DIFF
--- a/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
+++ b/config/crd/bases/pxc.percona.com_perconaxtradbclusters.yaml
@@ -4367,6 +4367,8 @@ spec:
                             type: string
                         type: object
                     type: object
+                  customClusterName:
+                    type: string
                   enabled:
                     type: boolean
                   image:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -5319,6 +5319,8 @@ spec:
                             type: string
                         type: object
                     type: object
+                  customClusterName:
+                    type: string
                   enabled:
                     type: boolean
                   image:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -578,6 +578,7 @@ spec:
     enabled: false
     image: perconalab/pmm-client:dev-latest
     serverHost: monitoring-service
+#    customClusterName: "testClusterName"
 #    serverUser: admin
 #    pxcParams: "--disable-tablestats-limit=2000"
 #    proxysqlParams: "--custom-labels=CUSTOM-LABELS"

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -5319,6 +5319,8 @@ spec:
                             type: string
                         type: object
                     type: object
+                  customClusterName:
+                    type: string
                   enabled:
                     type: boolean
                   image:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -5319,6 +5319,8 @@ spec:
                             type: string
                         type: object
                     type: object
+                  customClusterName:
+                    type: string
                   enabled:
                     type: boolean
                   image:

--- a/pkg/apis/pxc/v1/pxc_types.go
+++ b/pkg/apis/pxc/v1/pxc_types.go
@@ -642,6 +642,7 @@ type PMMSpec struct {
 	ServerHost               string                      `json:"serverHost,omitempty"`
 	Image                    string                      `json:"image,omitempty"`
 	ServerUser               string                      `json:"serverUser,omitempty"`
+	CustomClusterName        string                      `json:"customClusterName,omitempty"`
 	PxcParams                string                      `json:"pxcParams,omitempty"`
 	ProxysqlParams           string                      `json:"proxysqlParams,omitempty"`
 	Resources                corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/pkg/pxc/app/statefulset/haproxy.go
+++ b/pkg/pxc/app/statefulset/haproxy.go
@@ -307,8 +307,9 @@ func (c *HAProxy) LogCollectorContainer(_ *api.LogCollectorSpec, _ string, _ str
 }
 
 func (c *HAProxy) PMMContainer(ctx context.Context, cl client.Client, spec *api.PMMSpec, secret *corev1.Secret, cr *api.PerconaXtraDBCluster) (*corev1.Container, error) {
-	if cr.CompareVersionWith("1.9.0") < 0 {
-		return nil, nil
+	clusterName := cr.Name
+	if cr.CompareVersionWith("1.18.0") >= 0 && cr.Spec.PMM.CustomClusterName != "" {
+		clusterName = cr.Spec.PMM.CustomClusterName
 	}
 
 	envVarsSecret := &corev1.Secret{}
@@ -358,7 +359,7 @@ func (c *HAProxy) PMMContainer(ctx context.Context, cl client.Client, spec *api.
 		},
 		{
 			Name:  "CLUSTER_NAME",
-			Value: cr.Name,
+			Value: clusterName,
 		},
 		{
 			Name:  "PMM_ADMIN_CUSTOM_PARAMS",

--- a/pkg/pxc/app/statefulset/node.go
+++ b/pkg/pxc/app/statefulset/node.go
@@ -379,6 +379,11 @@ func (c *Node) PMMContainer(ctx context.Context, cl client.Client, spec *api.PMM
 		return nil, errors.Wrap(err, "get env vars secret")
 	}
 
+	clusterName := cr.Name
+	if cr.CompareVersionWith("1.18.0") >= 0 && cr.Spec.PMM.CustomClusterName != "" {
+		clusterName = cr.Spec.PMM.CustomClusterName
+	}
+
 	ct := app.PMMClient(cr, spec, secret, envVarsSecret)
 
 	pmmEnvs := []corev1.EnvVar{
@@ -436,7 +441,7 @@ func (c *Node) PMMContainer(ctx context.Context, cl client.Client, spec *api.PMM
 		clusterPmmEnvs := []corev1.EnvVar{
 			{
 				Name:  "CLUSTER_NAME",
-				Value: cr.Name,
+				Value: clusterName,
 			},
 			{
 				Name:  "PMM_ADMIN_CUSTOM_PARAMS",

--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -337,6 +337,11 @@ func (c *Proxy) PMMContainer(ctx context.Context, cl client.Client, spec *api.PM
 		return nil, errors.Wrap(err, "get env vars secret")
 	}
 
+	clusterName := cr.Name
+	if cr.CompareVersionWith("1.18.0") >= 0 && cr.Spec.PMM.CustomClusterName != "" {
+		clusterName = cr.Spec.PMM.CustomClusterName
+	}
+
 	ct := app.PMMClient(cr, spec, secret, envVarsSecret)
 
 	pmmEnvs := []corev1.EnvVar{
@@ -418,7 +423,7 @@ func (c *Proxy) PMMContainer(ctx context.Context, cl client.Client, spec *api.PM
 		clusterPmmEnvs := []corev1.EnvVar{
 			{
 				Name:  "CLUSTER_NAME",
-				Value: cr.Name,
+				Value: clusterName,
 			},
 			{
 				Name:  "PMM_ADMIN_CUSTOM_PARAMS",


### PR DESCRIPTION
[![K8SPXC-1615](https://badgen.net/badge/JIRA/K8SPXC-1615/green)](https://jira.percona.com/browse/K8SPXC-1615) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Add opportunity to add custom pmm name.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
https://github.com/percona/percona-helm-charts/pull/535

[K8SPXC-1615]: https://perconadev.atlassian.net/browse/K8SPXC-1615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ