### PR TITLE
K8SPXC-735: Reap defunct processes created by percona-scheduler-admin

### DIFF
--- a/build/proxysql-entrypoint.sh
+++ b/build/proxysql-entrypoint.sh
@@ -124,4 +124,42 @@ fi
 
 test -e /opt/percona/hookscript/hook.sh && source /opt/percona/hookscript/hook.sh
 
-exec "$@"
+# Start zombie reaper to clean up processes spawned by sidecars
+# This is needed because proxysql (PID 1) may not properly reap all child processes
+# The reaper runs as a background process and continuously reaps zombies
+(
+       while true; do
+               sleep 0.5
+               # Reap any zombie processes that are children of PID 1
+               while wait -n 2>/dev/null; do :; done
+       done
+) &
+REAPER_PID=$!
+
+# Cleanup function
+cleanup() {
+       kill $REAPER_PID 2>/dev/null || true
+       wait $REAPER_PID 2>/dev/null || true
+}
+trap cleanup EXIT TERM INT
+
+# Run proxysql in foreground (not exec) so reaper can continue running
+# This allows the reaper to clean up zombies spawned by sidecar processes
+"$@" &
+PROXYSQL_PID=$!
+
+# Forward signals to proxysql
+forward_signal() {
+       kill -"$1" "$PROXYSQL_PID" 2>/dev/null || true
+}
+trap 'forward_signal TERM' TERM
+trap 'forward_signal INT' INT
+
+# Wait for proxysql and forward its exit code
+wait $PROXYSQL_PID
+EXIT_CODE=$?
+
+# Clean up reaper
+cleanup
+
+exit $EXIT_CODE


### PR DESCRIPTION
[![K8SPXC-735](https://img.shields.io/badge/JIRA-K8SPXC--735-green?logo=)](https://jira.percona.com/browse/K8SPXC-735) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---

Running `percona-scheduler-admin --syncusers` create a lot of zombie processes:
```
bash-5.1$ percona-scheduler-admin --config-file=/opt/percona/scheduler-config.toml --syncusers --add-query-rule

Syncing user accounts from PXC(some-name-pxc-0.some-name-pxc.proxysql-scheduler-30579.svc.cluster.local:3306) to ProxySQL

Synced PXC users to the ProxySQL database!

bash-5.1$ ps -eFH
UID          PID    PPID  C    SZ   RSS PSR STIME TTY          TIME CMD
proxysql     462       0  0  1113  3832   3 15:18 pts/1    00:00:00 bash
proxysql    1370     462  0  1757  3212   3 15:19 pts/1    00:00:00   ps -eFH
proxysql     341       0  0  1112  3600   3 15:18 pts/0    00:00:00 bash
proxysql     405     341  0   937  3004   2 15:18 pts/0    00:00:00   watch -n 1 ps -eFH
proxysql       1       0  2 68878 110960  0 15:17 ?        00:00:02 proxysql -f -c /etc/proxysql/proxysql.cnf --reload
proxysql     911       1  0     0     0   2 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     915       1  0     0     0   2 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     919       1  0     0     0   1 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     923       1  0     0     0   1 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     927       1  0     0     0   3 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     931       1  0     0     0   0 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     936       1  0     0     0   3 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     943       1  0     0     0   3 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     955       1  0     0     0   3 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     967       1  0     0     0   3 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     974       1  0     0     0   1 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     982       1  0     0     0   1 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql     989       1  0     0     0   1 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
proxysql    1082       1  0     0     0   0 15:19 pts/1    00:00:00   [percona-schedul] <defunct>
```

As a workaround we'll have a reaper that actually waits for child processes properly until this issue is fixed in percona-scheduler-admin.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-735]: https://perconadev.atlassian.net/browse/K8SPXC-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ