### PR TITLE
K8SPXC-1548: Minor log improvements

### DIFF
--- a/pkg/pxc/backup/storage/storage.go
+++ b/pkg/pxc/backup/storage/storage.go
@@ -180,9 +180,10 @@ func (s *S3) DeleteObject(ctx context.Context, objectName string) error {
 	log := logf.FromContext(ctx).WithValues("bucket", s.bucketName, "prefix", s.prefix)
 
 	// minio sdk automatically URL-encodes the path
-	objPath, err := url.QueryUnescape(path.Join(s.prefix, objectName))
+	p := path.Join(s.prefix, objectName)
+	objPath, err := url.QueryUnescape(p)
 	if err != nil {
-		return errors.Wrapf(err, "failed to unescape object path %s", objPath)
+		return errors.Wrapf(err, "failed to unescape object path %s", p)
 	}
 
 	log.V(1).Info("deleting object", "object", objPath)
@@ -290,9 +291,9 @@ func (a *Azure) GetPrefix() string {
 func (a *Azure) DeleteObject(ctx context.Context, objectName string) error {
 	log := logf.FromContext(ctx).WithValues("container", a.container, "prefix", a.prefix, "object", objectName)
 
-	log.V(1).Info("deleting object")
-
 	objPath := path.Join(a.prefix, objectName)
+	log.V(1).Info("deleting object", "object", objPath)
+
 	_, err := a.client.DeleteBlob(ctx, a.container, objPath, nil)
 	if err != nil {
 		if bloberror.HasCode(errors.Cause(err), bloberror.BlobNotFound) {
@@ -301,7 +302,7 @@ func (a *Azure) DeleteObject(ctx context.Context, objectName string) error {
 		return errors.Wrapf(err, "delete blob %s", objPath)
 	}
 
-	log.V(1).Info("object deleted")
+	log.V(1).Info("object deleted", "object", objPath)
 
 	return nil
 }


### PR DESCRIPTION
[![K8SPXC-1548](https://badgen.net/badge/JIRA/K8SPXC-1548/green)](https://jira.percona.com/browse/K8SPXC-1548) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
Few improvements for logs when deleting backups from storages.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1548]: https://perconadev.atlassian.net/browse/K8SPXC-1548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ