### PR TITLE
Support file-based keyring components in restore operations

### DIFF
--- a/build/backup/recovery-cloud.sh
+++ b/build/backup/recovery-cloud.sh
@@ -73,10 +73,34 @@ fi
 
 PXB_VAULT_PREPARE_ARGS=""
 PXB_VAULT_MOVEBACK_ARGS=""
-VAULT_CONFIG_FILE=/etc/mysql/vault-keyring-secret/keyring_vault.conf
-VAULT_KEYRING_COMPONENT=/opt/percona/component_keyring_vault.cnf
+
+VAULT_CONFIG_FILE=""
+VAULT_KEYRING_COMPONENT=/opt/percona/component_keyring.cnf
+
+if [[ -f "/usr/lib64/mysql/plugin/component_keyring_file.cnf" ]]; then
+	VAULT_CONFIG_FILE="/usr/lib64/mysql/plugin/component_keyring_file.cnf"
+elif [[ -f "/etc/mysql/vault-keyring-secret/keyring_vault.conf" ]]; then
+	VAULT_CONFIG_FILE="/etc/mysql/vault-keyring-secret/keyring_vault.conf"
+fi
+
+# Detect if we should use component-based keyring
+# Check for:
+# 1. XtraBackup 8.4.0+ (always uses components)
+# 2. XtraBackup 8.0.25+ with global manifest file (indicates component-based setup)
+USE_COMPONENT_KEYRING=0
+
+if check_for_version "$XTRABACKUP_VERSION" '8.4.0'; then
+	# XtraBackup 8.4+ always uses components
+	USE_COMPONENT_KEYRING=1
+elif check_for_version "$XTRABACKUP_VERSION" '8.0.25'; then
+	# XtraBackup 8.0.25+ supports components if manifest file exists
+	if [[ -f /usr/sbin/mysqld.my ]]; then
+		USE_COMPONENT_KEYRING=1
+	fi
+fi
+
 if [[ -f ${VAULT_CONFIG_FILE} ]]; then
-	if check_for_version "$XTRABACKUP_VERSION" '8.4.0'; then
+	if [[ ${USE_COMPONENT_KEYRING} -eq 1 ]]; then
 		cp ${VAULT_CONFIG_FILE} ${VAULT_KEYRING_COMPONENT}
 		PXB_VAULT_MOVEBACK_ARGS="--component-keyring-config=${VAULT_KEYRING_COMPONENT}"
 		PXB_VAULT_PREPARE_ARGS="${PXB_VAULT_MOVEBACK_ARGS}"

--- a/build/backup/recovery-pvc-joiner.sh
+++ b/build/backup/recovery-pvc-joiner.sh
@@ -52,10 +52,35 @@ socat -u "$SOCAT_OPTS" stdio | xbstream -x -C "$tmp" --parallel="$(grep -c proce
 
 PXB_VAULT_PREPARE_ARGS=""
 PXB_VAULT_MOVEBACK_ARGS=""
-VAULT_CONFIG_FILE=/etc/mysql/vault-keyring-secret/keyring_vault.conf
-VAULT_KEYRING_COMPONENT=/opt/percona/component_keyring_vault.cnf
+
+
+VAULT_CONFIG_FILE=""
+VAULT_KEYRING_COMPONENT=/opt/percona/component_keyring.cnf
+
+if [[ -f "/usr/lib64/mysql/plugin/component_keyring_file.cnf" ]]; then
+	VAULT_CONFIG_FILE="/usr/lib64/mysql/plugin/component_keyring_file.cnf"
+elif [[ -f "/etc/mysql/vault-keyring-secret/keyring_vault.conf" ]]; then
+	VAULT_CONFIG_FILE="/etc/mysql/vault-keyring-secret/keyring_vault.conf"
+fi
+
+# Detect if we should use component-based keyring
+# Check for:
+# 1. XtraBackup 8.4.0+ (always uses components)
+# 2. XtraBackup 8.0.25+ with global manifest file (indicates component-based setup)
+USE_COMPONENT_KEYRING=0
+
+if check_for_version "$XTRABACKUP_VERSION" '8.4.0'; then
+	# XtraBackup 8.4+ always uses components
+	USE_COMPONENT_KEYRING=1
+elif check_for_version "$XTRABACKUP_VERSION" '8.0.25'; then
+	# XtraBackup 8.0.25+ supports components if manifest file exists
+	if [[ -f /usr/sbin/mysqld.my ]]; then
+		USE_COMPONENT_KEYRING=1
+	fi
+fi
+
 if [[ -f ${VAULT_CONFIG_FILE} ]]; then
-	if check_for_version "$XTRABACKUP_VERSION" '8.4.0'; then
+	if [[ ${USE_COMPONENT_KEYRING} -eq 1 ]]; then
 		cp ${VAULT_CONFIG_FILE} ${VAULT_KEYRING_COMPONENT}
 		PXB_VAULT_MOVEBACK_ARGS="--component-keyring-config=${VAULT_KEYRING_COMPONENT}"
 		PXB_VAULT_PREPARE_ARGS="${PXB_VAULT_MOVEBACK_ARGS}"

--- a/pkg/pxc/backup/restore.go
+++ b/pkg/pxc/backup/restore.go
@@ -355,6 +355,15 @@ func RestoreJob(
 		initContainers = []corev1.Container{statefulset.BackupInitContainer(cluster, initImage, cluster.Spec.PXC.ContainerSecurityContext)}
 	}
 
+	// Add extraPVCs from cluster spec to restore job
+	if cluster.CompareVersionWith("1.19.0") >= 0 && cluster.Spec.PXC != nil && len(cluster.Spec.PXC.ExtraPVCs) > 0 {
+		extraVolumes := api.ExtraPVCVolumes(ctx, cluster.Spec.PXC.ExtraPVCs)
+		volumes = append(volumes, extraVolumes...)
+
+		extraMounts := api.ExtraPVCVolumeMounts(ctx, cluster.Spec.PXC.ExtraPVCs)
+		volumeMounts = append(volumeMounts, extraMounts...)
+	}
+
 	jobName := naming.RestoreJobName(cr, pitr)
 	job := &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
@@ -839,6 +848,15 @@ func PrepareJob(
 		app.GetSecretVolumes("vault-keyring-secret", cluster.Spec.PXC.VaultSecretName, true),
 		app.GetSecretVolumes("ssl", cluster.Spec.PXC.SSLSecretName, !cluster.TLSEnabled()),
 		app.GetSecretVolumes("ssl-internal", cluster.Spec.PXC.SSLInternalSecretName, !cluster.TLSEnabled()),
+	}
+
+	// Add extraPVCs from cluster spec to prepare job
+	if cluster.CompareVersionWith("1.19.0") >= 0 && cluster.Spec.PXC != nil && len(cluster.Spec.PXC.ExtraPVCs) > 0 {
+		extraVolumes := api.ExtraPVCVolumes(context.Background(), cluster.Spec.PXC.ExtraPVCs)
+		volumes = append(volumes, extraVolumes...)
+
+		extraMounts := api.ExtraPVCVolumeMounts(context.Background(), cluster.Spec.PXC.ExtraPVCs)
+		volumeMounts = append(volumeMounts, extraMounts...)
 	}
 
 	job := &batchv1.Job{


### PR DESCRIPTION
Due to the high volume of requests, we're unable to provide free service for this account. To continue using the service, please **[upgarde to a paid plan](https://pullrequestbadge.com/unlock/1683025?utm_medium=github&utm_source=percona&utm_campaign=unlock_text)**.

<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

-Mount extraPVCs to restore and prepare jobs for custom keyring access
- Add auto-detection for component keyring configs in recovery scripts
- Support XtraBackup 8.0.25+ with component-based keyring

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version? 