### PR TITLE
K8SPXC-1470 add "--retries=5" option to "kubectl cp"

### DIFF
--- a/deploy/backup/copy-backup.sh
+++ b/deploy/backup/copy-backup.sh
@@ -175,8 +175,13 @@ copy_files_pvc() {
 
 	echo ""
 	echo "Downloading started"
-	$ctrl cp backup-access:/backup/ "${real_dest_dir%/}/"
-	echo "Downloading finished"
+	$ctrl cp --retries=5 backup-access:/backup/ "${real_dest_dir%/}/"
+	if [ -f "${real_dest_dir%/}/xtrabackup.stream" ] && [ "$(file -b "${real_dest_dir%/}/xtrabackup.stream")" == "data" ]; then
+		echo "Downloading finished"
+	else
+		echo "Download failed: ${real_dest_dir%/}/xtrabackup.stream file is missing or not of type 'data'."
+		exit 1
+	fi
 }
 
 copy_files_xbcloud() {
@@ -190,6 +195,7 @@ copy_files_xbcloud() {
 		echo "Downloading finished"
 	else
 		echo "Download failed: $dest_dir/xtrabackup.stream file is missing or not of type 'data'."
+		exit 1
 	fi
 }
 


### PR DESCRIPTION
[![K8SPXC-1470](https://img.shields.io/badge/JIRA-K8SPXC--1470-green?logo=)](https://jira.percona.com/browse/K8SPXC-1470) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1470]: https://perconadev.atlassian.net/browse/K8SPXC-1470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ