### PR TITLE
K8SPXC-1029 | revert PXC_READ_ONY gate to 1.19.1

### DIFF
--- a/pkg/pxc/app/statefulset/proxysql.go
+++ b/pkg/pxc/app/statefulset/proxysql.go
@@ -195,7 +195,7 @@ func (c *Proxy) AppContainer(ctx context.Context, _ client.Client, spec *api.Pod
 		appc.VolumeMounts = append(appc.VolumeMounts, extraMounts...)
 	}
 
-	if cr.CompareVersionWith("1.20.0") >= 0 {
+	if cr.CompareVersionWith("1.19.1") >= 0 {
 		appc.Env = append(appc.Env, corev1.EnvVar{
 			Name:  "PXC_READ_ONLY",
 			Value: strconv.FormatBool(cr.IsReadOnly()),
@@ -388,7 +388,7 @@ func (c *Proxy) SidecarContainers(ctx context.Context, cl client.Client, spec *a
 		proxysqlMonit.Command = []string{"/opt/percona/proxysql-entrypoint.sh"}
 	}
 
-	if cr.CompareVersionWith("1.20.0") >= 0 {
+	if cr.CompareVersionWith("1.19.1") >= 0 {
 		pxcMonit.Env = append(pxcMonit.Env, corev1.EnvVar{
 			Name:  "PXC_READ_ONLY",
 			Value: strconv.FormatBool(cr.IsReadOnly()),


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
`upgrade-proxysql` e2e test fails with the following error:
```
Generation for resource proxysql is: 2, but should be: 1
```

**Cause:**

Proxysql statefulsets are updated during the operator upgrade in the test from `1.19.1` -> `main`, here is why:
- While releasing 1.19.1 in https://github.com/percona/percona-xtradb-cluster-operator/pull/2436 we changed the version check for `PXC_READ_ONLY` env var to `1.19.1` from `1.20.0`
- `main` still uses `1.20.0`
- This results in the `PXC_READ_ONLY` env var getting removed.

**Solution:**
Use `1.19.1` as the version check

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
