### PR TITLE
K8SPXC-1834: Pin open files limit in HAProxy

### DIFF
--- a/build/haproxy-entrypoint.sh
+++ b/build/haproxy-entrypoint.sh
@@ -43,7 +43,7 @@ if ! [[ ${RLIMIT_NOFILE} =~ ^[0-9]+$ ]]; then
 	log "HA_RLIMIT_NOFILE is not a valid integer ('${RLIMIT_NOFILE}'), falling back to ${DEFAULT_RLIMIT_NOFILE}."
 	RLIMIT_NOFILE=${DEFAULT_RLIMIT_NOFILE}
 fi
-if [[ ${RLIMIT_NOFILE} -gt ${hard_limit} ]]; then
+if [[ ${hard_limit} =~ ^[0-9]+$ ]] && [[ ${RLIMIT_NOFILE} -gt ${hard_limit} ]]; then
 	log "Requested open file limit (${RLIMIT_NOFILE}) exceeds hard limit (${hard_limit}), clamping."
 	RLIMIT_NOFILE=${hard_limit}
 fi


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
HAProxy tries to close all file descriptors from 0 to soft limit before running the external check command, see https://github.com/haproxy/haproxy/issues/3299. This causes external checks to fail with timeout without even running on systems with huge soft limit.

This PR pins the limit for open files in HAProxy entrypoint. Since this affects maxconns too, we make it configurable by HA_RLIMIT_NOFILE environment variable. By default it's set to 1048576. If the value is invalid, it falls back to default value. If the value is bigger than the hard limit (`ulimit -Hn`), the value is clamped to hard limit.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
