### PR TITLE
K8SPXC-1725 HAProxy: Terminate sessions on server down

### DIFF
--- a/build/haproxy_add_pxc_nodes.sh
+++ b/build/haproxy_add_pxc_nodes.sh
@@ -22,7 +22,7 @@ function main() {
 	firs_node_replica=''
 	main_node=''
 
-	SERVER_OPTIONS=${HA_SERVER_OPTIONS:-'resolvers kubernetes check inter 10000 rise 1 fall 2 weight 1'}
+	SERVER_OPTIONS=${HA_SERVER_OPTIONS:-'resolvers kubernetes check inter 10000 rise 1 fall 2 weight 1 on-marked-down shutdown-sessions'}
 	send_proxy=''
 	path_to_haproxy_cfg='/etc/haproxy/pxc'
 	if [[ "${IS_PROXY_PROTOCOL}" = "yes" ]]; then


### PR DESCRIPTION
Adds the on-marked-down shutdown-sessions directive to ensure that any persistent connections to a backend server are immediately closed upon its health check failure. This is critical for our database/stateful services to guarantee a quick and complete failover to a healthy node.

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
