### PR TITLE
K8SPXC-1789 | fix logrotate config validation

### DIFF
--- a/build/logcollector/entrypoint.sh
+++ b/build/logcollector/entrypoint.sh
@@ -29,7 +29,7 @@ is_logrotate_config_invalid() {
 	# Filter out logrotate.status lines first, then check for remaining errors
 	(
 		set +e
-		logrotate -d "$config_file" 2>&1 | grep -v "logrotate.status" | grep -qi "error"
+		logrotate -d "$config_file" 2>&1 | grep -v "logrotate.status" | grep -qi "^error:"
 	)
 	return $?
 }

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -601,17 +601,18 @@ spec:
 #    logRotate:
 #      schedule: "*/5 * * * *"
 #      configuration: |
-#        /var/lib/mysql/GRA_*.log {
-#          daily
-#          rotate 7
-#          missingok
-#          notifempty
-#          compress
-#          delaycompress
-#          sharedscripts
-#          postrotate
-#            /usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete
-#          endscript
+#        /var/lib/mysql/[!G]*.log {
+#           daily
+#           minsize 10M
+#           maxsize 100M
+#           rotate 10
+#           missingok
+#           nocompress
+#           notifempty
+#           sharedscripts
+#           postrotate
+#               /opt/percona/logcollector/logrotate/postrotate-mysql.sh
+#           endscript
 #        }
 #      extraConfig:
 #        name: my-logrotate-config


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**

The current logrotate config does not allow setting a file name with the word 'error' in it

**Cause:**
The validation runs the following:
```
logrotate -d "$config_file" 2>&1 | grep -v "logrotate.status" | grep -qi "error"
```

**Solution:**
```
logrotate -d "$config_file" 2>&1 | grep -v "logrotate.status" | grep -qi "^error:"
```

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
