### PR TITLE
CLOUD-940 - Use authenticated calls to check backup existence

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,6 +315,27 @@ EOF
         sudo percona-release enable-only tools
         sudo yum install -y percona-xtrabackup-80 | true
     """
+    installAzureCLI()
+    azureAuth()
+}
+
+void azureAuth() {
+    withCredentials([azureServicePrincipal('PERCONA-OPERATORS-SP')]) {
+        sh '''
+            az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"  --allow-no-subscriptions
+            az account set -s "$AZURE_SUBSCRIPTION_ID"
+        '''
+    }
+}
+
+void installAzureCLI() {
+    sh """
+        if ! command -v az &>/dev/null; then
+            curl -s -L https://azurecliprod.blob.core.windows.net/install.py -o install.py
+            printf "/usr/azure-cli\\n/usr/bin" | sudo python3 install.py
+            sudo /usr/azure-cli/bin/python -m pip install "urllib3<2.0.0" > /dev/null
+        fi
+    """
 }
 
 boolean isManualBuild() {

--- a/e2e-tests/demand-backup-cloud/run
+++ b/e2e-tests/demand-backup-cloud/run
@@ -154,6 +154,25 @@ main() {
 		echo "Skipping test because SKIP_REMOTE_BACKUPS variable is set!"
 		exit 0
 	else
+		if command -v aws >/dev/null 2>&1; then
+			echo "AWS CLI is installed"
+		else
+			echo "AWS CLI is not installed"
+			exit 1
+		fi
+		if command -v gsutil >/dev/null 2>&1; then
+			echo "gutil is installed"
+		else
+			echo "gsutil command is not installed"
+			exit 1
+		fi
+		if command -v az >/dev/null 2>&1; then
+			echo "Azure CLI is installed"
+		else
+			echo "Azure CLI is not installed"
+			exit 1
+		fi
+
 		create_infra $namespace
 
 		cluster="demand-backup-cloud"
@@ -211,16 +230,21 @@ main() {
 		backup_dest_azure=$(kubectl_bin get pxc-backup "$backup_name_azure" -o jsonpath='{.status.destination}' | sed -e 's/.json$//' | cut -c 9-)
 
 		desc "Check backup existence"
-		check_backup_existence_aws "$backup_dest_aws" ".sst_info/sst_info.00000000000000000000" "aws-s3"
-		check_backup_existence "https://storage.googleapis.com/${backup_dest_gcp}.sst_info/sst_info.00000000000000000000" "gcp-cs"
-		check_backup_existence "https://engk8soperators.blob.core.windows.net/${backup_dest_azure}.sst_info/sst_info.00000000000000000000" "azure-blob"
+		setup_aws_credentials
+		check_backup_existence_aws "$backup_dest_aws" ".sst_info/sst_info.00000000000000000000"
+		
+		setup_gcs_credentials
+		check_backup_existence_gcs "${backup_dest_gcp}"
+		
+		setup_azure_credentials
+		check_backup_existence_azure "${backup_dest_azure}" ".sst_info/sst_info.00000000000000000000"
 
 		kubectl_bin delete pxc-backup --all
 
 		desc "Check backup deletion"
-		check_backup_existence_aws "$backup_dest_aws" ".sst_info/sst_info.00000000000000000000" "aws-s3"
-		check_backup_deletion "https://storage.googleapis.com/${backup_dest_gcp}.sst_info/sst_info.00000000000000000000" "gcp-cs"
-		check_backup_deletion "https://engk8soperators.blob.core.windows.net/${backup_dest_azure}.sst_info/sst_info.00000000000000000000" "azure-blob"
+		check_backup_deletion_aws "$backup_dest_aws" ".sst_info/sst_info.00000000000000000000"
+		check_backup_deletion_gcs "${backup_dest_gcp}"
+		check_backup_deletion_azure "${backup_dest_azure}" ".sst_info/sst_info.00000000000000000000"
 
 		if [ "$EKS" = 1 ]; then
 			backup_name_aws_iam="on-demand-backup-aws-s3-iam"
@@ -228,7 +252,7 @@ main() {
 			run_backup_with_delete "${backup_name_aws_iam}"
 			desc "Check backup existence for $backup_name_aws_iam"
 			backup_dest_aws_iam=$(kubectl_bin get pxc-backup "$backup_name_aws_iam" -o jsonpath='{.status.destination}' | sed -e 's/.json$//' | cut -c 6-)
-			check_backup_existence "https://s3.amazonaws.com/${backup_dest_aws_iam}.sst_info/sst_info.00000000000000000000" "aws-s3-iam"
+			check_backup_existence_aws "${backup_dest_aws_iam}" ".sst_info/sst_info.00000000000000000000"
 		fi
 
 		destroy $namespace

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1604,11 +1604,124 @@ function kpatch_set_field() {
 	kubectl_bin patch $type $name --type=json -p "[{\"op\": \"replace\", \"path\": \"$path\", \"value\": $value}]" >/dev/null
 }
 
+function setup_aws_credentials() {
+    local secret_name="aws-s3-secret"
+    
+    if [[ -n "$AWS_ACCESS_KEY_ID" ]] && [[ -n "$AWS_SECRET_ACCESS_KEY" ]]; then
+        echo "AWS credentials already set in environment"
+        return 0
+    fi
+    
+    echo "Setting up AWS credentials from secret: $secret_name"
+    
+    # Disable tracing for the entire credential section
+    local trace_was_on=0
+    if [[ $- == *x* ]]; then
+        trace_was_on=1
+        set +x
+    fi
+
+    AWS_ACCESS_KEY_ID=$(kubectl get secret "$secret_name" -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' 2>/dev/null | base64 -d 2>/dev/null)
+    AWS_SECRET_ACCESS_KEY=$(kubectl get secret "$secret_name" -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -d 2>/dev/null)
+    
+    if [[ -z "$AWS_ACCESS_KEY_ID" ]] || [[ -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+        # Re-enable tracing before error message if it was on
+        [[ $trace_was_on -eq 1 ]] && set -x
+        echo "Failed to extract AWS credentials from secret"
+        return 1
+    fi
+    
+    export AWS_ACCESS_KEY_ID
+    export AWS_SECRET_ACCESS_KEY
+    
+    # Re-enable tracing if it was on
+    [[ $trace_was_on -eq 1 ]] && set -x
+    
+    echo "AWS credentials configured successfully"
+}
+
+function setup_gcs_credentials() {
+    local secret_name="gcp-cs-secret"
+
+    if gsutil ls >/dev/null 2>&1; then
+        echo "GCS credentials already set in environment"
+        return 0
+    fi
+
+    echo "Setting up GCS credentials from K8s secret: $secret_name"
+    
+    # Disable tracing for the entire credential section
+    local trace_was_on=0
+    if [[ $- == *x* ]]; then
+        trace_was_on=1
+        set +x
+    fi
+    
+    ACCESS_KEY_ID=$(kubectl get secret "$secret_name" -o jsonpath='{.data.AWS_ACCESS_KEY_ID}' 2>/dev/null | base64 -d 2>/dev/null)
+    SECRET_ACCESS_KEY=$(kubectl get secret "$secret_name" -o jsonpath='{.data.AWS_SECRET_ACCESS_KEY}' 2>/dev/null | base64 -d 2>/dev/null)
+    
+    if [[ -z "$ACCESS_KEY_ID" ]] || [[ -z "$SECRET_ACCESS_KEY" ]]; then
+        # Re-enable tracing before error message if it was on
+        [[ $trace_was_on -eq 1 ]] && set -x
+        echo "Failed to extract GCS credentials from secret" >&2
+        return 1
+    fi
+    
+    boto_tmp=$(mktemp /tmp/boto.XXXXXX)
+    chmod 600 "$boto_tmp"
+
+    cat <<EOF >"$boto_tmp"
+[Credentials]
+gs_access_key_id = ${ACCESS_KEY_ID}
+gs_secret_access_key = ${SECRET_ACCESS_KEY}
+EOF
+
+    export BOTO_CONFIG="$boto_tmp"
+
+    unset ACCESS_KEY_ID
+    unset SECRET_ACCESS_KEY
+    
+    [[ $trace_was_on -eq 1 ]] && set -x
+    
+    echo "GCS credentials configured successfully"
+}
+
+function setup_azure_credentials() {
+    local secret_name="azure-secret"
+
+    echo "Setting up Azure credentials from K8s secret: $secret_name"
+    
+    # Disable tracing for the entire credential section
+    local trace_was_on=0
+    if [[ $- == *x* ]]; then
+        trace_was_on=1
+        set +x
+    fi
+    
+    AZURE_STORAGE_ACCOUNT=$(kubectl_bin get secret "$secret_name" -o jsonpath='{.data.AZURE_STORAGE_ACCOUNT_NAME}' 2>/dev/null | base64 -d 2>/dev/null)
+    AZURE_STORAGE_KEY=$(kubectl_bin get secret "$secret_name" -o jsonpath='{.data.AZURE_STORAGE_ACCOUNT_KEY}' 2>/dev/null | base64 -d 2>/dev/null)
+
+    if [[ -z "$AZURE_STORAGE_ACCOUNT" ]] || [[ -z "$AZURE_STORAGE_KEY" ]]; then
+        # Re-enable tracing before error message if it was on
+        [[ $trace_was_on -eq 1 ]] && set -x
+        echo "Failed to extract Azure credentials from secret" >&2
+        return 1
+    fi
+
+    export AZURE_STORAGE_ACCOUNT
+    export AZURE_STORAGE_KEY
+
+    # Re-enable tracing if it was on
+    [[ $trace_was_on -eq 1 ]] && set -x
+
+    echo "Azure credentials configured successfully"
+}
+
 function check_backup_existence_aws() {
 	bucket=$(echo "$1" | cut -d'/' -f1)
 	key_prefix=$(echo "$1" | cut -d'/' -f2-)
 	key=$2
-	storage_name=$3
+	storage_name="aws-s3"
 	retry=0
 
 	until aws s3api head-object --bucket "$bucket" --key "${key_prefix}${key}" &>/dev/null; do
@@ -1622,39 +1735,113 @@ function check_backup_existence_aws() {
 		((retry += 1))
 	done
 	
-	echo "Backup found in $storage_name"
+	echo "Backup ${key_prefix}${key} found in bucket $bucket in $storage_name"
 }
 
-function check_backup_existence() {
-	path=$1
-	storage_name=$2
+function check_backup_existence_gcs() {
+	backup_dest_gcp=$1
+	storage_name="gcp-cs"
 	retry=0
-	until [[ $(curl -sw '%{http_code}' -o /dev/null "$path") -eq 200 ]]; do
+
+	gcs_path="gs://${backup_dest_gcp}.sst_info/sst_info.00000000000000000000"
+
+	until gsutil ls "$gcs_path" >/dev/null 2>&1; do
+		if [ $retry -ge 30 ]; then
+			echo "Max retry count $retry reached. Something went wrong with operator or Kubernetes cluster."
+			echo "Backup was not found in bucket -- $storage_name"
+			exit 1
+		fi
+		echo "Waiting for backup in $storage_name ($gcs_path)..."
+		sleep 10
+		((retry += 1))
+	done
+	
+	echo "Backup found in $storage_name: $gcs_path"
+}
+
+function check_backup_existence_azure() {
+	container=$(echo "$1" | cut -d'/' -f1)
+	blob_prefix=$(echo "$1" | cut -d'/' -f2-)
+	blob=$2
+	storage_name="azure-blob"
+	retry=0
+	blob_path="${blob_prefix}${blob}"
+
+	until az storage blob show --container-name "$container" --name "$blob_path" &>/dev/null; do
 		if [ $retry -ge 30 ]; then
 			echo "max retry count $retry reached. something went wrong with operator or kubernetes cluster"
-			echo "Backup was not found in bucket -- $storage_name"
+			echo "Backup was not found in container -- $storage_name"
 			exit 1
 		fi
 		echo "waiting for backup in $storage_name"
 		sleep 10
 		((retry += 1))
 	done
+	
+	echo "Backup ${blob_path} found in container $container in $storage_name"
 }
 
-function check_backup_deletion() {
-	path=$1
-	storage_name=$2
+function check_backup_deletion_aws() {
+	bucket=$(echo "$1" | cut -d'/' -f1)
+	key_prefix=$(echo "$1" | cut -d'/' -f2-)
+	key=$2
+	storage_name="aws-s3"
 	retry=0
-	until [[ $(curl -sw '%{http_code}' -o /dev/null "$path") -eq 403 ]] || [[ $(curl -sw '%{http_code}' -o /dev/null "$path") -eq 404 ]] || [[ $(curl -sw '%{http_code}' -o /dev/null "$path") -eq 400 ]]; do
-		if [ $retry -ge 30 ]; then
+
+	while aws s3api head-object --bucket "$bucket" --key "${key_prefix}${key}" &>/dev/null; do
+		if [ $retry -ge 15 ]; then
 			echo "max retry count $retry reached. something went wrong with operator or kubernetes cluster"
-			echo "Backup was not removed from bucket -- $storage_name"
+			echo "Backup still exists in $storage_name (expected it to be deleted)"
 			exit 1
 		fi
-		echo "waiting for backup deletion $storage_name"
+		echo "waiting for backup to be deleted from $storage_name"
 		sleep 10
 		((retry += 1))
 	done
+	
+	echo "Backup ${key_prefix}${key} in bucket $bucket not found in $storage_name"
+}
+
+function check_backup_deletion_gcs() {
+    backup_dest_gcp=$1
+    storage_name="gcp-cs"
+    retry=0
+    gcs_path="gs://${backup_dest_gcp}.sst_info/sst_info.00000000000000000000"
+
+    while gsutil ls "$gcs_path" >/dev/null 2>&1; do
+        if [ $retry -ge 15 ]; then
+            echo "max retry count $retry reached. something went wrong with operator or kubernetes cluster"
+            echo "Backup $gcs_path still exists in $storage_name (expected it to be deleted)"
+            exit 1
+        fi
+        echo "waiting for backup to be deleted from $storage_name"
+        sleep 10
+        ((retry += 1))
+    done
+
+    echo "Backup $gcs_path not found in $storage_name"
+}
+
+function check_backup_deletion_azure() {
+	container=$(echo "$1" | cut -d'/' -f1)
+	blob_prefix=$(echo "$1" | cut -d'/' -f2-)
+	blob=$2
+	storage_name="azure-blob"
+	retry=0
+	blob_path="${blob_prefix}${blob}"
+
+	while az storage blob show --container-name "$container" --name "$blob_path" &>/dev/null; do
+		if [ $retry -ge 15 ]; then
+			echo "max retry count $retry reached. something went wrong with operator or kubernetes cluster"
+			echo "Backup still exists in $storage_name (expected it to be deleted)"
+			exit 1
+		fi
+		echo "waiting for backup to be deleted from $storage_name"
+		sleep 10
+		((retry += 1))
+	done
+	
+	echo "Backup ${blob_path} in container $container not found in $storage_name"
 }
 
 check_passwords_leak() {

--- a/e2e-tests/scheduled-backup/run
+++ b/e2e-tests/scheduled-backup/run
@@ -231,6 +231,25 @@ main() {
 	POD_MINIO_BACKUP=$(kubectl_bin get pods | grep ${JOB_MINIO_BACKUP%-*} | awk '{print $1}')
 
 	if [ -z "$SKIP_REMOTE_BACKUPS" ]; then
+		if command -v aws >/dev/null 2>&1; then
+			echo "AWS CLI is installed"
+		else
+			echo "AWS CLI is not installed"
+			exit 1
+		fi
+		if command -v gsutil >/dev/null 2>&1; then
+			echo "gutil is installed"
+		else
+			echo "gsutil command is not installed"
+			exit 1
+		fi
+		if command -v az >/dev/null 2>&1; then
+			echo "Azure CLI is installed"
+		else
+			echo "Azure CLI is not installed"
+			exit 1
+		fi
+
 		FIRST_AWS_BACKUP=$(kubectl_bin get pxc-backup -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.storageName}:{.status.state}{"\n"}{end}' | grep Succeeded | grep aws | head -n1 | cut -d: -f1)
 		JOB_AWS_BACKUP=$(kubectl_bin get jobs | grep ${FIRST_AWS_BACKUP} | awk '{print $1}')
 		POD_AWS_BACKUP=$(kubectl_bin get pods | grep ${JOB_AWS_BACKUP%-*} | awk '{print $1}')
@@ -248,9 +267,14 @@ main() {
 		BACKUP_DEST_AZURE=$(kubectl_bin get pxc-backup "$FIRST_AZURE_BACKUP" -o jsonpath='{.status.destination}' | sed -e 's/.json$//' | cut -c 9-)
 
 		desc "Check backup existence"
-		check_backup_existence_aws "$BACKUP_DEST_AWS" ".sst_info/sst_info.00000000000000000000" "aws-s3"
-		check_backup_existence "https://storage.googleapis.com/${BACKUP_DEST_GCP}.sst_info/sst_info.00000000000000000000" "gcp-cs"
-		check_backup_existence "https://engk8soperators.blob.core.windows.net/${BACKUP_DEST_AZURE}.sst_info/sst_info.00000000000000000000" "azure-blob"
+		setup_aws_credentials
+		check_backup_existence_aws "$BACKUP_DEST_AWS" ".sst_info/sst_info.00000000000000000000"
+
+		setup_gcs_credentials
+		check_backup_existence_gcs "$BACKUP_DEST_GCP"
+
+		setup_azure_credentials
+		check_backup_existence_azure "$BACKUP_DEST_AZURE" ".sst_info/sst_info.00000000000000000000"
 
 		desc "Check that KEEP option saves correct backup's amount (1 for our settings)"
 
@@ -292,9 +316,9 @@ main() {
 		fi
 
 		desc "Check backup deletion"
-		check_backup_deletion "https://s3.amazonaws.com/${BACKUP_DEST_AWS}.sst_info/sst_info.00000000000000000000" "aws-s3"
-		check_backup_deletion "https://storage.googleapis.com/${BACKUP_DEST_GCP}.sst_info/sst_info.00000000000000000000" "gcp-cs"
-		check_backup_deletion "https://engk8soperators.blob.core.windows.net/${BACKUP_DEST_AZURE}.sst_info/sst_info.00000000000000000000" "azure-blob"
+		check_backup_deletion_aws "$BACKUP_DEST_AWS" ".sst_info/sst_info.00000000000000000000"
+		check_backup_deletion_gcs "$BACKUP_DEST_GCP"
+		check_backup_deletion_azure "$BACKUP_DEST_AZURE" ".sst_info/sst_info.00000000000000000000"
 	fi
 
 	backup_name_pvc=$(get_backup_name "pvc")


### PR DESCRIPTION
[![CLOUD-940](https://badgen.net/badge/JIRA/CLOUD-940/green)](https://jira.percona.com/browse/CLOUD-940) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem**
The operator-testing S3 bucket is now private, so its objects can no longer be accessed through unauthenticated object URLs. As a result, tests that verify the existence of backups in this bucket are failing.

**Solution**
Use the AWS CLI, authenticated via the pipeline credentials, to verify the existence of backups.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-940]: https://perconadev.atlassian.net/browse/CLOUD-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ