### PR TITLE
K8SPXC-1375: Fix panic if retention is nil

### DIFF
--- a/pkg/controller/pxc/backup.go
+++ b/pkg/controller/pxc/backup.go
@@ -119,9 +119,16 @@ func (r *ReconcilePerconaXtraDBCluster) reconcileBackups(ctx context.Context, cr
 
 // shouldRecreateBackupJob determines whether the existing backup job needs to be recreated.
 func shouldRecreateBackupJob(expected api.PXCScheduledBackupSchedule, existing BackupScheduleJob) bool {
-	return existing.PXCScheduledBackupSchedule.Schedule != expected.Schedule ||
-		existing.PXCScheduledBackupSchedule.StorageName != expected.StorageName ||
-		existing.PXCScheduledBackupSchedule.Retention.DeleteFromStorage != expected.Retention.DeleteFromStorage
+	recreate := existing.PXCScheduledBackupSchedule.Schedule != expected.Schedule ||
+		existing.PXCScheduledBackupSchedule.StorageName != expected.StorageName
+
+	if existing.PXCScheduledBackupSchedule.Retention != nil && expected.Retention != nil {
+		recreate = recreate ||
+			existing.PXCScheduledBackupSchedule.Retention.DeleteFromStorage !=
+				expected.Retention.DeleteFromStorage
+	}
+
+	return recreate
 }
 
 func backupJobClusterPrefix(clusterName string) string {

--- a/pkg/controller/pxc/backup_test.go
+++ b/pkg/controller/pxc/backup_test.go
@@ -1,0 +1,105 @@
+package pxc
+
+import (
+	"testing"
+
+	pxcv1 "github.com/percona/percona-xtradb-cluster-operator/pkg/apis/pxc/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldRecreateJob(t *testing.T) {
+	tests := map[string]struct {
+		job      BackupScheduleJob
+		schedule pxcv1.PXCScheduledBackupSchedule
+		expected bool
+	}{
+		"no need to recreate": {
+			job: BackupScheduleJob{
+				PXCScheduledBackupSchedule: pxcv1.PXCScheduledBackupSchedule{
+					StorageName: "test-storage",
+					Schedule:    "10 4 * * *",
+				},
+			},
+			schedule: pxcv1.PXCScheduledBackupSchedule{
+				StorageName: "test-storage",
+				Schedule:    "10 4 * * *",
+			},
+			expected: false,
+		},
+		"no need to recreate (with retention)": {
+			job: BackupScheduleJob{
+				PXCScheduledBackupSchedule: pxcv1.PXCScheduledBackupSchedule{
+					StorageName: "test-storage",
+					Schedule:    "10 4 * * *",
+					Retention: &pxcv1.PXCScheduledBackupRetention{
+						Count:             3,
+						DeleteFromStorage: true,
+					},
+				},
+			},
+			schedule: pxcv1.PXCScheduledBackupSchedule{
+				StorageName: "test-storage",
+				Schedule:    "10 4 * * *",
+				Retention: &pxcv1.PXCScheduledBackupRetention{
+					Count:             5,
+					DeleteFromStorage: true,
+				},
+			},
+			expected: false,
+		},
+		"storage changed": {
+			job: BackupScheduleJob{
+				PXCScheduledBackupSchedule: pxcv1.PXCScheduledBackupSchedule{
+					StorageName: "test-storage",
+					Schedule:    "10 4 * * *",
+				},
+			},
+			schedule: pxcv1.PXCScheduledBackupSchedule{
+				StorageName: "test-storage-1",
+				Schedule:    "10 4 * * *",
+			},
+			expected: true,
+		},
+		"schedule changed": {
+			job: BackupScheduleJob{
+				PXCScheduledBackupSchedule: pxcv1.PXCScheduledBackupSchedule{
+					StorageName: "test-storage",
+					Schedule:    "10 4 * * *",
+				},
+			},
+			schedule: pxcv1.PXCScheduledBackupSchedule{
+				StorageName: "test-storage",
+				Schedule:    "10 5 * * *",
+			},
+			expected: true,
+		},
+		"deleteFromStorage changed": {
+			job: BackupScheduleJob{
+				PXCScheduledBackupSchedule: pxcv1.PXCScheduledBackupSchedule{
+					StorageName: "test-storage",
+					Schedule:    "10 4 * * *",
+					Retention: &pxcv1.PXCScheduledBackupRetention{
+						Count:             3,
+						DeleteFromStorage: false,
+					},
+				},
+			},
+			schedule: pxcv1.PXCScheduledBackupSchedule{
+				StorageName: "test-storage",
+				Schedule:    "10 4 * * *",
+				Retention: &pxcv1.PXCScheduledBackupRetention{
+					Count:             3,
+					DeleteFromStorage: true,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := shouldRecreateBackupJob(tt.schedule, tt.job)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Operator panics when a new scheduled backup is created and retention field is not defined in cr.yaml

**Solution:**
Sanity check.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
