### PR TITLE
K8SPXC-1772: fix incorrect backup state transition for suspended jobs

### DIFF
--- a/pkg/controller/pxcbackup/controller.go
+++ b/pkg/controller/pxcbackup/controller.go
@@ -726,7 +726,7 @@ func (r *ReconcilePerconaXtraDBClusterBackup) updateJobStatus(
 	// As a workaround, when the computed state is `Starting`, we shall double check if there are any running pods.
 	// See: https://perconadev.atlassian.net/browse/K8SPXC-1772
 	//
-	// Note: As of writing this, the bug has not been reported in Kubernetes, but fixed in 1.34.0
+	// This was fixed in k8s 1.33.6. See: https://github.com/kubernetes/kubernetes/pull/135129
 	if status.State == api.BackupStarting {
 		running, err := r.checkJobPodsRunning(ctx, job)
 		if err != nil {


### PR DESCRIPTION
[![K8SPXC-1772](https://img.shields.io/badge/JIRA-K8SPXC--1772-green?logo=)](https://jira.percona.com/browse/K8SPXC-1772) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**

On k8s 1.33.2, once a backup has been suspended (due to unready cluster), it will transition to `Succeeded` without going through `Running` state

**Cause:**

It seems k8s 1.33.2 contains a bug where an unsuspended job (previously suspended) contains a stale status. I.e, even though the job pods are running, it reflects a suspended state. As a consequence, the backup never goes through `Running` and directly skips Succeeded/Failed

This was fixed upstream in v1.33.6 https://github.com/kubernetes/kubernetes/pull/135129

**Solution:**

Add an additional check that bypasses the Job status and directly checks the state of the job pods

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPXC-1772]: https://perconadev.atlassian.net/browse/K8SPXC-1772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ