### PR TITLE
K8SPXC-1568: prevent having `*` prefix in proxyadmin password

### DIFF
--- a/pkg/controller/pxc/secrets_test.go
+++ b/pkg/controller/pxc/secrets_test.go
@@ -1,0 +1,66 @@
+package pxc
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/percona/percona-xtradb-cluster-operator/pkg/pxc/users"
+)
+
+type repeatingReader struct {
+	pattern []byte
+	pos     int
+	reads   int
+}
+
+func (r *repeatingReader) Read(p []byte) (int, error) {
+	if len(r.pattern) == 0 {
+		return 0, io.ErrUnexpectedEOF
+	}
+	for i := range p {
+		p[i] = r.pattern[r.pos]
+		r.pos = (r.pos + 1) % len(r.pattern)
+	}
+	r.reads++
+	if r.reads > 10000 {
+		panic("too many reads: likely stuck in crypto/rand.Int retry loop. Try using a different pattern that produces values < max")
+	}
+	return len(p), nil
+}
+
+func TestGeneratePassProxyadmin(t *testing.T) {
+	idx := strings.Index(passSymbols, "*")
+	if idx == -1 {
+		t.Fatal("we can delete this test if passSymbols doesn't contain '*'")
+	}
+	randReader = &repeatingReader{
+		pattern: []byte{
+			byte(idx),
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+			7,
+			8,
+		},
+	}
+
+	p, err := generatePass()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(p), "*") {
+		t.Fatal("expected '*' prefix when no rules are applied to the password")
+	}
+
+	p, err = generatePass(users.ProxyAdmin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(string(p), "*") {
+		t.Fatal("unexpected '*' prefix: proxyadmin passwords should not include it")
+	}
+}


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPXC-1568

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
