### PR TITLE
K8SPXC-1382 set AWS credentials only when provided

### DIFF
--- a/build/backup/lib/pxc/aws.sh
+++ b/build/backup/lib/pxc/aws.sh
@@ -25,7 +25,9 @@ is_object_exist() {
 
 s3_add_bucket_dest() {
 	{ set +x; } 2>/dev/null
-	aws configure set aws_access_key_id "$ACCESS_KEY_ID"
-	aws configure set aws_secret_access_key "$SECRET_ACCESS_KEY"
+	if [ -n "$ACCESS_KEY_ID" ] && [ -n "$SECRET_ACCESS_KEY" ]; then
+		aws configure set aws_access_key_id "$ACCESS_KEY_ID"
+		aws configure set aws_secret_access_key "$SECRET_ACCESS_KEY"
+	fi
 	set -x
 }


### PR DESCRIPTION
[![K8SPXC-1382](https://badgen.net/badge/JIRA/K8SPXC-1382/green)](https://jira.percona.com/browse/K8SPXC-1382) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1382]: https://perconadev.atlassian.net/browse/K8SPXC-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ