### PR TITLE
K8SPXC-804 enrich wsrep recovery logs with severity and alert fields

### DIFF
--- a/build/logcollector/fluentbit/fluentbit_pxc.conf
+++ b/build/logcollector/fluentbit/fluentbit_pxc.conf
@@ -66,6 +66,20 @@
     read_from_head   true
     Path_Key         file
 
+[FILTER]
+    Name             modify
+    Match            *.wsrep_recovery_verbose.log
+    Condition        Key_Value_Matches log MY-012551
+    Add              severity ERROR
+    Add              alert    unclean_shutdown
+
+[FILTER]
+    Name             modify
+    Match            *.wsrep_recovery_verbose.log
+    Condition        Key_Value_Matches log MY-012552
+    Add              severity ERROR
+    Add              alert    innodb_crash_recovery
+
 [OUTPUT]
     Name             stdout
     Match            *


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Add two FluentBit modify filters to fluentbit_pxc.conf that detect unclean MySQL shutdowns from wsrep_recovery_verbose.log entries:

- MY-012551 ("Database was not shutdown normally") → severity=ERROR, alert=unclean_shutdown
- MY-012552 ("Starting crash recovery") → severity=ERROR, alert=innodb_crash_recovery

These log lines are emitted at [Note] level by MySQL, making them invisible in ERROR-filtered log aggregators. The filters promote them to ERROR severity, so OOM kills and crash recovery events surface automatically in monitoring pipelines.


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
