### PR TITLE
CLOUD-901 Revert marked passed tests in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,21 +130,17 @@ void markPassedTests() {
     echo "Marking passed tests in the tests map!"
 
     withCredentials([aws(credentialsId: 'AMI/OVF', accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-        def existingArtifacts = sh(
-            script: """
-                aws s3 ls s3://percona-jenkins-artifactory/\$JOB_NAME/${env.GIT_SHORT_COMMIT}/ 2>/dev/null | awk '{print \$4}' || echo ''
-            """,
-            returnStdout: true
-        ).trim()
+        sh """
+            aws s3 ls "s3://percona-jenkins-artifactory/${JOB_NAME}/${env.GIT_SHORT_COMMIT}/" || :
+        """
 
-        def artifactSet = existingArtifacts.split('\n').findAll { it }.toSet()
-
-        for (int i = 0; i < tests.size(); i++) {
+        for (int i=0; i<tests.size(); i++) {
             def testNameWithMysqlVersion = tests[i]["name"] +"-"+ tests[i]["mysql_ver"].replace(".", "-")
-            def file = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$testNameWithMysqlVersion"
+            def file="${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}-$testNameWithMysqlVersion"
+            def retFileExists = sh(script: "aws s3api head-object --bucket percona-jenkins-artifactory --key ${JOB_NAME}/${env.GIT_SHORT_COMMIT}/${file} >/dev/null 2>&1", returnStatus: true)
 
-            if (artifactSet.contains(file)) {
-                tests[i]['result'] = 'passed'
+            if (retFileExists == 0) {
+                tests[i]["result"] = "passed"
             }
         }
     }


### PR DESCRIPTION
[![CLOUD-901](https://img.shields.io/badge/JIRA-CLOUD--901-green?logo=)](https://jira.percona.com/browse/CLOUD-901) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
There is an issue where the tests are not correctly recognized as passed in the PR job, causing all of them to rerun unnecessarily.

**Solution:**
Revert to previous implementation temporarily. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-901]: https://perconadev.atlassian.net/browse/CLOUD-901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ