### PR TITLE
K8SPXC-1450: handle error when downsizing pvc

### DIFF
--- a/pkg/controller/pxc/volumes.go
+++ b/pkg/controller/pxc/volumes.go
@@ -231,6 +231,9 @@ func (r *ReconcilePerconaXtraDBCluster) reconcilePersistentVolumes(ctx context.C
 	}
 
 	if requested.Cmp(actual) < 0 {
+		if err := r.revertVolumeTemplate(ctx, cr, configured); err != nil {
+			return errors.Wrapf(err, "revert volume template in pxc/%s", cr.Name)
+		}
 		return errors.Errorf("requested storage (%s) is less than actual storage (%s)", requested.String(), actual.String())
 	}
 


### PR DESCRIPTION
[![K8SPXC-1450](https://badgen.net/badge/JIRA/K8SPXC-1450/green)](https://jira.percona.com/browse/K8SPXC-1450) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPXC-1450

**DESCRIPTION**
---
**Problem:**
*PVC resizing to smaller sizes is not allowed and results in an error, leaving the cluster in an error state. However, when a quota is reached, the values in the cr are reverted.*

**Solution:**
*The operator should not only return an error but also revert the changes made to the cr.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1450]: https://perconadev.atlassian.net/browse/K8SPXC-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ