### PR TITLE
Remove mysql init secret deletion when backups are successful

### DIFF
--- a/pkg/controller/pxcbackup/controller.go
+++ b/pkg/controller/pxcbackup/controller.go
@@ -13,7 +13,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -653,17 +652,6 @@ func (r *ReconcilePerconaXtraDBClusterBackup) updateJobStatus(
 			if err := binlogcollector.RemoveTimelineFile(r.clientcmd, collectorPod); err != nil {
 				return errors.Wrap(err, "remove timeline file")
 			}
-		}
-
-		initSecret := corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      cluster.Name + "-mysql-init",
-				Namespace: cluster.Namespace,
-			},
-		}
-		log.V(1).Info("Removing mysql-init secret", "secret", initSecret.Name)
-		if err := r.client.Delete(ctx, &initSecret); client.IgnoreNotFound(err) != nil {
-			return errors.Wrap(err, "delete mysql-init secret")
 		}
 	case api.BackupFailed:
 		log.Info("Backup failed")


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?