### PR TITLE
K8SPXC-1789 | fix logrotate EUID check

### DIFF
--- a/build/logcollector/entrypoint.sh
+++ b/build/logcollector/entrypoint.sh
@@ -40,6 +40,14 @@ run_logrotate() {
 	local logrotate_additional_conf_files=()
 	local conf_d_dir="/opt/percona/logcollector/logrotate/conf.d"
 
+	# Ensure logrotate can run with current UID
+	if [[ $EUID != 1001 ]]; then
+		# logrotate requires UID in /etc/passwd
+		sed -e "s^x:1001:^x:$EUID:^" /etc/passwd >/tmp/passwd
+		cat /tmp/passwd >/etc/passwd
+		rm -rf /tmp/passwd
+	fi
+
 	# Check if logrotate-mysql.conf exists and validate it
 	if [ -f "$conf_d_dir/logrotate-$SERVICE_TYPE.conf" ]; then
 		logrotate_conf_file="$conf_d_dir/logrotate-$SERVICE_TYPE.conf"
@@ -62,13 +70,6 @@ run_logrotate() {
 				logrotate_additional_conf_files+=("$conf_file")
 			fi
 		done
-	fi
-	# Ensure logrotate can run with current UID
-	if [[ $EUID != 1001 ]]; then
-		# logrotate requires UID in /etc/passwd
-		sed -e "s^x:1001:^x:$EUID:^" /etc/passwd >/tmp/passwd
-		cat /tmp/passwd >/etc/passwd
-		rm -rf /tmp/passwd
 	fi
 
 	local logrotate_cmd="logrotate -s \"$logrotate_status_file\" \"$logrotate_conf_file\""


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Cannot run custom logrotate on Openshift

**Cause:**
$EUID validation happens after attempting to run logrotate.

**Solution:**
EUID validation must happen first

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PXC version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
