### PR TITLE
K8SPXC-1822: anchor binlog matcher on current source UUID only

### DIFF
--- a/cmd/pitr/collector/collector.go
+++ b/cmd/pitr/collector/collector.go
@@ -587,9 +587,12 @@ func gtidContainsSeq(gtidEntry, uuid string, seq int64) bool {
 }
 
 // findBinlogWithEndMarker walks binlogs from most recent to oldest and returns the
-// name of the first binlog whose GTID set contains the end (highest) sequence of any
-// GTID entry in lastUploadedSet. Returns "" when no binlog matches, indicating a gap.
-func findBinlogWithEndMarker(binlogs []pxc.Binlog, lastUploadedSet pxc.GTIDSet) string {
+// name of the first binlog whose GTID set contains the end (highest) sequence of
+// the sourceID entry in lastUploadedSet. Returns "" when no binlog matches,
+// indicating a gap. Entries for other UUIDs are ignored: post-restore the old
+// UUID's range is frozen across every subsequent binlog, so matching on it would
+// anchor on a newer binlog and skip the current UUID's resume point.
+func findBinlogWithEndMarker(binlogs []pxc.Binlog, lastUploadedSet pxc.GTIDSet, sourceID string) string {
 	for i := len(binlogs) - 1; i >= 0; i-- {
 		log.Printf("checking %s (%s) against last uploaded set", binlogs[i].Name, binlogs[i].GTIDSet.Raw())
 
@@ -597,6 +600,9 @@ func findBinlogWithEndMarker(binlogs []pxc.Binlog, lastUploadedSet pxc.GTIDSet) 
 			uuid, endSeq, err := gtidEndMarker(lastUploaded)
 			if err != nil {
 				log.Printf("failed to get end marker of last uploaded gtid: %v", err)
+				continue
+			}
+			if uuid != sourceID {
 				continue
 			}
 
@@ -674,7 +680,7 @@ func (c *Collector) CollectBinLogs(ctx context.Context) error {
 	if !c.lastUploadedSet.IsEmpty() {
 		log.Printf("last uploaded GTID set: %s", c.lastUploadedSet.Raw())
 
-		lastUploadedBinlogName = findBinlogWithEndMarker(binlogList, c.lastUploadedSet)
+		lastUploadedBinlogName = findBinlogWithEndMarker(binlogList, c.lastUploadedSet, c.sourceID)
 
 		if lastUploadedBinlogName == "" {
 			log.Println("ERROR: Couldn't find the binlog that contains GTID set:", c.lastUploadedSet.Raw())

--- a/cmd/pitr/collector/collector_test.go
+++ b/cmd/pitr/collector/collector_test.go
@@ -296,6 +296,7 @@ func TestFindBinlogWithEndMarker(t *testing.T) {
 		name         string
 		binlogs      []pxc.Binlog
 		lastUploaded string
+		sourceID     string
 		want         string
 	}{
 		{
@@ -309,6 +310,7 @@ func TestFindBinlogWithEndMarker(t *testing.T) {
 				binlog("binlog.000003", uuidA+":101-150"),
 			},
 			lastUploaded: uuidA + ":1-100",
+			sourceID:     uuidA,
 			want:         "binlog.000002",
 		},
 		{
@@ -318,6 +320,7 @@ func TestFindBinlogWithEndMarker(t *testing.T) {
 				binlog("binlog.000002", uuidA+":51-100"),
 			},
 			lastUploaded: uuidA + ":1-50",
+			sourceID:     uuidA,
 			want:         "binlog.000001",
 		},
 		{
@@ -328,6 +331,7 @@ func TestFindBinlogWithEndMarker(t *testing.T) {
 				binlog("binlog.000003", uuidA+":101-150"),
 			},
 			lastUploaded: uuidA + ":1-100",
+			sourceID:     uuidA,
 			want:         "",
 		},
 		{
@@ -337,19 +341,23 @@ func TestFindBinlogWithEndMarker(t *testing.T) {
 				binlog("binlog.000002", uuidA+":101-150"),
 			},
 			lastUploaded: uuidA + ":1-100",
+			sourceID:     uuidA,
 			want:         "binlog.000001",
 		},
 		{
-			// After a restore the cluster gets a new UUID, so the last uploaded
-			// set may carry both old and new UUID ranges. The match should be
-			// found via whichever UUID's end marker exists in a binlog.
-			name: "matches via second uuid in lastUploadedSet",
+			// After a restore the cluster gets a new UUID. The last uploaded
+			// set may still carry the old UUID's range, but matching must be
+			// anchored on the current source UUID only — otherwise the old
+			// UUID's frozen end marker could anchor on a newer binlog and
+			// skip the resume point.
+			name: "ignores entries from non-current source UUIDs",
 			binlogs: []pxc.Binlog{
-				binlog("binlog.000001", uuidA+":1-50"),
-				binlog("binlog.000002", uuidB+":1-25"),
+				binlog("binlog.000001", uuidA+":1-200,"+uuidB+":1-25"),
+				binlog("binlog.000002", uuidA+":1-200,"+uuidB+":26-50"),
 			},
 			lastUploaded: uuidA + ":1-200," + uuidB + ":1-25",
-			want:         "binlog.000002",
+			sourceID:     uuidB,
+			want:         "binlog.000001",
 		},
 		{
 			name: "binlog carrying multiple uuids matches on the relevant one",
@@ -358,6 +366,7 @@ func TestFindBinlogWithEndMarker(t *testing.T) {
 				binlog("binlog.000002", uuidB+":11-30"),
 			},
 			lastUploaded: uuidB + ":1-10",
+			sourceID:     uuidB,
 			want:         "binlog.000001",
 		},
 		{
@@ -369,12 +378,14 @@ func TestFindBinlogWithEndMarker(t *testing.T) {
 				binlog("binlog.000002", uuidA+":50-150"),
 			},
 			lastUploaded: uuidA + ":1-100",
+			sourceID:     uuidA,
 			want:         "binlog.000002",
 		},
 		{
 			name:         "empty binlog list returns empty",
 			binlogs:      nil,
 			lastUploaded: uuidA + ":1-100",
+			sourceID:     uuidA,
 			want:         "",
 		},
 		{
@@ -383,6 +394,7 @@ func TestFindBinlogWithEndMarker(t *testing.T) {
 				binlog("binlog.000001", uuidA+":1-50"),
 			},
 			lastUploaded: "not-a-gtid," + uuidA + ":1-50",
+			sourceID:     uuidA,
 			want:         "binlog.000001",
 		},
 	}
@@ -391,7 +403,7 @@ func TestFindBinlogWithEndMarker(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := findBinlogWithEndMarker(tt.binlogs, pxc.NewGTIDSet(tt.lastUploaded))
+			got := findBinlogWithEndMarker(tt.binlogs, pxc.NewGTIDSet(tt.lastUploaded), tt.sourceID)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION


**CHANGE DESCRIPTION**
---
After a restore the stored last-binlog-set may carry the old source UUID's frozen range. findBinlogWithEndMarker iterated every entry, so the old UUID could match a newer binlog and cause filterBinLogs to skip the binlog containing the current UUID's resume point.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
