### PR TITLE
K8SPXC-1619: fix log message for sst retry counter files

### DIFF
--- a/build/pxc-entrypoint.sh
+++ b/build/pxc-entrypoint.sh
@@ -158,6 +158,7 @@ pause_after_sst_retry_limit() {
 		SST retry limit reached.
 		The node attempted SST ${attempts} times and the configured limit is ${limit}.
 		The pod will stay running but unready until ${SST_RETRY_LIMIT_REACHED_FILE} is removed.
+		For manual recovery, remove both ${SST_RETRY_LIMIT_REACHED_FILE} and ${SST_RETRY_COUNTER_FILE}.
 	EOM
 
 	while [[ -f ${SST_RETRY_LIMIT_REACHED_FILE} ]]; do
@@ -191,6 +192,9 @@ handle_sst_retry_limit() {
 			attempts=$(cat "${SST_RETRY_COUNTER_FILE}" 2>/dev/null || echo 0)
 		fi
 		pause_after_sst_retry_limit "${limit}" "${attempts}"
+		if [[ ! -f ${SST_RETRY_COUNTER_FILE} ]]; then
+			attempts=0
+		fi
 	fi
 
 	if [[ -f ${SST_RETRY_COUNTER_FILE} ]]; then

--- a/e2e-tests/sst-retry-limit/run
+++ b/e2e-tests/sst-retry-limit/run
@@ -36,6 +36,40 @@ wait_for_pxc_restart_count() {
 	echo
 }
 
+wait_for_cluster_ready() {
+	local cluster=$1
+	local pxc_size=$2
+	local max_retry="${3:-900}"
+	local retry=0
+
+	echo -n "waiting for pxc/$cluster to become ready with $pxc_size PXC pods"
+	until [[ "$(kubectl_bin get pxc "$cluster" -o jsonpath='{.status.state}' 2>/dev/null)" == "ready" &&
+	"$(kubectl_bin get pxc "$cluster" -o jsonpath='{.status.pxc.ready}' 2>/dev/null)" == "$pxc_size" ]]; do
+		sleep 5
+		echo -n .
+		retry=$((retry + 5))
+		if [[ $retry -ge $max_retry ]]; then
+			echo
+			echo "ERROR: pxc/$cluster did not become ready with $pxc_size PXC pods"
+			kubectl_bin get pxc "$cluster" -o yaml || :
+			kubectl_bin get pods || :
+			kubectl_bin describe pod "$cluster-pxc-3" || :
+			kubectl_bin logs "$cluster-pxc-3" -c pxc || :
+			kubectl_bin logs "$cluster-pxc-3" -c pxc --previous || :
+			exit 1
+		fi
+	done
+	echo
+}
+
+recover_joiner_after_sst_retry_limit() {
+	local joiner_pod=$1
+
+	echo "removing SST retry marker files from pod/$joiner_pod"
+	kubectl_bin exec "$joiner_pod" -c pxc -- \
+		rm -f /var/lib/mysql/sst_retry_limit_reached /var/lib/mysql/sst_retry_count
+}
+
 detect_active_donor() {
 	local root_pass=$1
 	shift
@@ -230,6 +264,10 @@ main() {
 			exit 1
 		fi
 	done
+
+	desc 'manually recover the joiner and verify the cluster becomes ready'
+	recover_joiner_after_sst_retry_limit "$joiner_pod"
+	wait_for_cluster_ready "$cluster" 4 900
 
 	destroy "$namespace"
 	desc "test passed"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPXC-1619

**DESCRIPTION**
---
This PR adds e2e coverage for manual recovery after the SST retry limit is reached.

The `sst-retry-limit` test now removes the SST retry files from the joiner pod and verifies that the cluster becomes ready again after recovery.

Also improves the retry-limit log message to clearly mention that both files must be removed for manual recovery.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
