### PR TITLE
CLOUD-914: Fix cleaning namespaces function

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -130,7 +130,7 @@ create_namespace() {
 		destroy_chaos_mesh
 		desc 'cleaned up all old namespaces'
 		kubectl_bin get ns \
-			| egrep -v "^kube-|^default$|Terminating|pxc-operator|openshift|^NAME" \
+			| egrep -v "^kube-|^default|Terminating|pxc-operator|openshift|^gke-|^gmp-|^NAME" \
 			| awk '{print$1}' \
 			| xargs kubectl delete ns &
 	fi


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
When cleanup function was executed, it was not considering some namespaces created automatically by cloud providers, deleting namespaces wrongly.

**Solution:**
Fix regex expression.


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
